### PR TITLE
fix(ci): manual workflow_dispatch fallback for release.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,17 @@ jobs:
       # When the Release PR is merged, this action creates the git tag (vX.Y.Z)
       # and the GitHub Release. The release.yml workflow then triggers on that
       # tag to attach prebuilt asset bundles.
+      #
+      # `token` must be a Personal Access Token (RELEASE_PAT), NOT the
+      # default GITHUB_TOKEN. GitHub deliberately doesn't fire downstream
+      # workflows from pushes made with the default token — including the
+      # tag push release-please-action makes when the Release PR merges.
+      # That left v1.7.0 sitting in Releases with zero assets because the
+      # tagged-release `Build and Release` workflow never observed the tag.
+      # A PAT with `Contents: read/write` makes the tag push look like a
+      # normal user push, which DOES fire downstream workflows.
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PAT }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,19 +16,11 @@ jobs:
       # Watches conventional commits on main, opens (and updates) a Release PR
       # that bumps .release-please-manifest.json + regenerates CHANGELOG.md.
       # When the Release PR is merged, this action creates the git tag (vX.Y.Z)
-      # and the GitHub Release. The release.yml workflow then triggers on that
-      # tag to attach prebuilt asset bundles.
-      #
-      # `token` must be a Personal Access Token (RELEASE_PAT), NOT the
-      # default GITHUB_TOKEN. GitHub deliberately doesn't fire downstream
-      # workflows from pushes made with the default token — including the
-      # tag push release-please-action makes when the Release PR merges.
-      # That left v1.7.0 sitting in Releases with zero assets because the
-      # tagged-release `Build and Release` workflow never observed the tag.
-      # A PAT with `Contents: read/write` makes the tag push look like a
-      # normal user push, which DOES fire downstream workflows.
+      # and the GitHub Release. release.yml then attaches signed/notarized
+      # artifacts — either automatically when the next tag is created OR via
+      # its manual `workflow_dispatch` trigger as a fallback when the tag push
+      # didn't cascade (default GITHUB_TOKEN suppresses downstream triggers).
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.RELEASE_PAT }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,21 @@ name: Build and Release
 # trouble than two separate artifacts.
 
 on:
+  # Auto-fire when a vX.Y.Z tag is pushed by a user account.
   push:
     tags:
       - 'v*'
+  # Manual fallback for tags pushed by release-please-action — the default
+  # GITHUB_TOKEN deliberately suppresses downstream workflow triggers, so
+  # release-please-created tags don't auto-fire the `push: tags: v*` path
+  # above. Re-running this workflow from Actions → "Run workflow" picks up
+  # any existing tag and attaches its artifacts to the matching release.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g. v1.7.0). Must already exist as a Release.'
+        required: true
+        type: string
 
 jobs:
   release:
@@ -30,9 +42,18 @@ jobs:
       # Resources/venv/. Local dev iteration leaves this unset for speed.
       STACKNUDGE_BUNDLE_VENV: "1"
       KEYCHAIN: build-stack-nudge.keychain
+      # Tag we're operating on, regardless of trigger source. For push
+      # events this resolves to the tag that fired the workflow; for
+      # workflow_dispatch it's the input the user typed in the UI.
+      TARGET_TAG: ${{ inputs.tag || github.ref_name }}
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Check out the actual tag's commit rather than the workflow's
+          # ref, so workflow_dispatch builds the same source the original
+          # tag pointed at (not whatever HEAD on main looks like now).
+          ref: ${{ inputs.tag || github.ref }}
 
       # Stamp the tag's version into Info.plist so the bundled app
       # advertises the right version regardless of what's checked into
@@ -40,7 +61,7 @@ jobs:
       # sync too, but stamping at build time is belt-and-braces.
       - name: Stamp version from tag
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${TARGET_TAG#v}"
           /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" panel/Info.plist
           /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $VERSION" panel/Info.plist
 
@@ -118,7 +139,7 @@ jobs:
       - name: Package ${{ matrix.arch }}
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${TARGET_TAG#v}"
           ARTIFACT="stack-nudge-${VERSION}-macos-${{ matrix.arch }}.tar.gz"
           # Tarball wraps just the .app — it's now self-contained
           # (Bootstrap.swift owns the install side on first launch).
@@ -130,8 +151,12 @@ jobs:
       # release-please creates the GitHub Release before this workflow
       # runs, so action-gh-release attaches assets to the existing
       # release rather than creating a duplicate.
+      # tag_name explicit so workflow_dispatch attaches to the right release
+      # — without it action-gh-release uses github.ref which is "main"-ish
+      # for manual dispatches and fails to find a matching release.
       - uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ env.TARGET_TAG }}
           files: |
             stack-nudge-*-macos-${{ matrix.arch }}.tar.gz
             stack-nudge-*-macos-${{ matrix.arch }}.tar.gz.sha256


### PR DESCRIPTION
## Summary

v1.7.0 landed in Releases with **zero assets** because the tag push made by `release-please-action` (default \`GITHUB_TOKEN\`) doesn't fire downstream tag-keyed workflows. That's GitHub's deliberate anti-loop guard.

A PAT-based fix was tried in the first commit but needs StackOneHQ org-level approval to issue, which would block this. The second commit replaces it with a **manual \`workflow_dispatch\` fallback** — no secret needed, no org approval needed.

## How it works

After release-please opens + merges a Release PR, the next tag (eg \`v1.7.1\`) will exist but may have no assets. To populate:

1. Go to **Actions → Build and Release → "Run workflow"**.
2. Type the tag name (eg \`v1.7.1\`).
3. The workflow checks out that tag's commit, builds + signs + notarizes both arch artifacts, and attaches them to the matching release.

The auto path (push of a user-pushed tag → workflow fires) still works for any future tags pushed by an account rather than the actions bot. The branch factors the tag handling through a \`TARGET_TAG\` env so both trigger sources go through the same logic.

## Backfilling v1.7.0

Once this lands on main, dispatch the workflow against \`v1.7.0\` once and the existing release will get its two \`.tar.gz\` artifacts.

## Future: full automation

If/when the StackOneHQ org approves a fine-grained PAT, we can plumb it through release-please-action and remove the manual dispatch step. The dispatch path is harmless to keep around as an escape hatch.

## Test plan
- [ ] Merge this PR (will be a v1.7.1 patch bump via release-please)
- [ ] Dispatch \`Build and Release\` against \`v1.7.0\` to backfill assets
- [ ] When the release-please PR for v1.7.1 lands, dispatch again against \`v1.7.1\` and confirm assets attach

🤖 Generated with [Claude Code](https://claude.com/claude-code)