### PR TITLE
feat: detect Zed as a host editor (closes #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,12 @@ The hook calls `notify.sh <agent> <event>`, which plays a sound and shows a bann
 
 When you click the banner, `stack-nudge.app` uses System Events to raise the exact window that triggered the notification — even if you have multiple Cursor or terminal windows open. Supported apps:
 
-- Cursor, VS Code
+- Cursor, VS Code, Zed
 - iTerm2, Warp, Ghostty, Terminal.app
 
 If the target app is already in focus when the notification fires, the banner is suppressed and only the sound plays.
+
+> **Note on Zed:** Zed itself doesn't expose an external hook system, so stack-nudge relies on the agent's hooks (e.g. `~/.claude/settings.json` for Claude Code) firing from inside Zed's integrated terminal. Click-to-focus and frontmost-window suppression are wired up via `TERM_PROGRAM=zed`, which Zed sets automatically.
 
 ### Immediate focus mode
 

--- a/notify.sh
+++ b/notify.sh
@@ -268,6 +268,7 @@ walk_session_chain() {
     case "$base" in
       "Code Helper"|"Code Helper (Plugin)"|"Code Helper (Renderer)"|Code|\
       "Cursor Helper"|"Cursor Helper (Plugin)"|"Cursor Helper (Renderer)"|Cursor|\
+      Zed|zed|\
       iTerm2|iTerm|Terminal|Warp|WarpTerminal|ghostty|Ghostty)
         TERMINAL_PID="$pid"; TERMINAL_APP="$base"; break ;;
     esac
@@ -356,7 +357,8 @@ notify_macos() {
   local sound="$3"
   local voice_message="${4:-$message}"
 
-  # Detect terminal / editor bundle ID for click-to-focus
+  # Detect terminal / editor bundle ID for click-to-focus.
+  # Zed sets TERM_PROGRAM=zed in its integrated terminal as of zed-industries/zed#14213.
   local bundle_id
   case "${TERM_PROGRAM}" in
     vscode)
@@ -366,6 +368,7 @@ notify_macos() {
         bundle_id="com.microsoft.VSCode"
       fi
       ;;
+    zed)          bundle_id="dev.zed.Zed" ;;
     iTerm.app)    bundle_id="com.googlecode.iterm2" ;;
     WarpTerminal) bundle_id="dev.warp.Warp-Stable" ;;
     ghostty)      bundle_id="com.mitchellh.ghostty" ;;
@@ -377,6 +380,7 @@ notify_macos() {
   case "$bundle_id" in
     com.todesktop.230313mzl4w4u92) process_name="Cursor" ;;
     com.microsoft.VSCode)           process_name="Code" ;;
+    dev.zed.Zed)                    process_name="Zed" ;;
     com.googlecode.iterm2)          process_name="iTerm2" ;;
     dev.warp.Warp-Stable)           process_name="Warp" ;;
     com.mitchellh.ghostty)          process_name="Ghostty" ;;


### PR DESCRIPTION
Closes #18.

## Summary

Adds Zed to \`notify.sh\`'s editor-detection layer so notifications fired from agents running inside Zed's integrated terminal route correctly.

- \`TERM_PROGRAM=zed\` → bundle ID \`dev.zed.Zed\`. Zed sets this env var since [zed-industries/zed#14213](https://github.com/zed-industries/zed/pull/14213) (merged 2024-07).
- bundle ID \`dev.zed.Zed\` → process name \`Zed\` for System Events window-title capture and frontmost-window suppression.
- \`walk_session_chain\` recognises Zed so the panel's Sessions view records the host editor correctly.

## Why this is the only change needed

Zed has no external hook system of its own ([Zed docs explicitly state](https://zed.dev/docs/ai/agent-panel) "hooks are currently not supported in external agents"), so stack-nudge can't wire up a Zed-side \`hooks.json\` the way it does for Claude Code and Cursor. But the agent's own hooks (e.g. \`~/.claude/settings.json\`) still fire normally from inside Zed's integrated terminal — \`install.sh\` already auto-wires those. The only gap was that \`notify.sh\` didn't know how to map the agent's host editor back to a Zed window, so click-to-focus and mute-when-focused targeted the wrong app.

## Test plan

- [x] \`shellcheck --severity=warning notify.sh\` passes
- [x] \`bash -n notify.sh\` passes
- [x] Mapping smoketest: \`TERM_PROGRAM=zed\` → \`bundle_id=dev.zed.Zed\` → \`process_name=Zed\`
- [ ] Manual: install Zed, run Claude Code inside its integrated terminal, trigger a permission prompt, click the banner, confirm the right Zed window comes to front
- [ ] Manual: confirm that with \`STACKNUDGE_MUTE_WHEN_FOCUSED=true\` (default), notifications are suppressed when the Zed window is already frontmost