### PR TITLE
feat: keyboard-native panel with sessions, settings, voice phrases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 PANEL_APP := $(HOME)/Applications/stack-nudge-panel.app
 PANEL_LABEL := com.stackonehq.stack-nudge-panel
 BUILD_LOG := /tmp/stack-nudge-dev.log
-WATCH_DIRS := panel shared notifier
+WATCH_DIRS := panel shared notifier notify.sh phrases
 
 .PHONY: help
 help:
@@ -34,7 +34,8 @@ uninstall:
 clean:
 	@rm -rf build
 
-# One-shot dev cycle: rebuild, reinstall the panel.app, kickstart the daemon.
+# One-shot dev cycle: rebuild, reinstall the panel.app, refresh notify.sh in
+# ~/.stack-nudge so hook-side changes propagate, kickstart the daemon.
 # Build output goes to $(BUILD_LOG); on failure, last 20 lines tail to stderr.
 .PHONY: reload
 reload:
@@ -47,6 +48,13 @@ reload:
 	fi; \
 	rm -rf "$(PANEL_APP)"; \
 	cp -R build/stack-nudge-panel.app "$(PANEL_APP)"; \
+	if [ -d "$$HOME/.stack-nudge" ]; then \
+		cp notify.sh "$$HOME/.stack-nudge/notify.sh"; \
+		if [ -d phrases ]; then \
+			rm -rf "$$HOME/.stack-nudge/phrases"; \
+			cp -R phrases "$$HOME/.stack-nudge/phrases"; \
+		fi; \
+	fi; \
 	launchctl kickstart -k "gui/$$(id -u)/$(PANEL_LABEL)" 2>/dev/null || true; \
 	printf 'reloaded\n'
 

--- a/README.md
+++ b/README.md
@@ -68,15 +68,7 @@ Add that to your shell profile.
 
 ### Keyboard-native panel (macOS)
 
-If you'd rather not click banners with the mouse, stack-nudge can run a small floating panel that you summon with a hotkey. The panel queues recent nudges and lets you act on them with the keyboard:
-
-| Key   | Action                                                      |
-|-------|-------------------------------------------------------------|
-| `↑ ↓` | Move selection                                              |
-| `⏎`   | Approve permission / focus source editor                    |
-| `O`   | Focus source editor without approving                       |
-| `R` / `Del` | Dismiss the selected nudge locally                    |
-| `Esc` | Hide the panel                                              |
+If you'd rather not click banners with the mouse, stack-nudge can run a small floating panel that you summon with a hotkey. It has three tabs — **Events**, **Sessions**, and **Settings** — and is fully keyboard-driven.
 
 Enable it in `~/.stack-nudge/config`:
 
@@ -85,23 +77,64 @@ STACKNUDGE_PANEL=true
 STACKNUDGE_BANNER=false   # optional — suppress macOS banners when using the panel
 ```
 
-Default hotkey is `cmd+opt+n`. Override with `STACKNUDGE_PANEL_HOTKEY=cmd+opt+space` (or any combination of `cmd`/`shift`/`opt`/`ctrl` + a letter, digit, or `space`/`return`/`tab`/`escape`).
+Default hotkey is `cmd+opt+n`. Hit it from anywhere to summon the panel; hit it again while focused to hide. Switch tabs with `Cmd+1` (Events), `Cmd+2` (Sessions), `Cmd+3` (Settings) — or click them.
 
 The panel registers a launchd agent so it starts at login when enabled. Banner and panel can run together, alone, or both off — the sound and voice still fire as passive signals.
 
+#### Events tab
+
+Recent nudges in chronological order. Each shows agent, message, project name, time.
+
+| Key | Action |
+|-----|--------|
+| `↑ ↓` | Move selection |
+| `⏎` | Approve permission / focus source editor |
+| `O` | Focus source editor without approving |
+| `⌫` | Dismiss the selected nudge locally |
+| `Esc` | Hide the panel |
+
+When you press `⏎` on a permission event in a VS Code / Cursor terminal pane, stack-nudge walks the editor's accessibility tree to focus the right pane (matched by the agent name in the tab title) before sending Enter — so the approval keystroke lands in the agent's terminal, not whatever was last focused. Falls back gracefully if the pane can't be found.
+
+#### Sessions tab
+
+Live list of running agent processes (`claude`, `gemini`, `codex` — including node-hosted variants like `gemini-cli`). Polls every 3 seconds while visible. Sessions that exit linger for 30s with `ended Ns ago`.
+
+| Key | Action |
+|-----|--------|
+| `↑ ↓` | Move selection |
+| `⏎` | Focus the session's source terminal |
+| `n` | Rename the selected session inline |
+| `⌫` | Send SIGTERM to the agent process |
+| `Esc` | Hide the panel |
+
+#### Settings tab
+
+Reachable from the tab strip or `Cmd+3`. Keyboard-driven rows for hotkey, banner/voice toggles, sound picks (with preview-on-cycle), voice picker (with preview-on-cycle using a random conversational phrase), speed, and shortcuts to the permissions checker, config file, and quit.
+
+| Key | Action |
+|-----|--------|
+| `↑ ↓` / `Tab` | Move selection |
+| `← →` | Cycle the selected row's value (toggles flip, sounds/voices step) |
+| `⏎` | Activate (toggles flip, action rows fire, hotkey row records a new combo) |
+| `Esc` | Back to events |
+
+The hotkey row records live: press `⏎` on it, press the new combo, and stack-nudge re-registers the global hotkey and writes it to config. If the combo is already grabbed by another app, the previous one stays and an inline error explains why.
+
+stack-nudge also watches `~/.stack-nudge/config` for external edits, so changes you make via "Open config file…" or another editor flow back into the running panel without a restart.
+
 ### Menu bar (macOS)
 
-When the panel daemon is running, a bell icon appears in your menu bar. Click it for:
+When the panel daemon is running, a bell icon appears in your menu bar. The same items you can reach from the in-panel Settings tab are mirrored here for one-click access without summoning the panel:
 
-| Item                    | What it does                                                                                       |
-|-------------------------|----------------------------------------------------------------------------------------------------|
-| `Hotkey · …`            | Shows your current hotkey (info only)                                                              |
-| `Show banners`          | Toggles `STACKNUDGE_BANNER`. Enabling fires a confirmation banner.                                 |
-| `Voice notifications`   | Toggles `STACKNUDGE_VOICE`. Enabling speaks *"Voice notifications enabled"*.                       |
-| `Show panel`            | Brings the floating panel up (handy when no events are queued)                                     |
-| `Check permissions…`    | Opens the permissions checker (see below)                                                          |
-| `Open config file…`     | Opens `~/.stack-nudge/config` in your default editor                                               |
-| `Quit stack-nudge panel`| Exits the daemon                                                                                   |
+| Item | What it does |
+|------|--------------|
+| `Hotkey · …` | Shows your current hotkey (info only) |
+| `Show banners` | Toggles `STACKNUDGE_BANNER`. Enabling fires a confirmation banner. |
+| `Voice notifications` | Toggles `STACKNUDGE_VOICE`. Enabling speaks *"Voice notifications enabled"*. |
+| `Show panel` | Brings the floating panel up (handy when no events are queued) |
+| `Check permissions…` | Opens the permissions checker (see below) |
+| `Open config file…` | Opens `~/.stack-nudge/config` in your default editor |
+| `Quit stack-nudge panel` | Exits the daemon |
 
 Toggles re-read the live config every time the menu opens, so changes you make to `~/.stack-nudge/config` directly stay in sync. Banner and voice changes take effect immediately for the next nudge — no daemon restart needed.
 
@@ -139,7 +172,18 @@ STACKNUDGE_VOICE=true
 
 The voice daemon starts automatically on first notification and is registered as a login item so it stays running across reboots.
 
-Voice fires whenever `STACKNUDGE_VOICE=true`, alongside the banner and panel surfaces. The frontmost-suppression check still applies — when the source window is already focused, sound, banner, panel post, *and* voice are all suppressed (you don't need a nudge for the thing you're looking at). For permission events, voice says *"Bash command needs approval"* or *"Edit: filename"* rather than reading the raw command aloud.
+Voice fires whenever `STACKNUDGE_VOICE=true`, alongside the banner and panel surfaces. The frontmost-suppression check still applies — when the source window is already focused, sound, banner, panel post, *and* voice are all suppressed (you don't need a nudge for the thing you're looking at).
+
+When voice is enabled, the chime is suppressed automatically — voice replaces sound rather than playing alongside it.
+
+#### Phrasing
+
+Voice messages are picked at random from per-event phrase pools and labelled with the project name (cwd basename, with hyphens/underscores split and a few acronyms expanded — `CLI` → `C L I`, `MCP` → `M C P`, etc.). For a project called `unified-cloud-api` you'll hear things like:
+
+- **Stop:** *"unified cloud api is ready for you"* / *"task complete in unified cloud api"* / *"output ready in unified cloud api"*
+- **Permission:** *"unified cloud api requires a decision"* / *"unified cloud api has a question for you"* / *"unified cloud api is awaiting approval"*
+
+Phrase pools live in `~/.stack-nudge/phrases/` — `en.sh`, `fr.sh`, `hi.sh`, `it.sh`, `pt.sh`. The right pool is picked from the configured voice's prefix (`af_*`/`am_*`/`bf_*`/`bm_*` → en, `ff_*` → fr, `hf_*`/`hm_*` → hi, `if_*`/`im_*` → it, `pf_*`/`pm_*` → pt) so a French voice speaks French phrasing.
 
 Optional tuning (also in `~/.stack-nudge/config`):
 
@@ -155,7 +199,14 @@ STACKNUDGE_VOICE_SPEED=1.1       # playback speed (1.0 = normal)
 | Agent done | `Glass.aiff` | freedesktop bell | 800 Hz beep |
 | Waiting for approval | `Ping.aiff` | freedesktop bell | 1200 Hz beep |
 
-Any file from `/System/Library/Sounds/` works on macOS: Basso, Blow, Bottle, Frog, Funk, Glass, Hero, Morse, Ping, Pop, Purr, Sosumi, Submarine, Tink.
+Any file from `/System/Library/Sounds/` works on macOS: Basso, Blow, Bottle, Frog, Funk, Glass, Hero, Morse, Ping, Pop, Purr, Sosumi, Submarine, Tink. Override per-event in `~/.stack-nudge/config`:
+
+```bash
+STACKNUDGE_SOUND_STOP=Glass
+STACKNUDGE_SOUND_PERMISSION=Ping
+```
+
+The Settings tab exposes the same picks with audio preview on each change.
 
 ## Uninstall
 
@@ -187,20 +238,22 @@ Every supported agent just needs a hook that runs `notify.sh <agent-name> <event
 ```bash
 make build      # builds both .app bundles into build/
 make install    # full install (build + copy + register hooks + launchd)
-make reload     # rebuild + replace installed panel + bounce the daemon
-make dev        # watch sources; auto-reload on .swift / Info.plist changes
+make reload     # rebuild + replace installed panel + refresh notify.sh + bounce daemon
+make dev        # watch sources; auto-reload on .swift / Info.plist / notify.sh / phrase changes
 make uninstall  # remove apps, hooks, launchd agents, ~/.stack-nudge/
 ```
 
-`make dev` is the inner-loop tool — leave it running in another terminal, save a Swift file, and the daemon bounces with the new build in ~2 seconds.
+`make dev` is the inner-loop tool — leave it running in another terminal, save a Swift file or `notify.sh`, and the daemon bounces with the new build in ~2 seconds.
 
-Swift source is split across:
+Source layout:
 
 - `notifier/` — the transient banner-renderer that fires per nudge and exits
-- `panel/` — the persistent floating-panel daemon (hotkey, NSPanel, socket listener, menu bar, permissions window)
+- `panel/` — the persistent floating-panel daemon (hotkey, NSPanel, socket listener, menu bar, sessions list, settings, permissions window)
 - `shared/` — code shared by both binaries (currently `AppActivator.swift`)
+- `phrases/` — per-language voice phrase pools sourced by `notify.sh` at hook time
+- `notify.sh` — the shell entry-point CC/Cursor/Gemini hooks invoke; routes events to banner / panel / voice surfaces
 
-Compiled with `swiftc` directly. No Xcode, no SPM, no dependencies.
+Swift compiled with `swiftc` directly. No Xcode, no SPM, no dependencies.
 
 ## Credits
 

--- a/build.sh
+++ b/build.sh
@@ -54,6 +54,9 @@ build_app "$PANEL_APP" "stack-nudge-panel" \
   panel/EventStore.swift \
   panel/EventListener.swift \
   panel/Panel.swift \
+  panel/PanelNav.swift \
+  panel/Components.swift \
+  panel/Speaker.swift \
   panel/MenuBar.swift \
   panel/Permissions.swift \
   panel/Settings.swift \

--- a/install.sh
+++ b/install.sh
@@ -138,10 +138,17 @@ LAUNCHER
   echo "  Panel daemon registered as launchd agent (starts at login when STACKNUDGE_PANEL=true)"
 fi
 
-# Copy notify.sh to shared install dir
+# Copy notify.sh and the phrase pools (sourced by notify.sh at runtime
+# based on the configured voice's language) to the shared install dir.
 cp "$SCRIPT_DIR/notify.sh" "$INSTALL_DIR/notify.sh"
 chmod +x "$INSTALL_DIR/notify.sh"
 echo "  Installed notify.sh    -> $INSTALL_DIR/notify.sh"
+
+if [[ -d "$SCRIPT_DIR/phrases" ]]; then
+  rm -rf "$INSTALL_DIR/phrases"
+  cp -R "$SCRIPT_DIR/phrases" "$INSTALL_DIR/phrases"
+  echo "  Installed phrases/     -> $INSTALL_DIR/phrases"
+fi
 NOTIFY="$INSTALL_DIR/notify.sh"
 
 # Copy example config only if no config exists yet (preserve user customisations on reinstall)

--- a/notifier/Notifier.swift
+++ b/notifier/Notifier.swift
@@ -33,7 +33,9 @@ class Notifier: NSObject, NSApplicationDelegate, NSUserNotificationCenterDelegat
         let n = NSUserNotification()
         n.title = config.title
         n.informativeText = config.message
-        n.soundName = config.sound
+        // Empty value = silent banner — used when STACKNUDGE_VOICE=true so
+        // voice replaces the chime instead of playing alongside it.
+        n.soundName = config.sound.isEmpty ? nil : config.sound
         if config.hasActionButton {
             n.hasActionButton = true
             n.actionButtonTitle = "Allow"

--- a/notify.sh
+++ b/notify.sh
@@ -82,6 +82,110 @@ VOICE_ENABLED="${STACKNUDGE_VOICE:-false}"
 VOICE_NAME="${STACKNUDGE_VOICE_NAME:-af_heart}"
 VOICE_SPEED="${STACKNUDGE_VOICE_SPEED:-1.1}"
 
+# Map a Kokoro voice prefix to a phrase-file language code.
+voice_to_lang() {
+  case "${1:0:2}" in
+    af|am|bf|bm) echo "en" ;;
+    ff)          echo "fr" ;;
+    hf|hm)       echo "hi" ;;
+    if|im)       echo "it" ;;
+    pf|pm)       echo "pt" ;;
+    *)           echo "en" ;;
+  esac
+}
+
+# Map a Kokoro voice prefix to the --lang code stackvox expects.
+voice_to_kokoro_lang() {
+  case "${1:0:2}" in
+    af|am) echo "en-us" ;;
+    bf|bm) echo "en-gb" ;;
+    ff)    echo "fr-fr" ;;
+    hf|hm) echo "hi" ;;
+    if|im) echo "it" ;;
+    pf|pm) echo "pt-br" ;;
+    *)     echo "en-us" ;;
+  esac
+}
+
+# Light expansion for stackvox: split hyphens/underscores, fix a couple of
+# stackvox-specific tokens that the model otherwise mispronounces.
+repo_name_raw() {
+  local repo parts=() word
+  repo=$(basename "$PWD")
+  for word in $(echo "$repo" | tr '_-' '  '); do
+    case "$word" in
+      cli|CLI)           word="C L I" ;;
+      stackone|StackOne) word="stack one" ;;
+    esac
+    parts+=("$word")
+  done
+  echo "${parts[*]}"
+}
+
+# Heavier expansion for the macOS `say` fallback — that engine mispronounces
+# more acronyms, so split a wider set into letters.
+repo_name_expanded() {
+  local repo parts=() word
+  repo=$(basename "$PWD")
+  for word in $(echo "$repo" | tr '_-' '  '); do
+    case "$word" in
+      mcp|MCP)           word="M C P" ;;
+      api|API)           word="A P I" ;;
+      cli|CLI)           word="C L I" ;;
+      hris|HRIS)         word="H R I S" ;;
+      ai|AI)             word="A I" ;;
+      stackone|StackOne) word="stack one" ;;
+    esac
+    parts+=("$word")
+  done
+  echo "${parts[*]}"
+}
+
+# Pick a phrase from the right pool (TEMPLATES_RESPONSE for stop events,
+# TEMPLATES_NOTIFICATION for permission events) and format it with the
+# repo name. Phrase files live next to notify.sh in phrases/<lang>.sh
+# so they're co-located with the script wherever it's installed.
+voice_phrase_for() {
+  local event="$1"
+  local lang repo
+
+  if [[ -x "$STACKVOX_SAY" ]]; then
+    lang=$(voice_to_lang "$VOICE_NAME")
+    repo=$(repo_name_raw)
+  else
+    lang="en"
+    repo=$(repo_name_expanded)
+  fi
+
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local phrases_dir="$script_dir/phrases"
+  local lang_file="$phrases_dir/$lang.sh"
+  [[ -f "$lang_file" ]] || lang_file="$phrases_dir/en.sh"
+  if [[ ! -f "$lang_file" ]]; then
+    echo "$repo"
+    return
+  fi
+
+  # shellcheck disable=SC1090
+  source "$lang_file"
+
+  local templates=()
+  case "$event" in
+    permission) templates=("${TEMPLATES_NOTIFICATION[@]}") ;;
+    *)          templates=("${TEMPLATES_RESPONSE[@]}") ;;
+  esac
+
+  if [[ ${#templates[@]} -eq 0 ]]; then
+    echo "$repo"
+    return
+  fi
+
+  local template="${templates[$((RANDOM % ${#templates[@]}))]}"
+  # shellcheck disable=SC2059
+  printf "$template" "$repo"
+}
+
 # Banner and panel surfaces are independent; sound/voice always fire.
 BANNER_ENABLED="${STACKNUDGE_BANNER:-true}"
 PANEL_ENABLED="${STACKNUDGE_PANEL:-false}"
@@ -114,7 +218,9 @@ speak_notification() {
   if [[ ! -S "${HOME}/.cache/stackvox/daemon.sock" ]]; then
     nohup "$STACKVOX" serve >/dev/null 2>&1 &
   fi
-  "$STACKVOX_SAY" --voice "${VOICE_NAME}" --speed "${VOICE_SPEED}" "${text}" 2>/dev/null &
+  local kokoro_lang
+  kokoro_lang=$(voice_to_kokoro_lang "$VOICE_NAME")
+  "$STACKVOX_SAY" --voice "${VOICE_NAME}" --lang "${kokoro_lang}" --speed "${VOICE_SPEED}" "${text}" 2>/dev/null &
 }
 
 # Locate one of our .app bundles. Searches ~/Applications, the script's
@@ -315,7 +421,12 @@ notify_macos() {
       -e "  end tell" \
       -e "end tell" 2>/dev/null)
     if [[ "$frontmost_win" == "$win_title" ]]; then
-      afplay "/System/Library/Sounds/${sound}.aiff" 2>/dev/null
+      # Source window is already focused — minimal signal. Skip sound when
+      # voice is on (voice itself is suppressed here too, but keep the
+      # "voice replaces sound" rule consistent across all paths).
+      if [[ "${VOICE_ENABLED}" != "true" ]]; then
+        afplay "/System/Library/Sounds/${sound}.aiff" 2>/dev/null
+      fi
       return
     fi
   fi
@@ -327,10 +438,15 @@ notify_macos() {
   # Backgrounded — the python3 cold-start (~50ms) shouldn't block the agent's hook.
   post_to_panel "${title}" "${message}" "${bundle_id}" "${project_name:-}" "${has_action}" &
 
+  # Voice "replaces" sound — when both are configured, the spoken message
+  # is the audible signal so we don't double-cue with a chime.
+  local effective_sound="$sound"
+  [[ "${VOICE_ENABLED}" == "true" ]] && effective_sound=""
+
   if [[ "${BANNER_ENABLED}" == "true" ]]; then
-    fire_banner "$title" "$message" "$sound" "$bundle_id" \
+    fire_banner "$title" "$message" "$effective_sound" "$bundle_id" \
       "${project_name:-}" "${win_title}" "${has_action}"
-  else
+  elif [[ "${VOICE_ENABLED}" != "true" ]]; then
     afplay "/System/Library/Sounds/${sound}.aiff" 2>/dev/null &
   fi
 
@@ -345,8 +461,15 @@ fire_banner() {
   app_bundle=$(find_app_bundle "stack-nudge.app")
 
   if [[ -z "$app_bundle" ]]; then
-    afplay "/System/Library/Sounds/${sound}.aiff" 2>/dev/null &
-    osascript -e "display notification \"${message}\" with title \"${title}\" sound name \"${sound}\"" 2>/dev/null
+    # Fallback path when stack-nudge.app isn't installed. `sound` is empty
+    # when voice is enabled — skip both the afplay chime and osascript's
+    # sound name so the user hears voice only.
+    if [[ -n "$sound" ]]; then
+      afplay "/System/Library/Sounds/${sound}.aiff" 2>/dev/null &
+      osascript -e "display notification \"${message}\" with title \"${title}\" sound name \"${sound}\"" 2>/dev/null
+    else
+      osascript -e "display notification \"${message}\" with title \"${title}\"" 2>/dev/null
+    fi
     return
   fi
 
@@ -391,11 +514,18 @@ case "$OS" in
     SOUND_PERMISSION="${STACKNUDGE_SOUND_PERMISSION:-Ping}"
     case "$EVENT" in
       permission)
+        # Banner stays specific (tool / file context) so the user can read
+        # what's pending. Voice picks from the conversational notification
+        # pool, formatted with the repo name — same shape as
+        # stackone-say-hooks.
         ctx=$(permission_context)
-        voice_ctx=$(voice_permission_context)
-        notify_macos "$TITLE" "${ctx:-Waiting for your approval}" "$SOUND_PERMISSION" "${voice_ctx:-Waiting for your approval}"
+        voice_msg=$(voice_phrase_for permission)
+        notify_macos "$TITLE" "${ctx:-Waiting for your approval}" "$SOUND_PERMISSION" "$voice_msg"
         ;;
-      *) notify_macos "$TITLE" "Done" "$SOUND_STOP" ;;
+      *)
+        voice_msg=$(voice_phrase_for stop)
+        notify_macos "$TITLE" "Done" "$SOUND_STOP" "$voice_msg"
+        ;;
     esac
     ;;
   Linux)

--- a/panel/Components.swift
+++ b/panel/Components.swift
@@ -1,0 +1,109 @@
+import AppKit
+import SwiftUI
+
+// MARK: - Footer hint pieces
+
+// A keycap-shaped pill — used for inline shortcut hints throughout the UI.
+struct KeyCapView: View {
+    let symbol: String
+
+    var body: some View {
+        Text(symbol)
+            .font(.caption2.weight(.medium))
+            .foregroundStyle(.primary.opacity(0.85))
+            .frame(minWidth: 14, minHeight: 16)
+            .padding(.horizontal, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                    .fill(Color.primary.opacity(0.1))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4, style: .continuous)
+                            .strokeBorder(Color.primary.opacity(0.15), lineWidth: 0.5)
+                    )
+            )
+    }
+}
+
+// One labelled hint: "Select [↑][↓]" — used in PageFooter.
+struct FooterHint: View {
+    let label: String
+    let keys: [String]
+    var primary: Bool = false
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(primary ? Color.primary : Color.secondary)
+            HStack(spacing: 2) {
+                ForEach(keys, id: \.self) { KeyCapView(symbol: $0) }
+            }
+        }
+        .padding(.leading, 10)
+    }
+}
+
+// Vertical pipe between primary action and secondary hints in a footer.
+struct FooterDivider: View {
+    var body: some View {
+        Rectangle()
+            .fill(Color.primary.opacity(0.15))
+            .frame(width: 1, height: 14)
+            .padding(.leading, 14)
+            .padding(.trailing, 4)
+    }
+}
+
+// MARK: - Page-level layout
+
+// Bottom strip every panel page shares: bell icon on the left, hint pills on
+// the right, hairline divider above, subtle tint behind. Pages just fill the
+// hints slot.
+struct PageFooter<Hints: View>: View {
+
+    @ViewBuilder var hints: () -> Hints
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Image(systemName: "bell.badge.fill")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+            Spacer()
+            hints()
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 9)
+        .background(
+            ZStack {
+                Color.primary.opacity(0.05)
+                Rectangle()
+                    .fill(Color.primary.opacity(0.1))
+                    .frame(height: 0.5)
+                    .frame(maxHeight: .infinity, alignment: .top)
+            }
+        )
+    }
+}
+
+// MARK: - NSScrollView introspection
+
+// SwiftUI doesn't expose scroller width directly. Drop a zero-sized helper
+// into the ScrollView's content via .background, walk up the view hierarchy
+// to the underlying NSScrollView, and shrink its scroller to `.mini` —
+// roughly half the default width.
+struct ThinScrollers: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView { NSView(frame: .zero) }
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async {
+            var current: NSView? = nsView
+            while let v = current {
+                if let scrollView = v as? NSScrollView {
+                    scrollView.verticalScroller?.controlSize = .mini
+                    scrollView.horizontalScroller?.controlSize = .mini
+                    return
+                }
+                current = v.superview
+            }
+        }
+    }
+}

--- a/panel/MenuBar.swift
+++ b/panel/MenuBar.swift
@@ -153,30 +153,8 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         try? task.run()
     }
 
-    // Spoken confirmation via stackvox. Auto-starts the daemon if needed
-    // (mirrors notify.sh). Silent fallback if stackvox isn't installed.
     private func speak(_ text: String) {
-        let venvBin = "\(NSHomeDirectory())/.stack-nudge/venv/bin"
-        let stackvoxSay = "\(venvBin)/stackvox-say"
-        let stackvox    = "\(venvBin)/stackvox"
-        let socketPath  = "\(NSHomeDirectory())/.cache/stackvox/daemon.sock"
-        guard FileManager.default.isExecutableFile(atPath: stackvoxSay) else { return }
-
-        if !FileManager.default.fileExists(atPath: socketPath),
-           FileManager.default.isExecutableFile(atPath: stackvox) {
-            let serve = Process()
-            serve.executableURL = URL(fileURLWithPath: stackvox)
-            serve.arguments = ["serve"]
-            try? serve.run()
-        }
-
-        let config = ConfigFile.read()
-        let voice = config["STACKNUDGE_VOICE_NAME"]  ?? "af_heart"
-        let speed = config["STACKNUDGE_VOICE_SPEED"] ?? "1.1"
-        let say = Process()
-        say.executableURL = URL(fileURLWithPath: stackvoxSay)
-        say.arguments = ["--voice", voice, "--speed", speed, text]
-        try? say.run()
+        Speaker.speak(text)
     }
 
     @objc private func showPanelAction() {

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -84,26 +84,25 @@ struct PanelContentView: View {
                 .foregroundStyle(.tertiary)
                 .padding(.trailing, 4)
 
-            tab(.events,
-                label: "Events",
-                count: store.events.count,
-                shortcutKeys: ["⌘", "1"])
-            tab(.sessions,
-                label: "Sessions",
-                count: sessions.sessions.filter { $0.status == .active }.count,
-                shortcutKeys: ["⌘", "2"])
-            tab(.settings,
-                label: "Settings",
-                count: 0,
-                shortcutKeys: ["⌘", "3"])
+            tab(.events,   label: "Events",   count: store.events.count)
+            tab(.sessions, label: "Sessions", count: sessions.sessions.filter { $0.status == .active }.count)
+            tab(.settings, label: "Settings", count: 0)
 
             Spacer()
+
+            // One combined hint instead of per-tab keycaps — keeps the strip
+            // uncluttered while still surfacing the shortcut range.
+            HStack(spacing: 2) {
+                KeyCapView(symbol: "⌘")
+                KeyCapView(symbol: "1-3")
+            }
+            .opacity(0.7)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
     }
 
-    private func tab(_ mode: PanelMode, label: String, count: Int, shortcutKeys: [String]) -> some View {
+    private func tab(_ mode: PanelMode, label: String, count: Int) -> some View {
         let isActive = nav.mode == mode
         return Button {
             nav.mode = mode
@@ -120,10 +119,6 @@ struct PanelContentView: View {
                             Capsule().fill(Color.primary.opacity(isActive ? 0.18 : 0.10))
                         )
                 }
-                HStack(spacing: 2) {
-                    ForEach(shortcutKeys, id: \.self) { KeyCapView(symbol: $0) }
-                }
-                .opacity(isActive ? 0.5 : 0.85)
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 3)
@@ -172,15 +167,12 @@ struct PanelContentView: View {
                 }
             }
             .padding(.vertical, 4)
+            .background(ThinScrollers())
         }
     }
 
     private var footer: some View {
-        HStack(spacing: 0) {
-            Image(systemName: "bell.badge.fill")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-            Spacer()
+        PageFooter {
             if store.events.isEmpty {
                 FooterHint(label: "Hide", keys: ["esc"])
             } else {
@@ -188,22 +180,11 @@ struct PanelContentView: View {
                     FooterHint(label: primary, keys: ["⏎"], primary: true)
                     FooterDivider()
                 }
-                FooterHint(label: "Select", keys: ["↑", "↓"])
+                FooterHint(label: "Select",  keys: ["↑", "↓"])
                 FooterHint(label: "Dismiss", keys: ["⌫"])
-                FooterHint(label: "Hide", keys: ["esc"])
+                FooterHint(label: "Hide",    keys: ["esc"])
             }
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 9)
-        .background(
-            ZStack {
-                Color.primary.opacity(0.05)
-                Rectangle()
-                    .fill(Color.primary.opacity(0.1))
-                    .frame(height: 0.5)
-                    .frame(maxHeight: .infinity, alignment: .top)
-            }
-        )
     }
 
     private var primaryActionLabel: String? {
@@ -212,53 +193,6 @@ struct PanelContentView: View {
     }
 }
 
-struct FooterHint: View {
-    let label: String
-    let keys: [String]
-    var primary: Bool = false
-
-    var body: some View {
-        HStack(spacing: 5) {
-            Text(label)
-                .font(.caption)
-                .foregroundStyle(primary ? Color.primary : Color.secondary)
-            HStack(spacing: 2) {
-                ForEach(keys, id: \.self) { KeyCapView(symbol: $0) }
-            }
-        }
-        .padding(.leading, 10)
-    }
-}
-
-struct KeyCapView: View {
-    let symbol: String
-
-    var body: some View {
-        Text(symbol)
-            .font(.caption2.weight(.medium))
-            .foregroundStyle(.primary.opacity(0.85))
-            .frame(minWidth: 14, minHeight: 16)
-            .padding(.horizontal, 4)
-            .background(
-                RoundedRectangle(cornerRadius: 4, style: .continuous)
-                    .fill(Color.primary.opacity(0.1))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 4, style: .continuous)
-                            .strokeBorder(Color.primary.opacity(0.15), lineWidth: 0.5)
-                    )
-            )
-    }
-}
-
-struct FooterDivider: View {
-    var body: some View {
-        Rectangle()
-            .fill(Color.primary.opacity(0.15))
-            .frame(width: 1, height: 14)
-            .padding(.leading, 14)
-            .padding(.trailing, 4)
-    }
-}
 
 struct EventRow: View {
 
@@ -371,7 +305,13 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate {
 
         nav.actions = SettingsActions(
             checkPermissions: { [weak self] in self?.showPermissions() },
-            openConfig:       { NSWorkspace.shared.open(URL(fileURLWithPath: ConfigFile.path)) },
+            openConfig: { [weak self] in
+                // Same z-order issue: the editor app's regular window opens
+                // below our floating panel. Hide the panel first.
+                self?.panel.orderOut(nil)
+                self?.nav.mode = .events
+                NSWorkspace.shared.open(URL(fileURLWithPath: ConfigFile.path))
+            },
             quit:             { NSApp.terminate(nil) }
         )
         nav.setHotkey = { [weak self] spec in
@@ -446,8 +386,18 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate {
     }
 
     func showPermissions() {
-        if permissionsWC == nil { permissionsWC = PermissionsWindowController() }
-        permissionsWC?.showAndRaise()
+        // Defer to next runloop tick so we're not constructing a new
+        // NSHostingView in the middle of the current SwiftUI/event-handling
+        // pass — re-entrant construction surfaced as a deadlock.
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if self.permissionsWC == nil {
+                self.permissionsWC = PermissionsWindowController()
+            }
+            self.permissionsWC?.showAndRaise()
+            self.panel.orderOut(nil)
+            self.nav.mode = .events
+        }
     }
 
     func applicationWillTerminate(_ notification: Notification) {
@@ -461,16 +411,31 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate {
         let blockingMods: NSEvent.ModifierFlags = [.control, .option]
         let cmdOnly = mods.intersection([.command, .control, .option, .shift]) == .command
 
-        // While recording a hotkey, swallow every key so the new combo
-        // doesn't accidentally fire some other shortcut.
+        // While recording a hotkey, capture the next combo. Arrow keys / Tab
+        // bail out gracefully — otherwise users who entered record mode by
+        // mistake would be stuck on row 0 with all their keypresses swallowed.
         if nav.recordingHotkey {
-            if event.keyCode == KeyCode.escape && mods.intersection([.command, .control, .option, .shift]).isEmpty {
-                nav.cancelRecordingHotkey()
-                return true
+            let plainNav = mods.intersection([.command, .control, .option, .shift]).isEmpty
+            if plainNav {
+                switch event.keyCode {
+                case KeyCode.escape:
+                    nav.cancelRecordingHotkey()
+                    return true
+                case KeyCode.upArrow:
+                    nav.cancelRecordingHotkey()
+                    nav.selectPrevRow()
+                    return true
+                case KeyCode.downArrow, KeyCode.tab:
+                    nav.cancelRecordingHotkey()
+                    nav.selectNextRow()
+                    return true
+                default:
+                    break
+                }
             }
             let captured = mods.intersection([.command, .control, .option, .shift])
-            // Need at least one modifier (Carbon RegisterEventHotKey rejects
-            // bare keys, and we don't want to accidentally bind plain "n").
+            // Need at least one modifier — Carbon RegisterEventHotKey rejects
+            // bare keys, and we don't want to bind plain "n" by accident.
             guard !captured.isEmpty else { return true }
             if let spec = Hotkey.encode(eventModifiers: mods.rawValue, keyCode: event.keyCode) {
                 nav.commitHotkey(spec)

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -1,0 +1,220 @@
+import AppKit
+import SwiftUI
+
+enum PanelMode {
+    case events
+    case sessions
+    case settings
+}
+
+// Action callbacks the controller wires into nav so settings rows like
+// "Check permissions" / "Open config" / "Quit" can fire effects without the
+// SwiftUI view needing to know about windows or app-level state.
+struct SettingsActions {
+    let checkPermissions: () -> Void
+    let openConfig:       () -> Void
+    let quit:             () -> Void
+}
+
+// Owns the panel's navigation state plus the live values the Settings page
+// renders and mutates. Lives outside Settings.swift because the navigation
+// model (mode, selected row, hotkey state) is read across all pages — only
+// the settings field set is settings-page-specific.
+final class PanelNav: ObservableObject {
+
+    @Published var mode: PanelMode = .events
+    @Published var selectedSettingIndex: Int = 0
+
+    @Published var hotkeyDisplay:   String = "cmd+opt+n"
+    @Published var recordingHotkey: Bool = false
+    @Published var hotkeyError:     String?
+    @Published var bannerEnabled:   Bool = true
+    @Published var voiceEnabled:    Bool = false
+    @Published var soundStop:       String = "Glass"
+    @Published var soundPermission: String = "Ping"
+    @Published var voice:           String = "af_heart"
+    @Published var voiceSpeed:      Double = 1.1
+    @Published var voicesAvailable: [String] = []
+    @Published var voicesLoading:   Bool = true
+
+    var actions: SettingsActions?
+    // Wired by PanelController so nav can re-register the global hotkey
+    // without owning the Hotkey instance directly. Returns true if the
+    // new spec registered successfully.
+    var setHotkey: ((String) -> Bool)?
+
+    static let macSounds = [
+        "Basso", "Blow", "Bottle", "Frog", "Funk", "Glass", "Hero",
+        "Morse", "Ping", "Pop", "Purr", "Sosumi", "Submarine", "Tink",
+    ]
+
+    static let speedMin = 0.60
+    static let speedMax = 1.60
+    static let speedStep = 0.05
+
+    // Conversational, agent-flavoured preview phrases. Picked at random each
+    // time the user cycles voices so they hear varied cadence and intonation
+    // rather than the same word over and over.
+    static let voicePreviewPhrases = [
+        "Oh, I have a question.",
+        "Could you take a look at this?",
+        "I need your approval to continue.",
+        "Just finished that task — want to review?",
+        "Hey, I've got something to show you.",
+        "Quick question before I move on.",
+        "Hmm, this one's tricky. Mind helping?",
+        "All done. Ready when you are.",
+        "Should I proceed with this change?",
+        "I'd love your input on this.",
+    ]
+
+    var rowCount: Int { 10 }
+
+    // Row layout (kept in one place so the controller, view, and indexing
+    // logic all agree on what each row index means):
+    //   0  Hotkey                hotkey-record
+    //   1  Banner notifications  toggle
+    //   2  Voice notifications   toggle
+    //   3  Agent done sound      cycle
+    //   4  Permission sound      cycle
+    //   5  Voice                 cycle
+    //   6  Speed                 cycle
+    //   7  Check permissions…    action
+    //   8  Open config file…     action
+    //   9  Quit panel            action
+
+    // MARK: - Disk I/O
+
+    func loadFromConfig() {
+        let config = ConfigFile.read()
+        hotkeyDisplay   = config["STACKNUDGE_PANEL_HOTKEY"]    ?? "cmd+opt+n"
+        bannerEnabled   = ConfigFile.bool(config, "STACKNUDGE_BANNER", default: true)
+        voiceEnabled    = ConfigFile.bool(config, "STACKNUDGE_VOICE",  default: false)
+        soundStop       = config["STACKNUDGE_SOUND_STOP"]       ?? "Glass"
+        soundPermission = config["STACKNUDGE_SOUND_PERMISSION"] ?? "Ping"
+        voice           = config["STACKNUDGE_VOICE_NAME"]       ?? "af_heart"
+        voiceSpeed      = Double(config["STACKNUDGE_VOICE_SPEED"] ?? "") ?? 1.1
+    }
+
+    func loadVoices() {
+        Task.detached(priority: .userInitiated) {
+            let names = Self.runStackvoxVoices()
+            await MainActor.run { [weak self] in
+                self?.voicesAvailable = names
+                self?.voicesLoading = false
+            }
+        }
+    }
+
+    private nonisolated static func runStackvoxVoices() -> [String] {
+        let stackvox = "\(NSHomeDirectory())/.stack-nudge/venv/bin/stackvox"
+        guard FileManager.default.isExecutableFile(atPath: stackvox) else { return [] }
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: stackvox)
+        task.arguments = ["voices"]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = Pipe()
+        do { try task.run() } catch { return [] }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        task.waitUntilExit()
+        return (String(data: data, encoding: .utf8) ?? "")
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty && !$0.contains(" ") }
+    }
+
+    // MARK: - Row movement
+
+    func selectNextRow() {
+        guard rowCount > 0 else { return }
+        selectedSettingIndex = (selectedSettingIndex + 1) % rowCount
+    }
+
+    func selectPrevRow() {
+        guard rowCount > 0 else { return }
+        selectedSettingIndex = (selectedSettingIndex - 1 + rowCount) % rowCount
+    }
+
+    // MARK: - Cycle / activate
+
+    // Enter: toggles flip, cycle rows step forward, actions fire, hotkey
+    // row enters record mode.
+    func activate() {
+        switch selectedSettingIndex {
+        case 0: startRecordingHotkey()
+        case 7: actions?.checkPermissions()
+        case 8: actions?.openConfig()
+        case 9: actions?.quit()
+        default: applyCycle(forward: true)
+        }
+    }
+
+    func cycleForward()  { applyCycle(forward: true) }
+    func cycleBackward() { applyCycle(forward: false) }
+
+    private func applyCycle(forward: Bool) {
+        switch selectedSettingIndex {
+        case 0:
+            // Cycle on the hotkey row also enters record mode.
+            startRecordingHotkey()
+        case 1:
+            bannerEnabled.toggle()
+            ConfigFile.write(key: "STACKNUDGE_BANNER", value: bannerEnabled ? "true" : "false")
+        case 2:
+            voiceEnabled.toggle()
+            ConfigFile.write(key: "STACKNUDGE_VOICE", value: voiceEnabled ? "true" : "false")
+        case 3:
+            soundStop = step(soundStop, in: Self.macSounds, forward: forward, key: "STACKNUDGE_SOUND_STOP", preview: true)
+        case 4:
+            soundPermission = step(soundPermission, in: Self.macSounds, forward: forward, key: "STACKNUDGE_SOUND_PERMISSION", preview: true)
+        case 5:
+            guard !voicesLoading, !voicesAvailable.isEmpty else { return }
+            voice = step(voice, in: voicesAvailable, forward: forward, key: "STACKNUDGE_VOICE_NAME", preview: false)
+            let phrase = Self.voicePreviewPhrases.randomElement() ?? "Hello."
+            Speaker.speak(phrase, voice: voice, speed: String(format: "%.2f", voiceSpeed))
+        case 6:
+            let next = forward ? voiceSpeed + Self.speedStep : voiceSpeed - Self.speedStep
+            voiceSpeed = max(Self.speedMin, min(Self.speedMax, (next * 100).rounded() / 100))
+            ConfigFile.write(key: "STACKNUDGE_VOICE_SPEED", value: String(format: "%.2f", voiceSpeed))
+        default:
+            break
+        }
+    }
+
+    private func step(_ current: String, in list: [String], forward: Bool, key: String, preview: Bool) -> String {
+        guard !list.isEmpty else { return current }
+        let idx = list.firstIndex(of: current) ?? 0
+        let next = forward ? (idx + 1) % list.count : (idx - 1 + list.count) % list.count
+        let value = list[next]
+        ConfigFile.write(key: key, value: value)
+        if preview { NSSound(named: NSSound.Name(value))?.play() }
+        return value
+    }
+
+    // MARK: - Hotkey recording
+
+    func startRecordingHotkey() {
+        recordingHotkey = true
+        hotkeyError = nil
+    }
+
+    func cancelRecordingHotkey() {
+        recordingHotkey = false
+    }
+
+    func commitHotkey(_ spec: String) {
+        // Try to register first; only persist if it took. Failing means the
+        // combo was rejected by the OS (already-registered global, malformed,
+        // etc.) — keep the previous one and surface a message to the user.
+        guard let setHotkey, setHotkey(spec) else {
+            hotkeyError = "‘\(spec)’ is unavailable — already bound by another app"
+            recordingHotkey = false
+            return
+        }
+        hotkeyError = nil
+        hotkeyDisplay = spec
+        ConfigFile.write(key: "STACKNUDGE_PANEL_HOTKEY", value: spec)
+        recordingHotkey = false
+    }
+}

--- a/panel/Permissions.swift
+++ b/panel/Permissions.swift
@@ -189,10 +189,13 @@ final class PermissionsWindowController: NSWindowController {
         window.title = "stack-nudge — Permissions"
         window.center()
         window.isReleasedWhenClosed = false
-        // Float above System Settings so the user can flip between the two
-        // and grant both permissions in one pass.
-        window.level = .floating
-        window.collectionBehavior = [.canJoinAllSpaces, .moveToActiveSpace]
+        // Above the panel's .floating level so this window can't be hidden
+        // behind it. Modal-panel level still sits below the menu bar/dock.
+        window.level = .modalPanel
+        // .canJoinAllSpaces and .moveToActiveSpace are mutually exclusive —
+        // the latter follows the user to whatever Space they're on, which is
+        // what we want for an on-demand permissions window.
+        window.collectionBehavior = [.moveToActiveSpace]
         window.contentView = NSHostingView(rootView: PermissionsView())
         self.init(window: window)
     }

--- a/panel/Sessions.swift
+++ b/panel/Sessions.swift
@@ -54,6 +54,7 @@ struct SessionsView: View {
                     }
                 }
                 .padding(.vertical, 4)
+                .background(ThinScrollers())
             }
             .onChange(of: store.selectedPID) { newValue in
                 guard let pid = newValue else { return }
@@ -65,11 +66,7 @@ struct SessionsView: View {
     }
 
     private var footer: some View {
-        HStack(spacing: 0) {
-            Image(systemName: "bell.badge.fill")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-            Spacer()
+        PageFooter {
             if store.renamingPID != nil {
                 FooterHint(label: "Save",   keys: ["⏎"])
                 FooterHint(label: "Cancel", keys: ["esc"])
@@ -81,17 +78,6 @@ struct SessionsView: View {
                 FooterHint(label: "Back",   keys: ["esc"])
             }
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 9)
-        .background(
-            ZStack {
-                Color.primary.opacity(0.05)
-                Rectangle()
-                    .fill(Color.primary.opacity(0.1))
-                    .frame(height: 0.5)
-                    .frame(maxHeight: .infinity, alignment: .top)
-            }
-        )
     }
 }
 

--- a/panel/Settings.swift
+++ b/panel/Settings.swift
@@ -1,214 +1,8 @@
 import AppKit
 import SwiftUI
 
-enum PanelMode {
-    case events
-    case sessions
-    case settings
-}
-
-// Action callbacks the controller wires into nav so settings rows like
-// "Check permissions" / "Open config" / "Quit" can fire effects without the
-// SwiftUI view needing to know about windows or app-level state.
-struct SettingsActions {
-    let checkPermissions: () -> Void
-    let openConfig:       () -> Void
-    let quit:             () -> Void
-}
-
 enum SettingsKind {
     case toggle, cycle, action
-}
-
-private struct SettingsItem {
-    let id: Int
-    let label: String
-    let kind: SettingsKind
-    let value: String      // "On"/"Off" for toggles, current value for cycle, "" for action
-}
-
-// PanelNav owns navigation state and settings state. The controller drives
-// it directly from key events; the view is a pure renderer.
-final class PanelNav: ObservableObject {
-
-    @Published var mode: PanelMode = .events
-    @Published var selectedSettingIndex: Int = 0
-
-    @Published var hotkeyDisplay:   String = "cmd+opt+n"
-    @Published var recordingHotkey: Bool = false
-    @Published var hotkeyError:     String?
-    @Published var bannerEnabled:   Bool = true
-    @Published var voiceEnabled:    Bool = false
-    @Published var soundStop:       String = "Glass"
-    @Published var soundPermission: String = "Ping"
-    @Published var voice:           String = "af_heart"
-    @Published var voiceSpeed:      Double = 1.1
-    @Published var voicesAvailable: [String] = []
-    @Published var voicesLoading:   Bool = true
-
-    var actions: SettingsActions?
-    // Wired by PanelController so nav can re-register the global hotkey
-    // without owning the Hotkey instance directly. Returns true if the
-    // new spec registered successfully.
-    var setHotkey: ((String) -> Bool)?
-
-    static let macSounds = [
-        "Basso", "Blow", "Bottle", "Frog", "Funk", "Glass", "Hero",
-        "Morse", "Ping", "Pop", "Purr", "Sosumi", "Submarine", "Tink",
-    ]
-
-    static let speedMin = 0.60
-    static let speedMax = 1.60
-    static let speedStep = 0.05
-
-    var rowCount: Int { 10 }
-
-    // Row layout (kept in one place so the controller, view, and indexing
-    // logic all agree on what each row index means):
-    //   0  Hotkey                hotkey-record
-    //   1  Banner notifications  toggle
-    //   2  Voice notifications   toggle
-    //   3  Agent done sound      cycle
-    //   4  Permission sound      cycle
-    //   5  Voice                 cycle
-    //   6  Speed                 cycle
-    //   7  Check permissions…    action
-    //   8  Open config file…     action
-    //   9  Quit panel            action
-
-    // MARK: - Disk I/O
-
-    func loadFromConfig() {
-        let config = ConfigFile.read()
-        hotkeyDisplay   = config["STACKNUDGE_PANEL_HOTKEY"]    ?? "cmd+shift+n"
-        bannerEnabled   = ConfigFile.bool(config, "STACKNUDGE_BANNER", default: true)
-        voiceEnabled    = ConfigFile.bool(config, "STACKNUDGE_VOICE",  default: false)
-        soundStop       = config["STACKNUDGE_SOUND_STOP"]       ?? "Glass"
-        soundPermission = config["STACKNUDGE_SOUND_PERMISSION"] ?? "Ping"
-        voice           = config["STACKNUDGE_VOICE_NAME"]       ?? "af_heart"
-        voiceSpeed      = Double(config["STACKNUDGE_VOICE_SPEED"] ?? "") ?? 1.1
-    }
-
-    func loadVoices() {
-        Task.detached(priority: .userInitiated) {
-            let names = Self.runStackvoxVoices()
-            await MainActor.run { [weak self] in
-                self?.voicesAvailable = names
-                self?.voicesLoading = false
-            }
-        }
-    }
-
-    private nonisolated static func runStackvoxVoices() -> [String] {
-        let stackvox = "\(NSHomeDirectory())/.stack-nudge/venv/bin/stackvox"
-        guard FileManager.default.isExecutableFile(atPath: stackvox) else { return [] }
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: stackvox)
-        task.arguments = ["voices"]
-        let pipe = Pipe()
-        task.standardOutput = pipe
-        task.standardError = Pipe()
-        do { try task.run() } catch { return [] }
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        task.waitUntilExit()
-        return (String(data: data, encoding: .utf8) ?? "")
-            .split(separator: "\n")
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { !$0.isEmpty && !$0.contains(" ") }
-    }
-
-    // MARK: - Row movement
-
-    func selectNextRow() {
-        guard rowCount > 0 else { return }
-        selectedSettingIndex = (selectedSettingIndex + 1) % rowCount
-    }
-
-    func selectPrevRow() {
-        guard rowCount > 0 else { return }
-        selectedSettingIndex = (selectedSettingIndex - 1 + rowCount) % rowCount
-    }
-
-    // MARK: - Cycle / activate
-
-    // ←/→: toggles flip, cycle rows step, actions are no-op.
-    func cycleForward()  { applyCycle(forward: true) }
-    func cycleBackward() { applyCycle(forward: false) }
-
-    // Enter: toggles flip, cycle rows step forward, actions fire, hotkey
-    // row enters record mode.
-    func activate() {
-        switch selectedSettingIndex {
-        case 0: startRecordingHotkey()
-        case 7: actions?.checkPermissions()
-        case 8: actions?.openConfig()
-        case 9: actions?.quit()
-        default: applyCycle(forward: true)
-        }
-    }
-
-    private func applyCycle(forward: Bool) {
-        switch selectedSettingIndex {
-        case 0:
-            // Cycle on the hotkey row also enters record mode.
-            startRecordingHotkey()
-        case 1:
-            bannerEnabled.toggle()
-            ConfigFile.write(key: "STACKNUDGE_BANNER", value: bannerEnabled ? "true" : "false")
-        case 2:
-            voiceEnabled.toggle()
-            ConfigFile.write(key: "STACKNUDGE_VOICE", value: voiceEnabled ? "true" : "false")
-        case 3:
-            soundStop = step(soundStop, in: Self.macSounds, forward: forward, key: "STACKNUDGE_SOUND_STOP", preview: true)
-        case 4:
-            soundPermission = step(soundPermission, in: Self.macSounds, forward: forward, key: "STACKNUDGE_SOUND_PERMISSION", preview: true)
-        case 5:
-            guard !voicesLoading, !voicesAvailable.isEmpty else { return }
-            voice = step(voice, in: voicesAvailable, forward: forward, key: "STACKNUDGE_VOICE_NAME", preview: false)
-        case 6:
-            let next = forward ? voiceSpeed + Self.speedStep : voiceSpeed - Self.speedStep
-            voiceSpeed = max(Self.speedMin, min(Self.speedMax, (next * 100).rounded() / 100))
-            ConfigFile.write(key: "STACKNUDGE_VOICE_SPEED", value: String(format: "%.2f", voiceSpeed))
-        default:
-            break
-        }
-    }
-
-    // MARK: - Hotkey recording
-
-    func startRecordingHotkey() {
-        recordingHotkey = true
-        hotkeyError = nil
-    }
-
-    func cancelRecordingHotkey() {
-        recordingHotkey = false
-    }
-
-    func commitHotkey(_ spec: String) {
-        // Try to register first; only persist if it took. Failing means the
-        // combo was rejected by the OS (already-registered global, malformed,
-        // etc.) — keep the previous one and surface a message to the user.
-        guard let setHotkey, setHotkey(spec) else {
-            hotkeyError = "‘\(spec)’ is unavailable — already bound by another app"
-            recordingHotkey = false
-            return
-        }
-        hotkeyError = nil
-        hotkeyDisplay = spec
-        ConfigFile.write(key: "STACKNUDGE_PANEL_HOTKEY", value: spec)
-        recordingHotkey = false
-    }
-
-    private func step(_ current: String, in list: [String], forward: Bool, key: String, preview: Bool) -> String {
-        guard !list.isEmpty else { return current }
-        let idx = list.firstIndex(of: current) ?? 0
-        let next = forward ? (idx + 1) % list.count : (idx - 1 + list.count) % list.count
-        let value = list[next]
-        ConfigFile.write(key: key, value: value)
-        if preview { NSSound(named: NSSound.Name(value))?.play() }
-        return value
-    }
 }
 
 struct SettingsView: View {
@@ -256,6 +50,7 @@ struct SettingsView: View {
                     }
                     .padding(.horizontal, 14)
                     .padding(.vertical, 14)
+                    .background(ThinScrollers())
                 }
                 .onChange(of: nav.selectedSettingIndex) { newIndex in
                     withAnimation(.easeOut(duration: 0.15)) {
@@ -264,7 +59,17 @@ struct SettingsView: View {
                 }
             }
 
-            footer
+            PageFooter {
+                if nav.recordingHotkey {
+                    FooterHint(label: "Press a combo with ⌘ / ⇧ / ⌥ / ⌃", keys: [], primary: true)
+                    FooterHint(label: "Cancel", keys: ["esc"])
+                } else {
+                    FooterHint(label: "Move",  keys: ["↑", "↓"])
+                    FooterHint(label: "Cycle", keys: ["←", "→"])
+                    FooterHint(label: "Act",   keys: ["⏎"])
+                    FooterHint(label: "Back",  keys: ["esc"])
+                }
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .onAppear {
@@ -277,30 +82,6 @@ struct SettingsView: View {
         if nav.voicesLoading { return "Loading…" }
         if nav.voicesAvailable.isEmpty { return "Voices unavailable" }
         return nav.voice
-    }
-
-    private var footer: some View {
-        HStack(spacing: 0) {
-            Image(systemName: "bell.badge.fill")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-            Spacer()
-            FooterHint(label: "Move",   keys: ["↑", "↓"])
-            FooterHint(label: "Cycle",  keys: ["←", "→"])
-            FooterHint(label: "Act",    keys: ["⏎"])
-            FooterHint(label: "Back",   keys: ["esc"])
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 9)
-        .background(
-            ZStack {
-                Color.primary.opacity(0.05)
-                Rectangle()
-                    .fill(Color.primary.opacity(0.1))
-                    .frame(height: 0.5)
-                    .frame(maxHeight: .infinity, alignment: .top)
-            }
-        )
     }
 
     private func section<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {
@@ -333,7 +114,6 @@ struct SettingsView: View {
             }
         }
     }
-
 }
 
 private struct SettingsRowView: View {

--- a/panel/Speaker.swift
+++ b/panel/Speaker.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+// Thin wrapper around stackvox-say. Spawns the daemon if its socket isn't
+// up yet (mirrors notify.sh's auto-start) and falls back to a no-op if
+// stackvox isn't installed in the venv.
+enum Speaker {
+
+    static func speak(_ text: String, voice: String? = nil, speed: String? = nil) {
+        let venvBin = "\(NSHomeDirectory())/.stack-nudge/venv/bin"
+        let stackvoxSay = "\(venvBin)/stackvox-say"
+        let stackvox    = "\(venvBin)/stackvox"
+        let socketPath  = "\(NSHomeDirectory())/.cache/stackvox/daemon.sock"
+        guard FileManager.default.isExecutableFile(atPath: stackvoxSay) else { return }
+
+        if !FileManager.default.fileExists(atPath: socketPath),
+           FileManager.default.isExecutableFile(atPath: stackvox) {
+            let serve = Process()
+            serve.executableURL = URL(fileURLWithPath: stackvox)
+            serve.arguments = ["serve"]
+            try? serve.run()
+        }
+
+        let config = ConfigFile.read()
+        let resolvedVoice = voice ?? config["STACKNUDGE_VOICE_NAME"]  ?? "af_heart"
+        let resolvedSpeed = speed ?? config["STACKNUDGE_VOICE_SPEED"] ?? "1.1"
+        let say = Process()
+        say.executableURL = URL(fileURLWithPath: stackvoxSay)
+        say.arguments = ["--voice", resolvedVoice, "--speed", resolvedSpeed, text]
+        try? say.run()
+    }
+}

--- a/phrases/en.sh
+++ b/phrases/en.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# English phrase templates. %s is the repo name.
+TEMPLATES_RESPONSE=(
+  "%s is ready for you"
+  "%s needs your attention"
+  "task complete in %s"
+  "%s is ready for your review"
+  "your input is needed in %s"
+  "%s awaits your response"
+  "work complete in %s"
+  "output ready in %s"
+  "%s is prepared for your review"
+  "ready for your decision in %s"
+)
+TEMPLATES_NOTIFICATION=(
+  "%s requires a decision"
+  "%s is awaiting input"
+  "%s requires your attention"
+  "%s has a question for you"
+  "%s is awaiting approval"
+  "%s needs direction"
+  "approval needed in %s"
+  "%s is paused for your review"
+  "confirmation required in %s"
+  "%s is blocked awaiting input"
+)

--- a/phrases/fr.sh
+++ b/phrases/fr.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# French phrase templates. Formal addressing (vous). %s is the repo name.
+TEMPLATES_RESPONSE=(
+  "%s est prêt pour vous"
+  "%s requiert votre attention"
+  "tâche terminée dans %s"
+  "%s est prêt pour votre révision"
+  "votre intervention est requise dans %s"
+  "%s attend votre réponse"
+  "travail terminé dans %s"
+  "résultat prêt dans %s"
+  "%s est préparé pour votre révision"
+  "prêt pour votre décision dans %s"
+)
+TEMPLATES_NOTIFICATION=(
+  "%s requiert une décision"
+  "%s attend votre réponse"
+  "%s requiert votre attention"
+  "%s a une question pour vous"
+  "%s est en attente d'approbation"
+  "%s nécessite une orientation"
+  "approbation requise dans %s"
+  "%s est en pause pour votre révision"
+  "confirmation requise dans %s"
+  "%s est bloqué en attente d'une entrée"
+)

--- a/phrases/hi.sh
+++ b/phrases/hi.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Hindi phrase templates (romanized, matches Kokoro's hf_* / hm_* voices).
+# Formal addressing (aap). %s is the repo name.
+TEMPLATES_RESPONSE=(
+  "%s aapke liye taiyaar hai"
+  "%s ko aapke dhyaan ki zaroorat hai"
+  "%s mein kaam poora ho gaya"
+  "%s aapki samiksha ke liye taiyaar hai"
+  "%s mein aapka jawaab chahiye"
+  "%s aapke jawaab ka intezaar kar raha hai"
+  "%s mein kaam khatam ho gaya"
+  "%s mein nateeja taiyaar hai"
+  "%s aapke nirdesh ke liye taiyaar hai"
+  "%s aapke faisle ka intezaar kar raha hai"
+)
+TEMPLATES_NOTIFICATION=(
+  "%s mein ek faisla chahiye"
+  "%s aapke jawaab ka intezaar kar raha hai"
+  "%s ko aapke dhyaan ki zaroorat hai"
+  "%s mein aapke liye ek sawaal hai"
+  "%s manzoori ka intezaar kar raha hai"
+  "%s ko aapke nirdesh ki zaroorat hai"
+  "%s mein manzoori chahiye"
+  "%s aapki samiksha ke liye ruka hua hai"
+  "%s mein pushti chahiye"
+  "%s input ka intezaar kar raha hai"
+)

--- a/phrases/it.sh
+++ b/phrases/it.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Italian phrase templates. Formal addressing (Lei). %s is the repo name.
+TEMPLATES_RESPONSE=(
+  "%s è pronto per Lei"
+  "%s richiede la Sua attenzione"
+  "attività completata in %s"
+  "%s è pronto per la Sua revisione"
+  "il Suo intervento è richiesto in %s"
+  "%s attende la Sua risposta"
+  "lavoro completato in %s"
+  "risultato pronto in %s"
+  "%s è preparato per la Sua revisione"
+  "pronto per la Sua decisione in %s"
+)
+TEMPLATES_NOTIFICATION=(
+  "%s richiede una decisione"
+  "%s attende il Suo input"
+  "%s richiede la Sua attenzione"
+  "%s ha una domanda per Lei"
+  "%s è in attesa di approvazione"
+  "%s necessita di una direzione"
+  "approvazione richiesta in %s"
+  "%s è in pausa per la Sua revisione"
+  "conferma richiesta in %s"
+  "%s è bloccato in attesa di input"
+)

--- a/phrases/pt.sh
+++ b/phrases/pt.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Portuguese (Brazilian) phrase templates. %s is the repo name.
+TEMPLATES_RESPONSE=(
+  "%s está pronto para você"
+  "%s requer sua atenção"
+  "tarefa concluída em %s"
+  "%s está pronto para sua revisão"
+  "sua resposta é necessária em %s"
+  "%s aguarda sua resposta"
+  "trabalho concluído em %s"
+  "resultado pronto em %s"
+  "%s está preparado para sua revisão"
+  "pronto para sua decisão em %s"
+)
+TEMPLATES_NOTIFICATION=(
+  "%s requer uma decisão"
+  "%s aguarda sua resposta"
+  "%s requer sua atenção"
+  "%s tem uma pergunta para você"
+  "%s aguarda aprovação"
+  "%s precisa de direção"
+  "aprovação necessária em %s"
+  "%s está pausado para sua revisão"
+  "confirmação necessária em %s"
+  "%s está bloqueado aguardando entrada"
+)

--- a/shared/AppActivator.swift
+++ b/shared/AppActivator.swift
@@ -50,7 +50,9 @@ struct AppActivator {
 
             // Step 3: focus the agent's terminal pane via AX before sending Enter,
             // so the keystroke lands in the right pane instead of whatever was
-            // last focused in VS Code.
+            // last focused in VS Code. After AX press of the tab, dwell briefly
+            // for the xterm canvas to take focus, then send Enter routed
+            // explicitly to the Code/Cursor process.
             if pressEnter {
                 Thread.sleep(forTimeInterval: 0.3)
                 if let runningApp = NSRunningApplication
@@ -59,11 +61,15 @@ struct AppActivator {
                         pid: runningApp.processIdentifier,
                         agent: terminalLabelHint(for: agent)
                     )
-                    Thread.sleep(forTimeInterval: 0.1)
+                    Thread.sleep(forTimeInterval: 0.3)
                 }
                 var err3: NSDictionary?
                 NSAppleScript(source: """
-                    tell application "System Events" to key code 36
+                    tell application "System Events"
+                        tell process "\(procName)"
+                            key code 36
+                        end tell
+                    end tell
                 """)?.executeAndReturnError(&err3)
             }
             return
@@ -161,10 +167,9 @@ struct AppActivator {
     }
 
     private static func focus(_ element: AXUIElement) -> Bool {
-        // Prefer an explicit press (terminal tab elements respond to it the
-        // same way a click would, which both selects the tab and focuses the
-        // xterm canvas inside). Fall back to setting the focused attribute
-        // for elements that don't accept a press.
+        // AX press is the click-equivalent — for terminal tab radio buttons,
+        // it both selects the tab and lets VS Code's own JS focus handlers
+        // run, which is what moves keyboard focus into the xterm canvas.
         if AXUIElementPerformAction(element, kAXPressAction as CFString) == .success {
             return true
         }


### PR DESCRIPTION
## Summary

Three commits worth of work building out the floating panel into a full keyboard-driven UI for managing nudges and live agent sessions, plus voice notifications with per-language phrasing and per-pane focus targeting in VS Code / Cursor.

### What you get

**Tabbed panel** (⌘+Opt+N to summon — was ⌘+Shift+N, which collides with browsers / editors / Finder)
- **Events** — recent nudges; ↑↓ select, ⏎ approve / focus, ⌫ dismiss
- **Sessions** — live `claude` / `gemini` / `codex` processes; ⏎ focus, n rename, ⌫ kill (SIGTERM)
- **Settings** — keyboard-cycled rows for hotkey, banner/voice toggles, sounds (preview on cycle), voice (preview with random phrase), speed, plus actions (permissions / open config / quit)

**Per-pane focus in VS Code / Cursor**
Approval keystrokes used to land in whichever pane was last focused. Now AppActivator walks the editor's accessibility tree and focuses a terminal pane labelled with the agent's binary name (\`claude\` / \`gemini\` / \`codex\`) before sending Enter — so the keystroke lands in the right shell, not the editor.

**Voice phrasing à la \`stackone-say-hooks\`**
Phrase pools per event (response / notification) and per language (en, fr, hi, it, pt) live in \`phrases/\`. notify.sh picks one at random and formats it with the project name. A French voice (\`ff_*\`) speaks French phrasing. \`STACKNUDGE_VOICE=true\` now suppresses the chime — voice replaces sound rather than playing alongside it.

**Active sessions list** (closes #3)
\`pgrep\`-style scan every 3s; node-hosted agents (\`gemini-cli\`) detected via \`args\` since \`comm=node\`. Finished sessions linger 30s with \`ended Ns ago\`. Inline rename via \`n\`. Multi-session-aware (independent of project).

**Hotkey recorder + config watcher**
Settings → Hotkey row → ⏎ → press combo → re-registers live and writes config. \`DispatchSourceFileSystemObject\` watches \`~/.stack-nudge/config\` so external edits propagate without a restart. Re-arms on rename/delete so atomic-save editors don't orphan it.

**Permissions UX**
Reset & prompt button runs \`tccutil reset\` then triggers a fresh dialog — recovers the rebuild-invalidates-cdhash gotcha that bites every iteration of an ad-hoc-signed dev build. Window floats above System Settings (\`.modalPanel\` level) so you can grant both AX + Automation in one pass.

**Refactor + polish**
- \`panel/PanelNav.swift\` (nav model), \`panel/Components.swift\` (shared SwiftUI), \`panel/Speaker.swift\` (stackvox helper) — pulled out of \`Panel.swift\` and \`Settings.swift\`
- \`PageFooter\` view used by all three pages
- \`ThinScrollers\` shrinks scroll bars to ~half default width
- One \`⌘1-3\` keycap on the tab strip instead of per-tab keycaps
- \`make reload\` / \`make dev\` now refresh \`notify.sh\` and \`phrases/\` alongside the daemon binary

### Test plan

- [x] \`./install.sh\` from a clean state; daemon starts, menu bar bell icon visible
- [x] \`STACKNUDGE_PANEL=true\` in config → \`⌘+Opt+N\` summons the panel
- [x] Run a Claude Code session in a VS Code terminal, trigger a permission request, focus the editor pane, summon panel, ⏎ on the row → approval lands in the agent's terminal pane
- [x] Settings → Hotkey row → ⏎ → press a new combo → panel re-binds, config file updated
- [x] Sessions tab → cycle through running agents; \`n\` to rename; ⌫ to SIGTERM
- [x] Voice toggle on → next nudge speaks a phrase like \`<repo> is ready for you\` instead of "Done"
- [x] Switch \`STACKNUDGE_VOICE_NAME\` to a French voice (\`ff_siwis\`) → next nudge speaks French phrasing
- [x] \`make dev\` → save a Swift file or notify.sh → daemon bounces in ~2s

🤖 Generated with [Claude Code](https://claude.com/claude-code)