### PR TITLE
feat: npm package with auto-updates

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+.github/
+build/
+assets/
+Makefile
+.gitignore
+*.md

--- a/install.sh
+++ b/install.sh
@@ -136,6 +136,40 @@ LAUNCHER
     "${INSTALL_DIR}/panel.log" \
     "${PANEL_LAUNCHER}"
   echo "  Panel daemon registered as launchd agent (starts at login when STACKNUDGE_PANEL=true)"
+
+  # Auto-updater: checks npm for new versions every 4 hours.
+  # Harmless when not installed via npm (exits early).
+  if command -v npm >/dev/null 2>&1; then
+    command -v npm > "$INSTALL_DIR/.npm-path"
+  fi
+  cp "$SCRIPT_DIR/update.sh" "$INSTALL_DIR/update.sh"
+  chmod +x "$INSTALL_DIR/update.sh"
+
+  UPDATER_LABEL="com.stackonehq.stack-nudge-updater"
+  UPDATER_PLIST="$HOME/Library/LaunchAgents/${UPDATER_LABEL}.plist"
+  cat > "$UPDATER_PLIST" <<UPDATER
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${UPDATER_LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${INSTALL_DIR}/update.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>14400</integer>
+    <key>StandardOutPath</key>
+    <string>${INSTALL_DIR}/update.log</string>
+    <key>StandardErrorPath</key>
+    <string>${INSTALL_DIR}/update.log</string>
+</dict>
+</plist>
+UPDATER
+  launchctl unload "$UPDATER_PLIST" 2>/dev/null || true
+  launchctl load "$UPDATER_PLIST"
+  echo "  Auto-updater registered (checks npm every 4 hours)"
 fi
 
 # Copy notify.sh to shared install dir

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "stack-nudge",
+  "version": "1.1.2",
+  "description": "Desktop notifications for AI coding agents — sound, banner, voice, click-to-focus",
+  "license": "MIT",
+  "homepage": "https://github.com/StackOneHQ/stack-nudge#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/StackOneHQ/stack-nudge.git"
+  },
+  "os": [
+    "darwin",
+    "linux"
+  ],
+  "bin": {
+    "stack-nudge": "notify.sh"
+  },
+  "scripts": {
+    "postinstall": "./install.sh",
+    "preuninstall": "./uninstall.sh"
+  },
+  "files": [
+    "notifier/",
+    "panel/",
+    "shared/",
+    "hooks/",
+    "build.sh",
+    "install.sh",
+    "uninstall.sh",
+    "notify.sh",
+    "notify.conf.example",
+    "update.sh"
+  ]
+}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -56,7 +56,7 @@ PY
 fi
 
 # Stop and remove launchd agents (macOS)
-for label in com.stackonehq.stack-nudge-daemon com.stackonehq.stack-nudge-panel; do
+for label in com.stackonehq.stack-nudge-daemon com.stackonehq.stack-nudge-panel com.stackonehq.stack-nudge-updater; do
   plist="$HOME/Library/LaunchAgents/${label}.plist"
   if [[ -f "$plist" ]]; then
     launchctl unload "$plist" 2>/dev/null || true

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# stack-nudge auto-updater
+# Checks npm for a newer version and installs it if available.
+# Designed to run unattended via launchd (macOS).
+
+set -e
+
+INSTALL_DIR="${HOME}/.stack-nudge"
+LOG="$INSTALL_DIR/update.log"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >> "$LOG"; }
+
+# Rotate log if > 100KB
+if [[ -f "$LOG" ]]; then
+  size=$(stat -f%z "$LOG" 2>/dev/null || stat -c%s "$LOG" 2>/dev/null || echo 0)
+  (( size > 102400 )) && { tail -50 "$LOG" > "$LOG.tmp" && mv "$LOG.tmp" "$LOG"; }
+fi
+
+# Find npm — launchd doesn't source shell profiles, so check common paths.
+find_npm() {
+  [[ -f "$INSTALL_DIR/.npm-path" ]] && {
+    local stored
+    stored=$(cat "$INSTALL_DIR/.npm-path")
+    [[ -x "$stored" ]] && { echo "$stored"; return; }
+  }
+  for cand in /opt/homebrew/bin/npm /usr/local/bin/npm \
+              "$HOME/.nvm/versions/node"/*/bin/npm \
+              "$HOME/.volta/bin/npm" \
+              "$HOME/.fnm/aliases/default/bin/npm"; do
+    for match in $cand; do
+      [[ -x "$match" ]] && { echo "$match"; return; }
+    done
+  done
+  command -v npm 2>/dev/null || true
+}
+
+NPM=$(find_npm)
+if [[ -z "$NPM" || ! -x "$NPM" ]]; then
+  log "npm not found — skipping update check"
+  exit 0
+fi
+
+# Compare installed vs latest version
+CURRENT=$("$NPM" ls -g stack-nudge --depth=0 --json 2>/dev/null \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('dependencies',{}).get('stack-nudge',{}).get('version',''))" 2>/dev/null || echo "")
+
+if [[ -z "$CURRENT" ]]; then
+  log "stack-nudge not found in npm global — skipping"
+  exit 0
+fi
+
+LATEST=$("$NPM" view stack-nudge version 2>/dev/null || echo "")
+if [[ -z "$LATEST" ]]; then
+  log "Could not reach npm registry — skipping"
+  exit 0
+fi
+
+if [[ "$CURRENT" == "$LATEST" ]]; then
+  log "Up to date (v${CURRENT})"
+  exit 0
+fi
+
+log "Updating: v${CURRENT} -> v${LATEST}"
+if "$NPM" install -g "stack-nudge@${LATEST}" >> "$LOG" 2>&1; then
+  log "Update complete (v${LATEST})"
+else
+  log "Update failed (exit $?)"
+fi


### PR DESCRIPTION
## Summary
- Adds `package.json` so stack-nudge can be installed via `npm install -g stack-nudge`
- Adds `update.sh` auto-updater that runs as a launchd agent every 4 hours, checking npm for new versions and self-updating
- Wires the updater into `install.sh` (registration) and `uninstall.sh` (cleanup)
- Adds `.npmignore` to keep the published package lean (~127KB)

## How it works
1. `npm install -g stack-nudge` → `postinstall` runs `install.sh` (builds Swift apps, wires hooks, registers daemons + auto-updater)
2. Every 4 hours, launchd runs `update.sh` which compares installed vs latest npm version and updates if needed
3. `npm uninstall -g stack-nudge` → `preuninstall` runs `uninstall.sh` (cleans up everything including the updater agent)

## Test plan
- [ ] `npm pack --dry-run` — verify tarball contents
- [ ] `npm install -g .` from repo root — verify postinstall builds and registers all agents
- [ ] `launchctl list | grep stack-nudge` — verify updater agent is registered
- [ ] `npm uninstall -g stack-nudge` — verify clean uninstall including updater plist

🤖 Generated with [Claude Code](https://claude.com/claude-code)