### PR TITLE
feat(): use cmd left and right to change panels

### DIFF
--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -1129,7 +1129,8 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         }
 
         // Cmd+1/2/3/4 jump directly between modes; the in-panel tab strip is
-        // the discoverable mouse equivalent.
+        // the discoverable mouse equivalent. Cmd+←/→ steps through the same
+        // ordered tab list without wrapping.
         if cmdOnly {
             switch event.keyCode {
             case KeyCode.one:
@@ -1140,6 +1141,15 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                 nav.mode = .usage; return true
             case KeyCode.four:
                 nav.mode = .settings; return true
+            case KeyCode.leftArrow, KeyCode.rightArrow:
+                let tabs: [PanelMode] = [.events, .sessions, .usage, .settings]
+                if let idx = tabs.firstIndex(of: nav.mode) {
+                    let next = event.keyCode == KeyCode.leftArrow ? idx - 1 : idx + 1
+                    if tabs.indices.contains(next) {
+                        nav.mode = tabs[next]
+                    }
+                    return true
+                }
             default:
                 break
             }


### PR DESCRIPTION
## Summary

Adds Cmd+← / Cmd+→ as an alternative to Cmd+1-4 for stepping between the four main panel tabs (Events, Sessions, Usage, Settings).

## Changes

- `panel/Panel.swift`: extend the Cmd-only keyDown branch to handle `KeyCode.leftArrow` / `KeyCode.rightArrow`, stepping one tab left/right through `[.events, .sessions, .usage, .settings]`. No wrap; only fires when the current mode is one of those four (bootstrap, phrases, update flows are unaffected).

## Testing

- `swift build` — clean.
- Manual: `make reload`, opened panel, confirmed Cmd+→ cycles Events→Sessions→Usage→Settings and stops; Cmd+← walks back and stops at Events; Cmd+1-4 still jumps directly; arrows from bootstrap/phrases do nothing.

## Related issues

—