### PR TITLE
feat: sessions, in-panel settings, and PID/session enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ STACKNUDGE_PANEL=true
 STACKNUDGE_BANNER=false   # optional — suppress macOS banners when using the panel
 ```
 
-Default hotkey is `cmd+shift+n`. Override with `STACKNUDGE_PANEL_HOTKEY=cmd+opt+space` (or any combination of `cmd`/`shift`/`opt`/`ctrl` + a letter, digit, or `space`/`return`/`tab`/`escape`).
+Default hotkey is `cmd+opt+n`. Override with `STACKNUDGE_PANEL_HOTKEY=cmd+opt+space` (or any combination of `cmd`/`shift`/`opt`/`ctrl` + a letter, digit, or `space`/`return`/`tab`/`escape`).
 
 The panel registers a launchd agent so it starts at login when enabled. Banner and panel can run together, alone, or both off — the sound and voice still fire as passive signals.
 

--- a/build.sh
+++ b/build.sh
@@ -56,6 +56,9 @@ build_app "$PANEL_APP" "stack-nudge-panel" \
   panel/Panel.swift \
   panel/MenuBar.swift \
   panel/Permissions.swift \
+  panel/Settings.swift \
+  panel/SessionStore.swift \
+  panel/Sessions.swift \
   shared/AppActivator.swift \
   -framework Foundation -framework AppKit -framework SwiftUI -framework Carbon
 echo "  Built $PANEL_APP"

--- a/notify.conf.example
+++ b/notify.conf.example
@@ -38,3 +38,8 @@
 # Global hotkey that focuses the panel. Modifiers: cmd, shift, opt/alt, ctrl.
 # Default: cmd+shift+n
 #STACKNUDGE_PANEL_HOTKEY=cmd+shift+n
+
+# Sound played for the "agent done" event. Any name from /System/Library/Sounds/
+# (without the .aiff extension). Defaults: Glass for stop, Ping for permission.
+#STACKNUDGE_SOUND_STOP=Glass
+#STACKNUDGE_SOUND_PERMISSION=Ping

--- a/notify.conf.example
+++ b/notify.conf.example
@@ -36,8 +36,9 @@
 #STACKNUDGE_PANEL=true
 
 # Global hotkey that focuses the panel. Modifiers: cmd, shift, opt/alt, ctrl.
-# Default: cmd+shift+n
-#STACKNUDGE_PANEL_HOTKEY=cmd+shift+n
+# Default: cmd+opt+n  (avoids cmd+shift+n which most browsers bind to
+# "New Incognito Window")
+#STACKNUDGE_PANEL_HOTKEY=cmd+opt+n
 
 # Sound played for the "agent done" event. Any name from /System/Library/Sounds/
 # (without the .aiff extension). Defaults: Glass for stop, Ping for permission.

--- a/notify.sh
+++ b/notify.sh
@@ -148,30 +148,104 @@ ensure_panel_running() {
   done
 }
 
-# Construct one JSON line and write it to the panel socket. macOS nc lacks
-# the -N flag, so we send via python's socket module directly — no nc, no
-# nudges-stuck-in-stdout-buffer surprises.
+# Walk up the process tree from this hook's parent and detect the agent
+# binary, parent shell, and terminal/helper. Sets AGENT_PID, SHELL_PID,
+# TERMINAL_PID, TERMINAL_APP (each empty if not found).
+walk_session_chain() {
+  AGENT_PID=""; SHELL_PID=""; TERMINAL_PID=""; TERMINAL_APP=""
+  local pid="$PPID"
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
+    [[ -z "$pid" || "$pid" -le 1 ]] && break
+    local comm
+    comm=$(ps -p "$pid" -o comm= 2>/dev/null)
+    [[ -z "$comm" ]] && break
+    local base="${comm##*/}"
+    case "$base" in
+      claude|gemini|codex)
+        [[ -z "$AGENT_PID" ]] && AGENT_PID="$pid"
+        ;;
+      bash|zsh|sh|fish|dash|ksh)
+        [[ -z "$SHELL_PID" ]] && SHELL_PID="$pid"
+        ;;
+    esac
+    case "$base" in
+      "Code Helper"|"Code Helper (Plugin)"|"Code Helper (Renderer)"|Code|\
+      "Cursor Helper"|"Cursor Helper (Plugin)"|"Cursor Helper (Renderer)"|Cursor|\
+      iTerm2|iTerm|Terminal|Warp|WarpTerminal|ghostty|Ghostty)
+        TERMINAL_PID="$pid"; TERMINAL_APP="$base"; break ;;
+    esac
+    pid=$(ps -p "$pid" -o ppid= 2>/dev/null | tr -d ' ')
+  done
+}
+
+# Construct one JSON line and write it to the panel socket. Pass values via
+# env vars rather than positional argv to keep the heredoc readable now that
+# we have ~15 fields.
 # Args: title message bundle_id window_title has_action(true|false)
 post_to_panel() {
   [[ "${PANEL_ENABLED}" != "true" ]] && return
   ensure_panel_running
   [[ ! -S "$PANEL_SOCK" ]] && return
 
-  python3 - "$AGENT" "$EVENT" "$1" "$2" "$PWD" "$3" "$4" "${VSCODE_IPC_HOOK_CLI:-}" "$5" "$PANEL_SOCK" <<'PY' 2>/dev/null
-import json, socket, sys, time
-agent, event, title, message, project, bundle, window, ipc, has_action, sock_path = sys.argv[1:11]
+  walk_session_chain
+
+  NUDGE_AGENT="$AGENT" \
+  NUDGE_EVENT="$EVENT" \
+  NUDGE_TITLE="$1" \
+  NUDGE_MESSAGE="$2" \
+  NUDGE_PROJECT="$PWD" \
+  NUDGE_BUNDLE="$3" \
+  NUDGE_WINDOW="$4" \
+  NUDGE_IPC_HOOK="${VSCODE_IPC_HOOK_CLI:-}" \
+  NUDGE_HAS_ACTION="$5" \
+  NUDGE_SOCK="$PANEL_SOCK" \
+  NUDGE_AGENT_PID="${AGENT_PID:-}" \
+  NUDGE_SHELL_PID="${SHELL_PID:-}" \
+  NUDGE_TERMINAL_PID="${TERMINAL_PID:-}" \
+  NUDGE_TERMINAL_APP="${TERMINAL_APP:-}" \
+  NUDGE_TERM_PROGRAM="${TERM_PROGRAM:-}" \
+  NUDGE_SESSION_ID="${TERM_SESSION_ID:-${ITERM_SESSION_ID:-}}" \
+  python3 - <<'PY' 2>/dev/null
+import json, os, socket, time
+
+env = os.environ
 out = {
-  "agent": agent, "event": event, "title": title, "message": message,
-  "timestamp": time.time(), "has_action_button": has_action == "true",
+    "agent":             env["NUDGE_AGENT"],
+    "event":             env["NUDGE_EVENT"],
+    "title":             env["NUDGE_TITLE"],
+    "message":           env["NUDGE_MESSAGE"],
+    "timestamp":         time.time(),
+    "has_action_button": env["NUDGE_HAS_ACTION"] == "true",
 }
-if project: out["project_path"]  = project
-if bundle:  out["bundle_id"]     = bundle
-if window:  out["window_title"]  = window
-if ipc:     out["ipc_hook"]      = ipc
+
+# Only emit fields that have values — keeps the wire payload clean.
+optional = {
+    "project_path":  env.get("NUDGE_PROJECT"),
+    "bundle_id":     env.get("NUDGE_BUNDLE"),
+    "window_title":  env.get("NUDGE_WINDOW"),
+    "ipc_hook":      env.get("NUDGE_IPC_HOOK"),
+    "agent_pid":     env.get("NUDGE_AGENT_PID"),
+    "shell_pid":     env.get("NUDGE_SHELL_PID"),
+    "terminal_pid":  env.get("NUDGE_TERMINAL_PID"),
+    "terminal_app":  env.get("NUDGE_TERMINAL_APP"),
+    "term_program":  env.get("NUDGE_TERM_PROGRAM"),
+    "session_id":    env.get("NUDGE_SESSION_ID"),
+}
+for key, value in optional.items():
+    if not value:
+        continue
+    if key.endswith("_pid"):
+        try:
+            out[key] = int(value)
+        except ValueError:
+            continue
+    else:
+        out[key] = value
+
 data = (json.dumps(out) + "\n").encode()
 s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 try:
-    s.connect(sock_path)
+    s.connect(env["NUDGE_SOCK"])
     s.sendall(data)
 finally:
     s.close()
@@ -313,13 +387,15 @@ TITLE="$(agent_label "$AGENT")"
 
 case "$OS" in
   Darwin)
+    SOUND_STOP="${STACKNUDGE_SOUND_STOP:-Glass}"
+    SOUND_PERMISSION="${STACKNUDGE_SOUND_PERMISSION:-Ping}"
     case "$EVENT" in
       permission)
         ctx=$(permission_context)
         voice_ctx=$(voice_permission_context)
-        notify_macos "$TITLE" "${ctx:-Waiting for your approval}" "Ping" "${voice_ctx:-Waiting for your approval}"
+        notify_macos "$TITLE" "${ctx:-Waiting for your approval}" "$SOUND_PERMISSION" "${voice_ctx:-Waiting for your approval}"
         ;;
-      *) notify_macos "$TITLE" "Done" "Glass" ;;
+      *) notify_macos "$TITLE" "Done" "$SOUND_STOP" ;;
     esac
     ;;
   Linux)

--- a/panel/Config.swift
+++ b/panel/Config.swift
@@ -4,7 +4,7 @@ import Foundation
 // Parses simple `KEY=value` lines, ignoring comments and blank lines.
 // notify.sh shell-sources it; we just need the subset relevant to the panel.
 struct PanelConfig {
-    var hotkeySpec: String = "cmd+shift+n"
+    var hotkeySpec: String = "cmd+opt+n"
 
     static func load() -> PanelConfig {
         var config = PanelConfig()

--- a/panel/EventListener.swift
+++ b/panel/EventListener.swift
@@ -117,6 +117,12 @@ private struct NudgeEventDTO: Decodable {
     let ipc_hook: String?
     let has_action_button: Bool?
     let timestamp: Double?
+    let agent_pid: Int?
+    let shell_pid: Int?
+    let terminal_pid: Int?
+    let terminal_app: String?
+    let term_program: String?
+    let session_id: String?
 
     func toNudgeEvent() -> NudgeEvent {
         NudgeEvent(
@@ -129,7 +135,13 @@ private struct NudgeEventDTO: Decodable {
             windowTitle: window_title,
             ipcHook: ipc_hook,
             hasActionButton: has_action_button ?? false,
-            timestamp: timestamp.map { Date(timeIntervalSince1970: $0) } ?? Date()
+            timestamp: timestamp.map { Date(timeIntervalSince1970: $0) } ?? Date(),
+            agentPID: agent_pid,
+            shellPID: shell_pid,
+            terminalPID: terminal_pid,
+            terminalApp: terminal_app,
+            termProgram: term_program,
+            sessionID: session_id
         )
     }
 }

--- a/panel/EventStore.swift
+++ b/panel/EventStore.swift
@@ -23,11 +23,24 @@ struct NudgeEvent: Identifiable, Equatable {
     let ipcHook: String?
     let hasActionButton: Bool
     let timestamp: Date
+    // Session enrichment — populated by notify.sh's walk_session_chain. Used
+    // by AppActivator for precise pane focus and by the future sessions
+    // feature for grouping events back to their source CC/Gemini/Codex
+    // process.
+    let agentPID: Int?
+    let shellPID: Int?
+    let terminalPID: Int?
+    let terminalApp: String?
+    let termProgram: String?
+    let sessionID: String?
 
     init(agent: String, kind: NudgeKind, title: String, message: String,
          projectPath: String? = nil, bundleID: String? = nil,
          windowTitle: String? = nil, ipcHook: String? = nil,
-         hasActionButton: Bool = false, timestamp: Date = Date()) {
+         hasActionButton: Bool = false, timestamp: Date = Date(),
+         agentPID: Int? = nil, shellPID: Int? = nil,
+         terminalPID: Int? = nil, terminalApp: String? = nil,
+         termProgram: String? = nil, sessionID: String? = nil) {
         self.id = UUID()
         self.agent = agent
         self.kind = kind
@@ -39,6 +52,12 @@ struct NudgeEvent: Identifiable, Equatable {
         self.ipcHook = ipcHook
         self.hasActionButton = hasActionButton
         self.timestamp = timestamp
+        self.agentPID = agentPID
+        self.shellPID = shellPID
+        self.terminalPID = terminalPID
+        self.terminalApp = terminalApp
+        self.termProgram = termProgram
+        self.sessionID = sessionID
     }
 }
 

--- a/panel/Hotkey.swift
+++ b/panel/Hotkey.swift
@@ -78,4 +78,23 @@ final class Hotkey {
         "7": 26, "8": 28, "9": 25,
         "space": 49, "return": 36, "tab": 48, "escape": 53,
     ]
+
+    private static let codeToKey: [UInt16: String] = {
+        var inverted: [UInt16: String] = [:]
+        for (name, code) in keyCodes { inverted[UInt16(code)] = name }
+        return inverted
+    }()
+
+    // Reverse of `parse`: build a "cmd+shift+n" spec string from an NSEvent's
+    // modifiers + keyCode. Returns nil if the keyCode isn't one we can name.
+    static func encode(eventModifiers: UInt, keyCode: UInt16) -> String? {
+        guard let key = codeToKey[keyCode] else { return nil }
+        var parts: [String] = []
+        if eventModifiers & 0x100000 != 0 { parts.append("cmd")   } // NSEvent.ModifierFlags.command
+        if eventModifiers & 0x040000 != 0 { parts.append("ctrl")  } // .control
+        if eventModifiers & 0x080000 != 0 { parts.append("opt")   } // .option
+        if eventModifiers & 0x020000 != 0 { parts.append("shift") } // .shift
+        parts.append(key)
+        return parts.joined(separator: "+")
+    }
 }

--- a/panel/MenuBar.swift
+++ b/panel/MenuBar.swift
@@ -66,7 +66,6 @@ final class MenuBarController: NSObject, NSMenuDelegate {
 
     private let statusItem: NSStatusItem
     private weak var panelController: PanelController?
-    private var permissionsWC: PermissionsWindowController?
 
     init(panelController: PanelController) {
         self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -185,10 +184,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     }
 
     @objc private func showPermissionsAction() {
-        if permissionsWC == nil {
-            permissionsWC = PermissionsWindowController()
-        }
-        permissionsWC?.showAndRaise()
+        panelController?.showPermissions()
     }
 
     @objc private func openConfigAction() {

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -9,12 +9,20 @@ private enum KeyCode {
     static let escape:    UInt16 = 53
     static let upArrow:   UInt16 = 126
     static let downArrow: UInt16 = 125
+    static let leftArrow: UInt16 = 123
+    static let rightArrow: UInt16 = 124
     static let returnKey: UInt16 = 36
     static let numpadEnter: UInt16 = 76
+    static let tab:       UInt16 = 48
     static let oKey:      UInt16 = 31
     static let rKey:      UInt16 = 15
     static let delete:    UInt16 = 51
     static let forwardDelete: UInt16 = 117
+    static let comma:     UInt16 = 43
+    static let one:       UInt16 = 18
+    static let two:       UInt16 = 19
+    static let three:     UInt16 = 20
+    static let nKey:      UInt16 = 45
 }
 
 // Floating, non-activating panel. Shown via global hotkey; receives key
@@ -53,41 +61,91 @@ final class FloatingPanel: NSPanel {
 struct PanelContentView: View {
 
     @ObservedObject var store: EventStore
+    @ObservedObject var sessions: SessionStore
+    @ObservedObject var nav: PanelNav
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            header
+            tabStrip
+            Divider().opacity(0.4)
 
+            switch nav.mode {
+            case .events:   eventsBody
+            case .sessions: SessionsView(store: sessions)
+            case .settings: SettingsView(nav: nav)
+            }
+        }
+    }
+
+    private var tabStrip: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "bell.badge.fill")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .padding(.trailing, 4)
+
+            tab(.events,
+                label: "Events",
+                count: store.events.count,
+                shortcutKeys: ["⌘", "1"])
+            tab(.sessions,
+                label: "Sessions",
+                count: sessions.sessions.filter { $0.status == .active }.count,
+                shortcutKeys: ["⌘", "2"])
+            tab(.settings,
+                label: "Settings",
+                count: 0,
+                shortcutKeys: ["⌘", "3"])
+
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private func tab(_ mode: PanelMode, label: String, count: Int, shortcutKeys: [String]) -> some View {
+        let isActive = nav.mode == mode
+        return Button {
+            nav.mode = mode
+        } label: {
+            HStack(spacing: 5) {
+                Text(label)
+                    .font(.caption.weight(isActive ? .semibold : .regular))
+                if count > 0 {
+                    Text("\(count)")
+                        .font(.caption2.monospacedDigit())
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(
+                            Capsule().fill(Color.primary.opacity(isActive ? 0.18 : 0.10))
+                        )
+                }
+                HStack(spacing: 2) {
+                    ForEach(shortcutKeys, id: \.self) { KeyCapView(symbol: $0) }
+                }
+                .opacity(isActive ? 0.5 : 0.85)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .foregroundStyle(isActive ? Color.primary : Color.secondary)
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(isActive ? Color.accentColor.opacity(0.25) : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var eventsBody: some View {
+        VStack(alignment: .leading, spacing: 0) {
             if store.events.isEmpty {
                 emptyState
             } else {
                 eventList
             }
-
             footer
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-    }
-
-    private var header: some View {
-        HStack(spacing: 8) {
-            Text("stack-nudge")
-                .font(.subheadline.weight(.medium))
-                .foregroundStyle(.primary)
-            Spacer()
-            if !store.events.isEmpty {
-                Text("\(store.events.count)")
-                    .font(.caption2.monospacedDigit())
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(
-                        Capsule().fill(Color.primary.opacity(0.08))
-                    )
-            }
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
     }
 
     private var emptyState: some View {
@@ -154,7 +212,7 @@ struct PanelContentView: View {
     }
 }
 
-private struct FooterHint: View {
+struct FooterHint: View {
     let label: String
     let keys: [String]
     var primary: Bool = false
@@ -172,7 +230,7 @@ private struct FooterHint: View {
     }
 }
 
-private struct KeyCapView: View {
+struct KeyCapView: View {
     let symbol: String
 
     var body: some View {
@@ -192,7 +250,7 @@ private struct KeyCapView: View {
     }
 }
 
-private struct FooterDivider: View {
+struct FooterDivider: View {
     var body: some View {
         Rectangle()
             .fill(Color.primary.opacity(0.15))
@@ -271,8 +329,11 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate {
     private var panel: FloatingPanel!
     private var hotkey: Hotkey?
     private let store = EventStore()
+    private let sessions = SessionStore()
+    private let nav = PanelNav()
     private var listener: EventListener?
     private var menuBar: MenuBarController?
+    private var permissionsWC: PermissionsWindowController?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         let frame = NSRect(x: 0, y: 0, width: 420, height: 280)
@@ -288,7 +349,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate {
         blur.layer?.cornerRadius = 12
         blur.layer?.masksToBounds = true
 
-        let host = NSHostingView(rootView: PanelContentView(store: store))
+        let host = NSHostingView(rootView: PanelContentView(store: store, sessions: sessions, nav: nav))
         host.translatesAutoresizingMaskIntoConstraints = false
         blur.addSubview(host)
         NSLayoutConstraint.activate([
@@ -312,6 +373,17 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate {
 
         startListener()
         menuBar = MenuBarController(panelController: self)
+
+        nav.actions = SettingsActions(
+            checkPermissions: { [weak self] in self?.showPermissions() },
+            openConfig:       { NSWorkspace.shared.open(URL(fileURLWithPath: ConfigFile.path)) },
+            quit:             { NSApp.terminate(nil) }
+        )
+    }
+
+    func showPermissions() {
+        if permissionsWC == nil { permissionsWC = PermissionsWindowController() }
+        permissionsWC?.showAndRaise()
     }
 
     func applicationWillTerminate(_ notification: Notification) {
@@ -321,8 +393,88 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate {
     // MARK: - PanelKeyDelegate
 
     func panelHandlesKey(_ event: NSEvent) -> Bool {
-        let blockingMods: NSEvent.ModifierFlags = [.command, .control, .option]
-        guard event.modifierFlags.intersection(blockingMods).isEmpty else {
+        let mods = event.modifierFlags
+        let blockingMods: NSEvent.ModifierFlags = [.control, .option]
+        let cmdOnly = mods.intersection([.command, .control, .option, .shift]) == .command
+
+        // Cmd+1/2/3 jump directly between modes; the in-panel tab strip is
+        // the discoverable mouse equivalent.
+        if cmdOnly {
+            switch event.keyCode {
+            case KeyCode.one:
+                nav.mode = .events; return true
+            case KeyCode.two:
+                nav.mode = .sessions; return true
+            case KeyCode.three:
+                nav.mode = .settings; return true
+            default:
+                break
+            }
+        }
+
+        // Sessions mode: ↑/↓ select, Enter focus, ⌫/R kill, N rename.
+        // While the rename TextField is active, every key flows through to
+        // SwiftUI; the field handles Enter via .onSubmit and Esc via
+        // .onExitCommand.
+        if nav.mode == .sessions {
+            if sessions.renamingPID != nil { return false }
+            let plain = mods.intersection([.command, .control, .option, .shift]).isEmpty
+            switch event.keyCode {
+            case KeyCode.escape where plain:
+                nav.mode = .events
+            case KeyCode.upArrow where plain:
+                selectPrevSession()
+            case KeyCode.downArrow where plain:
+                selectNextSession()
+            case KeyCode.returnKey, KeyCode.numpadEnter:
+                guard plain else { return false }
+                focusSelectedSession()
+            case KeyCode.delete, KeyCode.forwardDelete, KeyCode.rKey:
+                guard plain else { return false }
+                killSelectedSession()
+            case KeyCode.nKey:
+                // Accept N regardless of shift (same physical key for n / N).
+                guard mods.intersection([.command, .control, .option]).isEmpty else { return false }
+                let pid = sessions.selectedPID ?? sessions.sessions.first?.pid
+                if let pid { sessions.startRenaming(pid) }
+            default:
+                return false
+            }
+            return true
+        }
+
+        // In settings mode, the controller drives row selection and value
+        // cycling on PanelNav so the SettingsView stays a pure renderer.
+        if nav.mode == .settings {
+            let plain = mods.intersection([.command, .control, .option, .shift]).isEmpty
+            let shiftOnly = mods.intersection([.command, .control, .option, .shift]) == .shift
+            switch event.keyCode {
+            case KeyCode.escape where plain:
+                nav.mode = .events
+            case KeyCode.upArrow where plain:
+                nav.selectPrevRow()
+            case KeyCode.downArrow where plain:
+                nav.selectNextRow()
+            case KeyCode.tab where plain:
+                nav.selectNextRow()
+            case KeyCode.tab where shiftOnly:
+                nav.selectPrevRow()
+            case KeyCode.leftArrow where plain:
+                nav.cycleBackward()
+            case KeyCode.rightArrow where plain:
+                nav.cycleForward()
+            case KeyCode.returnKey, KeyCode.numpadEnter:
+                guard plain else { return false }
+                nav.activate()
+            default:
+                return false
+            }
+            return true
+        }
+
+        // Events mode: filter out cmd/ctrl/opt-modified keys so app-level
+        // shortcuts pass through to the responder chain.
+        guard mods.intersection(blockingMods.union([.command])).isEmpty else {
             return false
         }
         switch event.keyCode {
@@ -375,6 +527,58 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate {
         if store.events.isEmpty { hidePanel() }
     }
 
+    // MARK: - Sessions actions
+
+    private func selectNextSession() {
+        guard !sessions.sessions.isEmpty else { return }
+        let pids = sessions.sessions.map(\.pid)
+        let idx = sessions.selectedPID.flatMap(pids.firstIndex(of:)) ?? -1
+        sessions.selectedPID = pids[min(idx + 1, pids.count - 1)]
+    }
+
+    private func selectPrevSession() {
+        guard !sessions.sessions.isEmpty else { return }
+        let pids = sessions.sessions.map(\.pid)
+        let idx = sessions.selectedPID.flatMap(pids.firstIndex(of:)) ?? 0
+        sessions.selectedPID = pids[max(idx - 1, 0)]
+    }
+
+    private func focusSelectedSession() {
+        guard let pid = sessions.selectedPID,
+              let session = sessions.sessions.first(where: { $0.pid == pid }),
+              let bundleID = bundleID(for: session.terminalApp) else { return }
+        hidePanel()
+        DispatchQueue.global(qos: .userInitiated).async {
+            AppActivator.activate(
+                bundleID: bundleID,
+                windowTitle: session.projectName,
+                ipcHook: nil,
+                projectPath: session.projectPath,
+                sendApproval: false
+            )
+        }
+    }
+
+    private func killSelectedSession() {
+        guard let pid = sessions.selectedPID else { return }
+        sessions.killSession(pid)
+    }
+
+    // Map a terminal/IDE process name to the launch-services bundle ID so
+    // AppActivator can talk to the right app.
+    private func bundleID(for terminalApp: String?) -> String? {
+        guard let app = terminalApp else { return nil }
+        if app.hasPrefix("Code") { return "com.microsoft.VSCode" }
+        if app.hasPrefix("Cursor") { return "com.todesktop.230313mzl4w4u92" }
+        switch app {
+        case "iTerm2", "iTerm":     return "com.googlecode.iterm2"
+        case "Warp", "WarpTerminal": return "dev.warp.Warp-Stable"
+        case "Ghostty", "ghostty":   return "com.mitchellh.ghostty"
+        case "Terminal":             return "com.apple.Terminal"
+        default:                     return nil
+        }
+    }
+
     // MARK: - Show / hide
 
     // Toggle behaves on focus, not visibility: hotkey while panel is key hides it;
@@ -394,8 +598,10 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate {
 
     // NSApp.hide hides all our windows AND deactivates the app, so the system
     // frontmost reverts to whatever was active before the panel was summoned.
+    // Always return to events mode on hide so the next show is predictable.
     private func hidePanel() {
         panel.orderOut(nil)
+        nav.mode = .events
         NSApp.hide(nil)
     }
 

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -363,13 +363,8 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate {
         positionPanel()
 
         let config = PanelConfig.load()
-        hotkey = Hotkey(spec: config.hotkeySpec) { [weak self] in
-            self?.toggle()
-        }
-        if hotkey == nil {
-            FileHandle.standardError.write(Data(
-                "stack-nudge-panel: failed to register hotkey '\(config.hotkeySpec)'\n".utf8))
-        }
+        nav.hotkeyDisplay = config.hotkeySpec
+        _ = registerHotkey(spec: config.hotkeySpec)
 
         startListener()
         menuBar = MenuBarController(panelController: self)
@@ -379,6 +374,75 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate {
             openConfig:       { NSWorkspace.shared.open(URL(fileURLWithPath: ConfigFile.path)) },
             quit:             { NSApp.terminate(nil) }
         )
+        nav.setHotkey = { [weak self] spec in
+            self?.registerHotkey(spec: spec) ?? false
+        }
+
+        startConfigWatcher()
+    }
+
+    @discardableResult
+    private func registerHotkey(spec: String) -> Bool {
+        let new = Hotkey(spec: spec) { [weak self] in self?.toggle() }
+        guard let new else {
+            FileHandle.standardError.write(Data(
+                "stack-nudge-panel: failed to register hotkey '\(spec)'\n".utf8))
+            return false
+        }
+        hotkey = new  // releasing the old instance unregisters it via deinit
+        return true
+    }
+
+    // MARK: - Config file watcher
+
+    private var configWatcher: DispatchSourceFileSystemObject?
+
+    // Watches ~/.stack-nudge/config for writes so that edits made via "Open
+    // config file…" or any external editor flow back into the running panel
+    // without needing a daemon restart. Most macOS editors save by writing to
+    // a temp file and renaming, which would orphan a vanilla file watcher; we
+    // re-arm on .rename/.delete so subsequent edits keep firing.
+    private func startConfigWatcher() {
+        configWatcher?.cancel()
+        configWatcher = nil
+
+        let fd = open(ConfigFile.path, O_EVTONLY)
+        guard fd >= 0 else {
+            // File may not exist yet during install — try again shortly.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?.startConfigWatcher()
+            }
+            return
+        }
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .rename, .delete],
+            queue: .main
+        )
+        source.setEventHandler { [weak self, weak source] in
+            guard let self, let source else { return }
+            let flags = source.data
+            self.reloadConfigFromDisk()
+            if flags.contains(.rename) || flags.contains(.delete) {
+                // Atomic-save replaced the inode under us; re-open against
+                // the new file. Small delay lets the editor finish its swap.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    self.startConfigWatcher()
+                }
+            }
+        }
+        source.setCancelHandler { close(fd) }
+        source.resume()
+        configWatcher = source
+    }
+
+    private func reloadConfigFromDisk() {
+        let config = PanelConfig.load()
+        if config.hotkeySpec != nav.hotkeyDisplay {
+            if registerHotkey(spec: config.hotkeySpec) {
+                nav.hotkeyDisplay = config.hotkeySpec
+            }
+        }
     }
 
     func showPermissions() {
@@ -396,6 +460,23 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate {
         let mods = event.modifierFlags
         let blockingMods: NSEvent.ModifierFlags = [.control, .option]
         let cmdOnly = mods.intersection([.command, .control, .option, .shift]) == .command
+
+        // While recording a hotkey, swallow every key so the new combo
+        // doesn't accidentally fire some other shortcut.
+        if nav.recordingHotkey {
+            if event.keyCode == KeyCode.escape && mods.intersection([.command, .control, .option, .shift]).isEmpty {
+                nav.cancelRecordingHotkey()
+                return true
+            }
+            let captured = mods.intersection([.command, .control, .option, .shift])
+            // Need at least one modifier (Carbon RegisterEventHotKey rejects
+            // bare keys, and we don't want to accidentally bind plain "n").
+            guard !captured.isEmpty else { return true }
+            if let spec = Hotkey.encode(eventModifiers: mods.rawValue, keyCode: event.keyCode) {
+                nav.commitHotkey(spec)
+            }
+            return true
+        }
 
         // Cmd+1/2/3 jump directly between modes; the in-panel tab strip is
         // the discoverable mouse equivalent.
@@ -516,7 +597,8 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate {
                 windowTitle: event.windowTitle,
                 ipcHook: event.ipcHook,
                 projectPath: event.projectPath,
-                sendApproval: sendApproval
+                sendApproval: sendApproval,
+                agent: event.agent
             )
         }
     }
@@ -554,7 +636,8 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate {
                 windowTitle: session.projectName,
                 ipcHook: nil,
                 projectPath: session.projectPath,
-                sendApproval: false
+                sendApproval: false,
+                agent: session.agent
             )
         }
     }

--- a/panel/SessionStore.swift
+++ b/panel/SessionStore.swift
@@ -1,0 +1,280 @@
+import Foundation
+import SwiftUI
+
+enum SessionStatus: Equatable {
+    case active
+    case finished(at: Date)
+}
+
+struct Session: Identifiable, Equatable {
+    let id: Int           // pid — pids are reusable but stable for this process's lifetime
+    let pid: Int
+    let agent: String     // "claude" | "gemini" | "codex"
+    let projectPath: String?
+    let projectName: String?
+    let terminalPID: Int?
+    let terminalApp: String?
+    let elapsed: String?  // ps etime — display-only
+    var customName: String?
+    var status: SessionStatus
+}
+
+// Polls for live agent processes (claude / gemini / codex) every few seconds
+// while the sessions view is on screen. Maintains "finished" state for
+// sessions that disappeared between polls so the user can see ones that
+// just exited.
+final class SessionStore: ObservableObject {
+
+    @Published private(set) var sessions: [Session] = []
+    @Published var selectedPID: Int?
+    @Published var renamingPID: Int?
+    @Published var renameBuffer: String = ""
+    @Published private(set) var isScanning: Bool = false
+    @Published private(set) var didFirstScan: Bool = false
+
+    private var pollTimer: Timer?
+    private let queue = DispatchQueue(label: "stack-nudge.sessions", qos: .utility)
+    private static let agentBinaries: Set<String> = ["claude", "gemini", "codex"]
+    private static let pollInterval: TimeInterval = 3.0
+
+    func startPolling() {
+        scan()
+        pollTimer?.invalidate()
+        pollTimer = Timer.scheduledTimer(withTimeInterval: Self.pollInterval, repeats: true) { [weak self] _ in
+            self?.scan()
+        }
+    }
+
+    func stopPolling() {
+        pollTimer?.invalidate()
+        pollTimer = nil
+    }
+
+    func killSession(_ pid: Int) {
+        // SIGTERM — give the agent a chance to clean up
+        kill(pid_t(pid), SIGTERM)
+        // Optimistically mark finished so the UI updates without waiting
+        // for the next poll.
+        if let idx = sessions.firstIndex(where: { $0.pid == pid }) {
+            sessions[idx].status = .finished(at: Date())
+        }
+    }
+
+    func rename(_ pid: Int, to name: String?) {
+        if let idx = sessions.firstIndex(where: { $0.pid == pid }) {
+            sessions[idx].customName = (name?.isEmpty ?? true) ? nil : name
+        }
+    }
+
+    func startRenaming(_ pid: Int) {
+        guard let session = sessions.first(where: { $0.pid == pid }) else { return }
+        renamingPID = pid
+        renameBuffer = session.customName ?? session.projectName ?? ""
+    }
+
+    func commitRename() {
+        guard let pid = renamingPID else { return }
+        rename(pid, to: renameBuffer.trimmingCharacters(in: .whitespaces))
+        renamingPID = nil
+        renameBuffer = ""
+    }
+
+    func cancelRename() {
+        renamingPID = nil
+        renameBuffer = ""
+    }
+
+    private func scan() {
+        isScanning = true
+        queue.async { [weak self] in
+            let found = Self.discover()
+            DispatchQueue.main.async { [weak self] in
+                self?.merge(found)
+                self?.isScanning = false
+                self?.didFirstScan = true
+            }
+        }
+    }
+
+    private func merge(_ found: [Session]) {
+        let foundByPID = Dictionary(uniqueKeysWithValues: found.map { ($0.pid, $0) })
+        let now = Date()
+        let cutoff = now.addingTimeInterval(-30) // hide finished sessions after 30s
+
+        var next: [Session] = []
+
+        // Update / mark-finished existing sessions in place so customName persists.
+        for var existing in sessions {
+            if let live = foundByPID[existing.pid] {
+                existing = live.with(customName: existing.customName, status: .active)
+                next.append(existing)
+            } else {
+                switch existing.status {
+                case .active:
+                    existing.status = .finished(at: now)
+                    next.append(existing)
+                case .finished(let at) where at >= cutoff:
+                    next.append(existing)
+                default:
+                    break // drop stale finished
+                }
+            }
+        }
+
+        // Add genuinely new sessions.
+        let knownPIDs = Set(next.map(\.pid))
+        for session in found where !knownPIDs.contains(session.pid) {
+            next.append(session)
+        }
+
+        // Sort: active first, then most-recently-finished, then by agent/pid.
+        next.sort { lhs, rhs in
+            let lActive = lhs.status == .active
+            let rActive = rhs.status == .active
+            if lActive != rActive { return lActive && !rActive }
+            return lhs.pid < rhs.pid
+        }
+
+        sessions = next
+
+        if let sel = selectedPID, !sessions.contains(where: { $0.pid == sel }) {
+            selectedPID = sessions.first?.pid
+        } else if selectedPID == nil {
+            selectedPID = sessions.first?.pid
+        }
+    }
+
+    // MARK: - Discovery
+
+    // Parse ps output as `pid etime <full args>`. Agent detection is done on
+    // args because `comm` is truncated by ps and node-hosted agents (gemini,
+    // codex when installed via npm) show comm as "node" with the script
+    // path in args.
+    private static func discover() -> [Session] {
+        let lines = runProcess("/bin/ps", ["-axo", "pid=,etime=,args="])
+            .split(separator: "\n")
+
+        var found: [Session] = []
+        for raw in lines {
+            let line = String(raw).trimmingCharacters(in: .whitespaces)
+            // pid (digits) <ws> etime <ws> args...
+            let parts = line.split(separator: " ", maxSplits: 2,
+                                   omittingEmptySubsequences: true)
+            guard parts.count >= 3 else { continue }
+            guard let pid = Int(parts[0]) else { continue }
+            let etime = String(parts[1])
+            let args = String(parts[2])
+
+            guard let agent = detectAgent(args: args) else { continue }
+
+            let cwd = readCWD(pid: pid)
+            let chain = walkParentChain(from: pid)
+
+            found.append(Session(
+                id: pid,
+                pid: pid,
+                agent: agent,
+                projectPath: cwd,
+                projectName: cwd.map { ($0 as NSString).lastPathComponent },
+                terminalPID: chain.terminalPID,
+                terminalApp: chain.terminalApp,
+                elapsed: etime,
+                customName: nil,
+                status: .active
+            ))
+        }
+        return found
+    }
+
+    private static func detectAgent(args: String) -> String? {
+        // First token of args is the executable path.
+        let firstToken = args.split(separator: " ", maxSplits: 1).first.map(String.init) ?? ""
+        let baseName = (firstToken as NSString).lastPathComponent
+
+        if baseName == "claude" { return "claude" }
+        if baseName == "gemini" { return "gemini" }
+        if baseName == "codex"  { return "codex"  }
+
+        // Node / Deno-hosted agents: inspect later tokens for known script paths.
+        if baseName == "node" || baseName == "deno" || baseName == "bun" {
+            if args.range(of: #"\bgemini(-cli)?\b"#, options: .regularExpression) != nil {
+                return "gemini"
+            }
+            if args.range(of: #"\bcodex(-cli)?\b"#, options: .regularExpression) != nil {
+                return "codex"
+            }
+        }
+        return nil
+    }
+
+    private static func readCWD(pid: Int) -> String? {
+        let output = runProcess("/usr/sbin/lsof", ["-a", "-d", "cwd", "-p", "\(pid)", "-Fn"])
+        for line in output.split(separator: "\n") {
+            if line.hasPrefix("n") {
+                return String(line.dropFirst())
+            }
+        }
+        return nil
+    }
+
+    private struct ParentChain {
+        var terminalPID: Int?
+        var terminalApp: String?
+    }
+
+    private static let terminalApps: Set<String> = [
+        "Code Helper", "Code Helper (Plugin)", "Code Helper (Renderer)", "Code",
+        "Cursor Helper", "Cursor Helper (Plugin)", "Cursor Helper (Renderer)", "Cursor",
+        "iTerm2", "iTerm", "Terminal", "Warp", "WarpTerminal", "ghostty", "Ghostty",
+    ]
+
+    private static func walkParentChain(from pid: Int) -> ParentChain {
+        var chain = ParentChain()
+        var current: Int? = pid
+        for _ in 0..<12 {
+            guard let next = current, next > 1 else { break }
+            let comm = runProcess("/bin/ps", ["-p", "\(next)", "-o", "comm="])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let base = (comm as NSString).lastPathComponent
+            if terminalApps.contains(base) {
+                chain.terminalPID = next
+                chain.terminalApp = base
+                return chain
+            }
+            let ppidStr = runProcess("/bin/ps", ["-p", "\(next)", "-o", "ppid="])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            current = Int(ppidStr)
+        }
+        return chain
+    }
+
+    private static func runProcess(_ path: String, _ args: [String]) -> String {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: path)
+        task.arguments = args
+        let outPipe = Pipe()
+        task.standardOutput = outPipe
+        task.standardError = Pipe()
+        do { try task.run() } catch { return "" }
+        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+        task.waitUntilExit()
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+}
+
+private extension Session {
+    func with(customName: String?, status: SessionStatus) -> Session {
+        Session(
+            id: id,
+            pid: pid,
+            agent: agent,
+            projectPath: projectPath,
+            projectName: projectName,
+            terminalPID: terminalPID,
+            terminalApp: terminalApp,
+            elapsed: elapsed,
+            customName: customName,
+            status: status
+        )
+    }
+}

--- a/panel/Sessions.swift
+++ b/panel/Sessions.swift
@@ -1,0 +1,212 @@
+import AppKit
+import SwiftUI
+
+struct SessionsView: View {
+
+    @ObservedObject var store: SessionStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if store.sessions.isEmpty {
+                emptyState
+            } else {
+                sessionsList
+            }
+
+            footer
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .onAppear  { store.startPolling() }
+        .onDisappear { store.stopPolling() }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+                .controlSize(.small)
+            Text(store.didFirstScan ? "No active agent sessions" : "Checking for sessions…")
+                .foregroundStyle(.secondary)
+                .font(.subheadline)
+            Text("claude · gemini · codex")
+                .foregroundStyle(.tertiary)
+                .font(.caption2.monospaced())
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.vertical, 24)
+    }
+
+    private var sessionsList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 2) {
+                    ForEach(store.sessions) { session in
+                        SessionRow(
+                            session: session,
+                            selected: store.selectedPID == session.pid,
+                            isEditing: store.renamingPID == session.pid,
+                            renameBuffer: $store.renameBuffer,
+                            onCommit: { store.commitRename() },
+                            onCancel: { store.cancelRename() }
+                        )
+                        .id(session.pid)
+                        .contentShape(Rectangle())
+                        .onTapGesture { store.selectedPID = session.pid }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .onChange(of: store.selectedPID) { newValue in
+                guard let pid = newValue else { return }
+                withAnimation(.easeOut(duration: 0.15)) {
+                    proxy.scrollTo(pid, anchor: .center)
+                }
+            }
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 0) {
+            Image(systemName: "bell.badge.fill")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+            Spacer()
+            if store.renamingPID != nil {
+                FooterHint(label: "Save",   keys: ["⏎"])
+                FooterHint(label: "Cancel", keys: ["esc"])
+            } else {
+                FooterHint(label: "Select", keys: ["↑", "↓"])
+                FooterHint(label: "Focus",  keys: ["⏎"])
+                FooterHint(label: "Rename", keys: ["n"])
+                FooterHint(label: "Kill",   keys: ["⌫"])
+                FooterHint(label: "Back",   keys: ["esc"])
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 9)
+        .background(
+            ZStack {
+                Color.primary.opacity(0.05)
+                Rectangle()
+                    .fill(Color.primary.opacity(0.1))
+                    .frame(height: 0.5)
+                    .frame(maxHeight: .infinity, alignment: .top)
+            }
+        )
+    }
+}
+
+private struct SessionRow: View {
+
+    let session: Session
+    let selected: Bool
+    let isEditing: Bool
+    @Binding var renameBuffer: String
+    let onCommit: () -> Void
+    let onCancel: () -> Void
+
+    @FocusState private var nameFieldFocused: Bool
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: glyph)
+                .font(.body)
+                .foregroundStyle(glyphColor)
+                .frame(width: 20, alignment: .center)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    if isEditing {
+                        TextField("Session name", text: $renameBuffer)
+                            .textFieldStyle(.plain)
+                            .font(.subheadline.weight(.medium))
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(
+                                RoundedRectangle(cornerRadius: 4)
+                                    .fill(Color.primary.opacity(0.15))
+                            )
+                            .focused($nameFieldFocused)
+                            .onSubmit(onCommit)
+                            .onExitCommand(perform: onCancel)
+                            .onAppear {
+                                // Defer focus by one tick — SwiftUI's @FocusState
+                                // binding inside an NSHostingView sometimes needs
+                                // the run-loop to settle before it accepts the
+                                // assignment.
+                                DispatchQueue.main.async {
+                                    nameFieldFocused = true
+                                }
+                            }
+                    } else {
+                        Text(displayName)
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(isActive ? Color.primary : Color.secondary)
+                    }
+                    Text(session.agent)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.tertiary)
+                    Spacer(minLength: 8)
+                    Text(rightMeta)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+                HStack(spacing: 8) {
+                    if let term = session.terminalApp {
+                        Text(term)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    Text("pid \(session.pid)")
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(rowBackgroundColor)
+        )
+        .padding(.horizontal, 6)
+        .opacity(isActive ? 1.0 : 0.55)
+    }
+
+    private var rowBackgroundColor: Color {
+        if isEditing { return Color.accentColor.opacity(0.30) }
+        if selected  { return Color.accentColor.opacity(0.22) }
+        return Color.clear
+    }
+
+    private var isActive: Bool { session.status == .active }
+
+    private var displayName: String {
+        if let custom = session.customName, !custom.isEmpty { return custom }
+        return session.projectName ?? "(no project)"
+    }
+
+    private var glyph: String {
+        switch session.status {
+        case .active:   return "circle.fill"
+        case .finished: return "circle"
+        }
+    }
+
+    private var glyphColor: Color {
+        switch session.status {
+        case .active:   return .green
+        case .finished: return .secondary
+        }
+    }
+
+    private var rightMeta: String {
+        switch session.status {
+        case .active:
+            return session.elapsed ?? ""
+        case .finished(let at):
+            let interval = Int(Date().timeIntervalSince(at))
+            return "ended \(interval)s ago"
+        }
+    }
+}

--- a/panel/Settings.swift
+++ b/panel/Settings.swift
@@ -1,0 +1,347 @@
+import AppKit
+import SwiftUI
+
+enum PanelMode {
+    case events
+    case sessions
+    case settings
+}
+
+// Action callbacks the controller wires into nav so settings rows like
+// "Check permissions" / "Open config" / "Quit" can fire effects without the
+// SwiftUI view needing to know about windows or app-level state.
+struct SettingsActions {
+    let checkPermissions: () -> Void
+    let openConfig:       () -> Void
+    let quit:             () -> Void
+}
+
+enum SettingsKind {
+    case toggle, cycle, action
+}
+
+private struct SettingsItem {
+    let id: Int
+    let label: String
+    let kind: SettingsKind
+    let value: String      // "On"/"Off" for toggles, current value for cycle, "" for action
+}
+
+// PanelNav owns navigation state and settings state. The controller drives
+// it directly from key events; the view is a pure renderer.
+final class PanelNav: ObservableObject {
+
+    @Published var mode: PanelMode = .events
+    @Published var selectedSettingIndex: Int = 0
+
+    @Published var hotkeyDisplay:   String = "cmd+shift+n"
+    @Published var bannerEnabled:   Bool = true
+    @Published var voiceEnabled:    Bool = false
+    @Published var soundStop:       String = "Glass"
+    @Published var soundPermission: String = "Ping"
+    @Published var voice:           String = "af_heart"
+    @Published var voiceSpeed:      Double = 1.1
+    @Published var voicesAvailable: [String] = []
+    @Published var voicesLoading:   Bool = true
+
+    var actions: SettingsActions?
+
+    static let macSounds = [
+        "Basso", "Blow", "Bottle", "Frog", "Funk", "Glass", "Hero",
+        "Morse", "Ping", "Pop", "Purr", "Sosumi", "Submarine", "Tink",
+    ]
+
+    static let speedMin = 0.60
+    static let speedMax = 1.60
+    static let speedStep = 0.05
+
+    var rowCount: Int { 9 }
+
+    // Row layout (kept in one place so the controller, view, and indexing
+    // logic all agree on what each row index means):
+    //   0  Banner notifications  toggle
+    //   1  Voice notifications   toggle
+    //   2  Agent done sound      cycle
+    //   3  Permission sound      cycle
+    //   4  Voice                 cycle
+    //   5  Speed                 cycle
+    //   6  Check permissions…    action
+    //   7  Open config file…     action
+    //   8  Quit panel            action
+
+    // MARK: - Disk I/O
+
+    func loadFromConfig() {
+        let config = ConfigFile.read()
+        hotkeyDisplay   = config["STACKNUDGE_PANEL_HOTKEY"]    ?? "cmd+shift+n"
+        bannerEnabled   = ConfigFile.bool(config, "STACKNUDGE_BANNER", default: true)
+        voiceEnabled    = ConfigFile.bool(config, "STACKNUDGE_VOICE",  default: false)
+        soundStop       = config["STACKNUDGE_SOUND_STOP"]       ?? "Glass"
+        soundPermission = config["STACKNUDGE_SOUND_PERMISSION"] ?? "Ping"
+        voice           = config["STACKNUDGE_VOICE_NAME"]       ?? "af_heart"
+        voiceSpeed      = Double(config["STACKNUDGE_VOICE_SPEED"] ?? "") ?? 1.1
+    }
+
+    func loadVoices() {
+        Task.detached(priority: .userInitiated) {
+            let names = Self.runStackvoxVoices()
+            await MainActor.run { [weak self] in
+                self?.voicesAvailable = names
+                self?.voicesLoading = false
+            }
+        }
+    }
+
+    private nonisolated static func runStackvoxVoices() -> [String] {
+        let stackvox = "\(NSHomeDirectory())/.stack-nudge/venv/bin/stackvox"
+        guard FileManager.default.isExecutableFile(atPath: stackvox) else { return [] }
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: stackvox)
+        task.arguments = ["voices"]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = Pipe()
+        do { try task.run() } catch { return [] }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        task.waitUntilExit()
+        return (String(data: data, encoding: .utf8) ?? "")
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty && !$0.contains(" ") }
+    }
+
+    // MARK: - Row movement
+
+    func selectNextRow() {
+        guard rowCount > 0 else { return }
+        selectedSettingIndex = (selectedSettingIndex + 1) % rowCount
+    }
+
+    func selectPrevRow() {
+        guard rowCount > 0 else { return }
+        selectedSettingIndex = (selectedSettingIndex - 1 + rowCount) % rowCount
+    }
+
+    // MARK: - Cycle / activate
+
+    // ←/→: toggles flip, cycle rows step, actions are no-op.
+    func cycleForward()  { applyCycle(forward: true) }
+    func cycleBackward() { applyCycle(forward: false) }
+
+    // Enter: toggles flip, cycle rows step forward, actions fire.
+    func activate() {
+        switch selectedSettingIndex {
+        case 6: actions?.checkPermissions()
+        case 7: actions?.openConfig()
+        case 8: actions?.quit()
+        default: applyCycle(forward: true)
+        }
+    }
+
+    private func applyCycle(forward: Bool) {
+        switch selectedSettingIndex {
+        case 0:
+            bannerEnabled.toggle()
+            ConfigFile.write(key: "STACKNUDGE_BANNER", value: bannerEnabled ? "true" : "false")
+        case 1:
+            voiceEnabled.toggle()
+            ConfigFile.write(key: "STACKNUDGE_VOICE", value: voiceEnabled ? "true" : "false")
+        case 2:
+            soundStop = step(soundStop, in: Self.macSounds, forward: forward, key: "STACKNUDGE_SOUND_STOP", preview: true)
+        case 3:
+            soundPermission = step(soundPermission, in: Self.macSounds, forward: forward, key: "STACKNUDGE_SOUND_PERMISSION", preview: true)
+        case 4:
+            guard !voicesLoading, !voicesAvailable.isEmpty else { return }
+            voice = step(voice, in: voicesAvailable, forward: forward, key: "STACKNUDGE_VOICE_NAME", preview: false)
+        case 5:
+            let next = forward ? voiceSpeed + Self.speedStep : voiceSpeed - Self.speedStep
+            voiceSpeed = max(Self.speedMin, min(Self.speedMax, (next * 100).rounded() / 100))
+            ConfigFile.write(key: "STACKNUDGE_VOICE_SPEED", value: String(format: "%.2f", voiceSpeed))
+        default:
+            break
+        }
+    }
+
+    private func step(_ current: String, in list: [String], forward: Bool, key: String, preview: Bool) -> String {
+        guard !list.isEmpty else { return current }
+        let idx = list.firstIndex(of: current) ?? 0
+        let next = forward ? (idx + 1) % list.count : (idx - 1 + list.count) % list.count
+        let value = list[next]
+        ConfigFile.write(key: key, value: value)
+        if preview { NSSound(named: NSSound.Name(value))?.play() }
+        return value
+    }
+}
+
+struct SettingsView: View {
+
+    @ObservedObject var nav: PanelNav
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 14) {
+                        infoRow(
+                            label: "Hotkey",
+                            value: nav.hotkeyDisplay
+                        )
+
+                        section("Toggles") {
+                            row(0, label: "Banner notifications", kind: .toggle, value: nav.bannerEnabled ? "On" : "Off")
+                            row(1, label: "Voice notifications",  kind: .toggle, value: nav.voiceEnabled  ? "On" : "Off")
+                        }
+
+                        section("Sounds") {
+                            row(2, label: "Agent done", kind: .cycle, value: nav.soundStop)
+                            row(3, label: "Permission", kind: .cycle, value: nav.soundPermission)
+                        }
+
+                        section("Voice") {
+                            row(4, label: "Voice",  kind: .cycle, value: voiceLabel)
+                            row(5, label: "Speed",  kind: .cycle, value: String(format: "%.2f×", nav.voiceSpeed))
+                        }
+
+                        section("Actions") {
+                            row(6, label: "Check permissions…", kind: .action, value: "")
+                            row(7, label: "Open config file…",  kind: .action, value: "")
+                            row(8, label: "Quit panel",         kind: .action, value: "")
+                        }
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 14)
+                }
+                .onChange(of: nav.selectedSettingIndex) { newIndex in
+                    withAnimation(.easeOut(duration: 0.15)) {
+                        proxy.scrollTo(newIndex, anchor: .center)
+                    }
+                }
+            }
+
+            footer
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .onAppear {
+            nav.loadFromConfig()
+            if nav.voicesAvailable.isEmpty { nav.loadVoices() }
+        }
+    }
+
+    private var voiceLabel: String {
+        if nav.voicesLoading { return "Loading…" }
+        if nav.voicesAvailable.isEmpty { return "Voices unavailable" }
+        return nav.voice
+    }
+
+    private var footer: some View {
+        HStack(spacing: 0) {
+            Image(systemName: "bell.badge.fill")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+            Spacer()
+            FooterHint(label: "Move",   keys: ["↑", "↓"])
+            FooterHint(label: "Cycle",  keys: ["←", "→"])
+            FooterHint(label: "Act",    keys: ["⏎"])
+            FooterHint(label: "Back",   keys: ["esc"])
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 9)
+        .background(
+            ZStack {
+                Color.primary.opacity(0.05)
+                Rectangle()
+                    .fill(Color.primary.opacity(0.1))
+                    .frame(height: 0.5)
+                    .frame(maxHeight: .infinity, alignment: .top)
+            }
+        )
+    }
+
+    private func section<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+                .padding(.horizontal, 6)
+                .padding(.bottom, 2)
+            VStack(spacing: 2) { content() }
+        }
+    }
+
+    @ViewBuilder
+    private func row(_ index: Int, label: String, kind: SettingsKind, value: String) -> some View {
+        SettingsRowView(
+            label: label,
+            value: value,
+            kind: kind,
+            selected: nav.selectedSettingIndex == index
+        )
+        .id(index)
+        .onTapGesture {
+            nav.selectedSettingIndex = index
+            // For actions, single-click is enough. For toggles/cycles a click
+            // on the row also acts so mouse users don't have to keyboard.
+            if kind == .action || kind == .toggle {
+                nav.activate()
+            }
+        }
+    }
+
+    private func infoRow(label: String, value: String) -> some View {
+        HStack {
+            Text(label)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+            Spacer()
+            Text(value)
+                .font(.caption.monospaced())
+                .foregroundStyle(.tertiary)
+        }
+        .padding(.horizontal, 6)
+    }
+}
+
+private struct SettingsRowView: View {
+
+    let label: String
+    let value: String
+    let kind: SettingsKind
+    let selected: Bool
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Text(label)
+                .font(.subheadline)
+                .foregroundStyle(selected ? Color.primary : Color.primary.opacity(0.85))
+            Spacer()
+            trailing
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(selected ? Color.accentColor.opacity(0.22) : Color.clear)
+        )
+        .contentShape(Rectangle())
+    }
+
+    @ViewBuilder
+    private var trailing: some View {
+        switch kind {
+        case .toggle:
+            Image(systemName: value == "On" ? "checkmark.circle.fill" : "circle")
+                .font(.callout)
+                .foregroundStyle(value == "On" ? Color.green : Color.secondary)
+        case .cycle:
+            Text(value)
+                .font(.subheadline.monospaced())
+                .foregroundStyle(selected ? Color.primary : .secondary)
+        case .action:
+            Image(systemName: "chevron.right")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+    }
+}

--- a/panel/Settings.swift
+++ b/panel/Settings.swift
@@ -34,7 +34,9 @@ final class PanelNav: ObservableObject {
     @Published var mode: PanelMode = .events
     @Published var selectedSettingIndex: Int = 0
 
-    @Published var hotkeyDisplay:   String = "cmd+shift+n"
+    @Published var hotkeyDisplay:   String = "cmd+opt+n"
+    @Published var recordingHotkey: Bool = false
+    @Published var hotkeyError:     String?
     @Published var bannerEnabled:   Bool = true
     @Published var voiceEnabled:    Bool = false
     @Published var soundStop:       String = "Glass"
@@ -45,6 +47,10 @@ final class PanelNav: ObservableObject {
     @Published var voicesLoading:   Bool = true
 
     var actions: SettingsActions?
+    // Wired by PanelController so nav can re-register the global hotkey
+    // without owning the Hotkey instance directly. Returns true if the
+    // new spec registered successfully.
+    var setHotkey: ((String) -> Bool)?
 
     static let macSounds = [
         "Basso", "Blow", "Bottle", "Frog", "Funk", "Glass", "Hero",
@@ -55,19 +61,20 @@ final class PanelNav: ObservableObject {
     static let speedMax = 1.60
     static let speedStep = 0.05
 
-    var rowCount: Int { 9 }
+    var rowCount: Int { 10 }
 
     // Row layout (kept in one place so the controller, view, and indexing
     // logic all agree on what each row index means):
-    //   0  Banner notifications  toggle
-    //   1  Voice notifications   toggle
-    //   2  Agent done sound      cycle
-    //   3  Permission sound      cycle
-    //   4  Voice                 cycle
-    //   5  Speed                 cycle
-    //   6  Check permissions…    action
-    //   7  Open config file…     action
-    //   8  Quit panel            action
+    //   0  Hotkey                hotkey-record
+    //   1  Banner notifications  toggle
+    //   2  Voice notifications   toggle
+    //   3  Agent done sound      cycle
+    //   4  Permission sound      cycle
+    //   5  Voice                 cycle
+    //   6  Speed                 cycle
+    //   7  Check permissions…    action
+    //   8  Open config file…     action
+    //   9  Quit panel            action
 
     // MARK: - Disk I/O
 
@@ -128,12 +135,14 @@ final class PanelNav: ObservableObject {
     func cycleForward()  { applyCycle(forward: true) }
     func cycleBackward() { applyCycle(forward: false) }
 
-    // Enter: toggles flip, cycle rows step forward, actions fire.
+    // Enter: toggles flip, cycle rows step forward, actions fire, hotkey
+    // row enters record mode.
     func activate() {
         switch selectedSettingIndex {
-        case 6: actions?.checkPermissions()
-        case 7: actions?.openConfig()
-        case 8: actions?.quit()
+        case 0: startRecordingHotkey()
+        case 7: actions?.checkPermissions()
+        case 8: actions?.openConfig()
+        case 9: actions?.quit()
         default: applyCycle(forward: true)
         }
     }
@@ -141,25 +150,54 @@ final class PanelNav: ObservableObject {
     private func applyCycle(forward: Bool) {
         switch selectedSettingIndex {
         case 0:
+            // Cycle on the hotkey row also enters record mode.
+            startRecordingHotkey()
+        case 1:
             bannerEnabled.toggle()
             ConfigFile.write(key: "STACKNUDGE_BANNER", value: bannerEnabled ? "true" : "false")
-        case 1:
+        case 2:
             voiceEnabled.toggle()
             ConfigFile.write(key: "STACKNUDGE_VOICE", value: voiceEnabled ? "true" : "false")
-        case 2:
-            soundStop = step(soundStop, in: Self.macSounds, forward: forward, key: "STACKNUDGE_SOUND_STOP", preview: true)
         case 3:
-            soundPermission = step(soundPermission, in: Self.macSounds, forward: forward, key: "STACKNUDGE_SOUND_PERMISSION", preview: true)
+            soundStop = step(soundStop, in: Self.macSounds, forward: forward, key: "STACKNUDGE_SOUND_STOP", preview: true)
         case 4:
+            soundPermission = step(soundPermission, in: Self.macSounds, forward: forward, key: "STACKNUDGE_SOUND_PERMISSION", preview: true)
+        case 5:
             guard !voicesLoading, !voicesAvailable.isEmpty else { return }
             voice = step(voice, in: voicesAvailable, forward: forward, key: "STACKNUDGE_VOICE_NAME", preview: false)
-        case 5:
+        case 6:
             let next = forward ? voiceSpeed + Self.speedStep : voiceSpeed - Self.speedStep
             voiceSpeed = max(Self.speedMin, min(Self.speedMax, (next * 100).rounded() / 100))
             ConfigFile.write(key: "STACKNUDGE_VOICE_SPEED", value: String(format: "%.2f", voiceSpeed))
         default:
             break
         }
+    }
+
+    // MARK: - Hotkey recording
+
+    func startRecordingHotkey() {
+        recordingHotkey = true
+        hotkeyError = nil
+    }
+
+    func cancelRecordingHotkey() {
+        recordingHotkey = false
+    }
+
+    func commitHotkey(_ spec: String) {
+        // Try to register first; only persist if it took. Failing means the
+        // combo was rejected by the OS (already-registered global, malformed,
+        // etc.) — keep the previous one and surface a message to the user.
+        guard let setHotkey, setHotkey(spec) else {
+            hotkeyError = "‘\(spec)’ is unavailable — already bound by another app"
+            recordingHotkey = false
+            return
+        }
+        hotkeyError = nil
+        hotkeyDisplay = spec
+        ConfigFile.write(key: "STACKNUDGE_PANEL_HOTKEY", value: spec)
+        recordingHotkey = false
     }
 
     private func step(_ current: String, in list: [String], forward: Bool, key: String, preview: Bool) -> String {
@@ -182,30 +220,38 @@ struct SettingsView: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     VStack(alignment: .leading, spacing: 14) {
-                        infoRow(
-                            label: "Hotkey",
-                            value: nav.hotkeyDisplay
-                        )
+                        section("Hotkey") {
+                            row(0, label: "Panel shortcut",
+                                kind: .cycle,
+                                value: nav.recordingHotkey ? "Press combo…" : nav.hotkeyDisplay)
+                            if let error = nav.hotkeyError {
+                                Text(error)
+                                    .font(.caption)
+                                    .foregroundStyle(.red)
+                                    .padding(.horizontal, 14)
+                                    .padding(.top, 2)
+                            }
+                        }
 
                         section("Toggles") {
-                            row(0, label: "Banner notifications", kind: .toggle, value: nav.bannerEnabled ? "On" : "Off")
-                            row(1, label: "Voice notifications",  kind: .toggle, value: nav.voiceEnabled  ? "On" : "Off")
+                            row(1, label: "Banner notifications", kind: .toggle, value: nav.bannerEnabled ? "On" : "Off")
+                            row(2, label: "Voice notifications",  kind: .toggle, value: nav.voiceEnabled  ? "On" : "Off")
                         }
 
                         section("Sounds") {
-                            row(2, label: "Agent done", kind: .cycle, value: nav.soundStop)
-                            row(3, label: "Permission", kind: .cycle, value: nav.soundPermission)
+                            row(3, label: "Agent done", kind: .cycle, value: nav.soundStop)
+                            row(4, label: "Permission", kind: .cycle, value: nav.soundPermission)
                         }
 
                         section("Voice") {
-                            row(4, label: "Voice",  kind: .cycle, value: voiceLabel)
-                            row(5, label: "Speed",  kind: .cycle, value: String(format: "%.2f×", nav.voiceSpeed))
+                            row(5, label: "Voice",  kind: .cycle, value: voiceLabel)
+                            row(6, label: "Speed",  kind: .cycle, value: String(format: "%.2f×", nav.voiceSpeed))
                         }
 
                         section("Actions") {
-                            row(6, label: "Check permissions…", kind: .action, value: "")
-                            row(7, label: "Open config file…",  kind: .action, value: "")
-                            row(8, label: "Quit panel",         kind: .action, value: "")
+                            row(7, label: "Check permissions…", kind: .action, value: "")
+                            row(8, label: "Open config file…",  kind: .action, value: "")
+                            row(9, label: "Quit panel",         kind: .action, value: "")
                         }
                     }
                     .padding(.horizontal, 14)
@@ -288,19 +334,6 @@ struct SettingsView: View {
         }
     }
 
-    private func infoRow(label: String, value: String) -> some View {
-        HStack {
-            Text(label)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .textCase(.uppercase)
-            Spacer()
-            Text(value)
-                .font(.caption.monospaced())
-                .foregroundStyle(.tertiary)
-        }
-        .padding(.horizontal, 6)
-    }
 }
 
 private struct SettingsRowView: View {

--- a/shared/AppActivator.swift
+++ b/shared/AppActivator.swift
@@ -19,7 +19,7 @@ struct AppActivator {
 
     static func activate(bundleID: String, windowTitle: String? = nil,
                          ipcHook: String? = nil, projectPath: String? = nil,
-                         sendApproval: Bool = false) {
+                         sendApproval: Bool = false, agent: String? = nil) {
         let folder = windowTitle ?? projectPath.map { ($0 as NSString).lastPathComponent }
         let proc = processName[bundleID]
 
@@ -32,6 +32,7 @@ struct AppActivator {
             let escapedCLI  = cli.replacingOccurrences(of: "'", with: "'\\''")
             let escapedPath = path.replacingOccurrences(of: "'", with: "'\\''")
             let trusted = AXIsProcessTrusted()
+            let pressEnter = sendApproval && trusted
 
             // Step 1: activate app + switch window via CLI (no Automation needed)
             var err: NSDictionary?
@@ -41,15 +42,30 @@ struct AppActivator {
                 do shell script "'\(escapedCLI)' --reuse-window '\(escapedPath)'"
             """)?.executeAndReturnError(&err)
 
-            // Step 2: set frontmost + optionally press Enter (requires Automation for System Events)
-            let pressEnter = sendApproval && trusted
+            // Step 2: set frontmost (requires Automation for System Events)
             var err2: NSDictionary?
             NSAppleScript(source: """
-                tell application "System Events"
-                    set frontmost of process "\(procName)" to true
-                    \(pressEnter ? "delay 0.3\nkey code 36" : "")
-                end tell
+                tell application "System Events" to set frontmost of process "\(procName)" to true
             """)?.executeAndReturnError(&err2)
+
+            // Step 3: focus the agent's terminal pane via AX before sending Enter,
+            // so the keystroke lands in the right pane instead of whatever was
+            // last focused in VS Code.
+            if pressEnter {
+                Thread.sleep(forTimeInterval: 0.3)
+                if let runningApp = NSRunningApplication
+                    .runningApplications(withBundleIdentifier: bundleID).first {
+                    _ = focusEditorTerminal(
+                        pid: runningApp.processIdentifier,
+                        agent: terminalLabelHint(for: agent)
+                    )
+                    Thread.sleep(forTimeInterval: 0.1)
+                }
+                var err3: NSDictionary?
+                NSAppleScript(source: """
+                    tell application "System Events" to key code 36
+                """)?.executeAndReturnError(&err3)
+            }
             return
         }
 
@@ -92,6 +108,99 @@ struct AppActivator {
             "\(NSHomeDirectory())/.local/bin/\(name)",
         ]
         return searchPaths.first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    // MARK: - AX terminal-pane focus (VS Code / Cursor)
+
+    // Map the agent identifier we get from notify.sh to the binary name that
+    // VS Code's shell-integrated terminal tab title would expose. Cursor's
+    // own IDE-embedded agent isn't a separate process and doesn't apply.
+    private static func terminalLabelHint(for agent: String?) -> String? {
+        switch agent?.lowercased() {
+        case "claude-code", "claude":  return "claude"
+        case "gemini", "gemini-cli":   return "gemini"
+        case "codex",  "codex-cli":    return "codex"
+        default:                       return nil
+        }
+    }
+
+    // Walk VS Code's accessibility tree and focus the terminal pane that hosts
+    // the running agent. Identifies the right pane via the AXTitle/AXDescription
+    // exposed by xterm.js — with shell integration on (default), the tab label
+    // reflects the running command name so a CC tab shows "claude". Falls back
+    // to the first terminal-shaped element if the labelled match misses.
+    @discardableResult
+    private static func focusEditorTerminal(pid: pid_t, agent: String?) -> Bool {
+        let appElement = AXUIElementCreateApplication(pid)
+        var window: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(appElement,
+                                            kAXFocusedWindowAttribute as CFString,
+                                            &window) == .success,
+              CFGetTypeID(window!) == AXUIElementGetTypeID() else { return false }
+        let win = window as! AXUIElement
+
+        // First pass: look for an element that names the agent — most reliable
+        // when shell integration sets the tab title to the running command.
+        if let agent {
+            if let match = findElement(in: win, depth: 0, matching: { node in
+                axStringContains(node, attribute: kAXTitleAttribute as CFString, fragment: agent) ||
+                axStringContains(node, attribute: kAXDescriptionAttribute as CFString, fragment: agent)
+            }) {
+                return focus(match)
+            }
+        }
+
+        // Fallback: any element whose label contains "terminal".
+        if let match = findElement(in: win, depth: 0, matching: { node in
+            axStringContains(node, attribute: kAXTitleAttribute as CFString, fragment: "terminal") ||
+            axStringContains(node, attribute: kAXDescriptionAttribute as CFString, fragment: "terminal")
+        }) {
+            return focus(match)
+        }
+        return false
+    }
+
+    private static func focus(_ element: AXUIElement) -> Bool {
+        // Prefer an explicit press (terminal tab elements respond to it the
+        // same way a click would, which both selects the tab and focuses the
+        // xterm canvas inside). Fall back to setting the focused attribute
+        // for elements that don't accept a press.
+        if AXUIElementPerformAction(element, kAXPressAction as CFString) == .success {
+            return true
+        }
+        return AXUIElementSetAttributeValue(element,
+                                            kAXFocusedAttribute as CFString,
+                                            kCFBooleanTrue) == .success
+    }
+
+    private static func axStringContains(_ element: AXUIElement,
+                                          attribute: CFString,
+                                          fragment: String) -> Bool {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success,
+              let str = value as? String else { return false }
+        return str.range(of: fragment, options: .caseInsensitive) != nil
+    }
+
+    // Bounded recursive search through the AX tree. VS Code's tree can be
+    // 15+ levels deep; cap at 25 so we don't blow the stack on pathological
+    // accessibility trees and don't burn time on deep walks.
+    private static func findElement(in element: AXUIElement,
+                                     depth: Int,
+                                     matching test: (AXUIElement) -> Bool) -> AXUIElement? {
+        guard depth < 25 else { return nil }
+        if test(element) { return element }
+        var children: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element,
+                                            kAXChildrenAttribute as CFString,
+                                            &children) == .success,
+              let kids = children as? [AXUIElement] else { return nil }
+        for child in kids {
+            if let found = findElement(in: child, depth: depth + 1, matching: test) {
+                return found
+            }
+        }
+        return nil
     }
 
     // MARK: - AX window raise (native terminal apps / fallback)


### PR DESCRIPTION
Adds two new modes to the floating panel and enriches each nudge with the source agent's process tree.

Tab strip + navigation
- Header now hosts a clickable tab strip (Events / Sessions / Settings) with active count badges and inline ⌘1/⌘2/⌘3 keycaps
- Cmd+1/2/3 jump directly between modes; Cmd+, removed in favour of the visible tab affordance
- Each mode owns its own footer hints so the keyboard contract matches what's on screen

Sessions tab
- Polls ps + lsof every 3s while the tab is visible to discover live claude / gemini / codex processes — including node-hosted agents (gemini-cli installed via npm shows comm=node, so detection is done on args)
- Shows project, terminal app, pid, runtime; finished sessions linger for 30s with "ended Ns ago" before dropping
- ↑↓ select, ⏎ focus the source terminal, ⌫/R kill (SIGTERM), N rename the row inline (TextField with onSubmit / onExitCommand), esc back
- Throbber + "Checking for sessions…" empty state until first scan completes; transitions to "No active agent sessions" if still empty

Settings tab (in-panel, keyboard-driven)
- Replaces the previous standalone settings UX. Sections: hotkey info, toggles (banner/voice), sounds (stop/permission), voice (picker + speed), actions (permissions / open config / quit panel)
- ↑↓/Tab select rows, ←→ cycle values (toggles flip, sound rows preview on cycle), ⏎ activate (toggles flip, action rows fire), esc back
- Selection auto-scrolls to keep the focused row visible
- ConfigFile read/write helpers preserve comments + ordering

Event enrichment
- notify.sh walks the parent process tree from the hook's PPID to detect agent_pid, shell_pid, terminal_pid, terminal_app, plus TERM_PROGRAM and TERM_SESSION_ID / ITERM_SESSION_ID
- post_to_panel emits these as additional JSON fields; values switched to env vars instead of positional argv to keep the heredoc readable
- STACKNUDGE_SOUND_STOP / STACKNUDGE_SOUND_PERMISSION configurable (defaults Glass / Ping)
- NudgeEventDTO and NudgeEvent decode and store the new fields; not yet consumed by AppActivator (deferred — focus still uses bundle_id + project_path matching for now)