### PR TITLE
chore: sync Info.plist version with release-please releases

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -6,7 +6,13 @@
     ".": {
       "package-name": "stack-nudge",
       "release-type": "simple",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "panel/Info.plist"
+        }
+      ]
     }
   }
 }

--- a/panel/Info.plist
+++ b/panel/Info.plist
@@ -15,7 +15,7 @@
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.1.2</string>
+    <string>1.4.1</string> <!-- x-release-please-version -->
     <key>LSUIElement</key>
     <true/>
     <key>NSPrincipalClass</key>


### PR DESCRIPTION
## Summary

- Wire release-please `extra-files` so `CFBundleShortVersionString` in `panel/Info.plist` gets bumped automatically on each release.
- Bring the current value forward from `1.1.2` to `1.4.1` to match the latest release tag.

## Why

release-please only bumps `.release-please-manifest.json` by default. The bundled app's `CFBundleShortVersionString` has been drifting — stuck on `1.1.2` while releases progressed through `1.2.0`, `1.3.0`, `1.4.0`, `1.4.1`.

This breaks any in-app feature that reads its own version, including the auto-updater I'm working on in `feat/notification-customization`: it compares `Bundle.main.infoDictionary["CFBundleShortVersionString"]` against the GitHub latest-release tag, and a stale plist value means the app always thinks an update is available — even right after updating.

The `x-release-please-version` marker comment on the version line is how release-please's `generic` extra-files type identifies which string to bump.

## Test plan

- [ ] Merge this PR
- [ ] Confirm the next release-please run bumps the Info.plist value (it'll appear in the auto-generated release PR's diff)
- [ ] Tag a release
- [ ] Build the resulting `stack-nudge.app` and verify `defaults read /path/to/stack-nudge.app/Contents/Info CFBundleShortVersionString` matches the new tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)