### PR TITLE
fix: migrate to stackvox 0.4.x unified CLI

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,7 @@ find_python() {
 # Install the voice engine (stackvox) from PyPI into an isolated venv.
 echo ""
 echo "Setting up voice engine..."
-STACKVOX_SPEC="stackvox>=0.3.0"
+STACKVOX_SPEC="stackvox>=0.4.0"
 PYTHON=$(find_python)
 if [[ -z "$PYTHON" ]]; then
   echo "  Could not find Python ≥ 3.10. Install one (e.g. 'brew install python@3.13')"

--- a/notify.sh
+++ b/notify.sh
@@ -146,7 +146,7 @@ voice_phrase_for() {
   local event="$1"
   local lang repo
 
-  if [[ -x "$STACKVOX_SAY" ]]; then
+  if [[ -x "$STACKVOX" ]]; then
     lang=$(voice_to_lang "$VOICE_NAME")
     repo=$(repo_name_raw)
   else
@@ -196,25 +196,37 @@ agent_label() {
   esac
 }
 
-# Bundled voice engine paths
+# Bundled voice engine paths. stackvox 0.3.x consolidated the CLI — there
+# is no separate `stackvox-say` console script anymore; speech goes through
+# `stackvox say <text>` as a subcommand.
 VENV="${HOME}/.stack-nudge/venv"
 STACKVOX="${VENV}/bin/stackvox"
-STACKVOX_SAY="${VENV}/bin/stackvox-say"
+
+# Log a debug line when STACKNUDGE_DEBUG=true. Used for "voice was
+# requested but couldn't fire" cases that previously failed silently.
+nudge_debug() {
+  [[ "${STACKNUDGE_DEBUG:-}" == "true" ]] || return 0
+  printf '[stack-nudge] %s\n' "$*" >&2
+}
 
 # Speak a message aloud via the bundled StackVox daemon.
 # Auto-starts the daemon if it isn't running. Falls back silently if the
-# venv isn't installed or the daemon fails to respond.
+# venv isn't installed or the daemon fails to respond — set STACKNUDGE_DEBUG=true
+# to surface why.
 speak_notification() {
   [[ "${VOICE_ENABLED}" != "true" ]] && return
-  [[ ! -x "$STACKVOX_SAY" ]] && return
+  if [[ ! -x "$STACKVOX" ]]; then
+    nudge_debug "voice requested but stackvox not found at $STACKVOX"
+    return
+  fi
   local text="$1"
-  # Start daemon if socket doesn't exist yet
   if [[ ! -S "${HOME}/.cache/stackvox/daemon.sock" ]]; then
+    nudge_debug "stackvox daemon socket missing — starting daemon"
     nohup "$STACKVOX" serve >/dev/null 2>&1 &
   fi
   local kokoro_lang
   kokoro_lang=$(voice_to_kokoro_lang "$VOICE_NAME")
-  "$STACKVOX_SAY" --voice "${VOICE_NAME}" --lang "${kokoro_lang}" --speed "${VOICE_SPEED}" "${text}" 2>/dev/null &
+  "$STACKVOX" say --voice "${VOICE_NAME}" --lang "${kokoro_lang}" --speed "${VOICE_SPEED}" "${text}" 2>/dev/null &
 }
 
 # Locate one of our .app bundles. Searches ~/Applications, the script's

--- a/panel/Speaker.swift
+++ b/panel/Speaker.swift
@@ -1,19 +1,20 @@
 import Foundation
 
-// Thin wrapper around stackvox-say. Spawns the daemon if its socket isn't
-// up yet (mirrors notify.sh's auto-start) and falls back to a no-op if
-// stackvox isn't installed in the venv.
+// Thin wrapper around the stackvox CLI. Spawns the daemon if its socket
+// isn't up yet (mirrors notify.sh's auto-start) and falls back to a no-op
+// if stackvox isn't installed in the venv.
+//
+// stackvox 0.3.x consolidated its CLI — there's no separate `stackvox-say`
+// binary anymore; speech goes through `stackvox say <text>` as a subcommand.
 enum Speaker {
 
     static func speak(_ text: String, voice: String? = nil, speed: String? = nil) {
         let venvBin = "\(NSHomeDirectory())/.stack-nudge/venv/bin"
-        let stackvoxSay = "\(venvBin)/stackvox-say"
         let stackvox    = "\(venvBin)/stackvox"
         let socketPath  = "\(NSHomeDirectory())/.cache/stackvox/daemon.sock"
-        guard FileManager.default.isExecutableFile(atPath: stackvoxSay) else { return }
+        guard FileManager.default.isExecutableFile(atPath: stackvox) else { return }
 
-        if !FileManager.default.fileExists(atPath: socketPath),
-           FileManager.default.isExecutableFile(atPath: stackvox) {
+        if !FileManager.default.fileExists(atPath: socketPath) {
             let serve = Process()
             serve.executableURL = URL(fileURLWithPath: stackvox)
             serve.arguments = ["serve"]
@@ -24,8 +25,8 @@ enum Speaker {
         let resolvedVoice = voice ?? config["STACKNUDGE_VOICE_NAME"]  ?? "af_aoede"
         let resolvedSpeed = speed ?? config["STACKNUDGE_VOICE_SPEED"] ?? "1.1"
         let say = Process()
-        say.executableURL = URL(fileURLWithPath: stackvoxSay)
-        say.arguments = ["--voice", resolvedVoice, "--speed", resolvedSpeed, text]
+        say.executableURL = URL(fileURLWithPath: stackvox)
+        say.arguments = ["say", "--voice", resolvedVoice, "--speed", resolvedSpeed, text]
         try? say.run()
     }
 }


### PR DESCRIPTION
## Summary

stackvox 0.4.x consolidated its CLI — there is no separate \`stackvox-say\` console_script anymore; speech goes through \`stackvox say <text>\` as a subcommand. \`notify.sh\` and \`Speaker.swift\` both still pointed at the old binary, so on fresh installs (where only \`stackvox\` exists in the venv) the existence guard bailed silently and voice never fired.

Closes #14, reported by @OMauriStkOne.

## Failure mode this fixes

- Install looks healthy, daemon running, models downloaded
- \`stackvox say "..."\` works manually
- \`STACKNUDGE_VOICE=true\` set
- Hook fires → banner + sound play → **voice never speaks, no error surfaced**

## Changes

**\`notify.sh\`**
- Drop \`STACKVOX_SAY\` variable
- \`speak_notification\` invokes \`"\$STACKVOX" say ...\`
- \`voice_phrase_for\` gates on \`STACKVOX\` existence
- New \`nudge_debug()\` helper writes to stderr when \`STACKNUDGE_DEBUG=true\`. Logs the missing-binary and missing-daemon-socket cases that previously failed silently — so the next time something like this happens, users can diagnose with one env var instead of bisecting the script.

**\`panel/Speaker.swift\`**
- Same migration on the Swift side (used by the menu-bar voice toggle preview and the voice-cycle preview in Settings)

## Test plan

- [x] \`stackvox say --voice af_aoede ...\` runs cleanly against an installed venv
- [x] \`notify.sh claude-code stop\` with \`STACKNUDGE_VOICE=true\` completes the voice path without error
- [x] \`STACKNUDGE_DEBUG=true\` surfaces the diagnostic when stackvox is absent
- [x] \`shellcheck -S warning\` and \`bash -n\` clean
- [x] \`make build\` (swiftc path) and \`swift build\` (Package.swift) both succeed

## Out of scope (deliberate)

- The two related issues from the same install session (#11 install.sh silent failure on Python < 3.10, #12 stale hook entries on upgrade) are independent of this — covered by separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)