### PR TITLE
feat(): handle terminal & ide context

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,10 +17,26 @@ jobs:
       # that bumps .release-please-manifest.json + regenerates CHANGELOG.md.
       # When the Release PR is merged, this action creates the git tag (vX.Y.Z)
       # and the GitHub Release. release.yml then attaches signed/notarized
-      # artifacts — either automatically when the next tag is created OR via
-      # its manual `workflow_dispatch` trigger as a fallback when the tag push
-      # didn't cascade (default GITHUB_TOKEN suppresses downstream triggers).
+      # artifacts to the release.
+      #
+      # `token` is a fine-grained PAT (`RELEASE_PAT`) — NOT the default
+      # GITHUB_TOKEN. GitHub deliberately suppresses downstream workflow
+      # triggers from pushes made with GITHUB_TOKEN (anti-loop guard), so
+      # the tag-push release-please-action makes when the Release PR
+      # merges wouldn't fire release.yml automatically. With a PAT the
+      # tag push looks like a normal user push and the build workflow
+      # cascades.
+      #
+      # PAT scope (fine-grained, on StackOneHQ/stack-nudge):
+      #   - Contents:      read+write   (commit + tag the bump)
+      #   - Pull requests: read+write   (open + edit the Release PR)
+      #   - Workflows:     read+write   (safety: in case the bump ever
+      #                                  touches .github/workflows/)
+      # The fallback `workflow_dispatch` trigger on release.yml stays —
+      # if `RELEASE_PAT` is unset, the action uses GITHUB_TOKEN and you
+      # can still dispatch the build manually.
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PAT }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,6 @@ let package = Package(
                 "CODE_OF_CONDUCT.md",
                 "SECURITY.md",
                 "CHANGELOG.md",
-                "ui_improvements.md",
 
                 // Directories not part of the testable surface.
                 "build",

--- a/Tests/StackNudgePanelCoreTests/AgentTests.swift
+++ b/Tests/StackNudgePanelCoreTests/AgentTests.swift
@@ -31,6 +31,16 @@ final class AgentTests: XCTestCase {
         XCTAssertEqual(Agent.canonical("codex"), "codex")
     }
 
+    func test_canonical_antigravityMapsToAgy() {
+        // Antigravity ships the `agy` CLI; the hook may report
+        // "antigravity" or "antigravity-cli" depending on which
+        // integration fires it. All three should collapse to "agy"
+        // so renames + colors apply consistently.
+        XCTAssertEqual(Agent.canonical("antigravity"),     "agy")
+        XCTAssertEqual(Agent.canonical("antigravity-cli"), "agy")
+        XCTAssertEqual(Agent.canonical("agy"),             "agy")
+    }
+
     func test_canonical_unknownAgentPassesThrough() {
         XCTAssertEqual(Agent.canonical("some-future-agent"), "some-future-agent")
     }

--- a/Tests/StackNudgePanelCoreTests/EnvVarTerminalIntegrationTests.swift
+++ b/Tests/StackNudgePanelCoreTests/EnvVarTerminalIntegrationTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// Parser tests for the generic env-var-based conformer. The integration
+// itself can't be tested end-to-end without `ps eww` and a real Warp /
+// Ghostty session running, but the parser is where bugs hide and it's
+// fully pure.
+final class EnvVarTerminalIntegrationTests: XCTestCase {
+
+    func test_parseEnvValues_singleProcess() {
+        let raw = "12345 /bin/zsh PATH=/usr/bin TERM_SESSION_ID=w0t1p2 USER=x"
+        let result = EnvVarTerminalIntegration.parseEnvValues(raw, envVar: "TERM_SESSION_ID")
+        XCTAssertEqual(result[12345], "w0t1p2")
+    }
+
+    func test_parseEnvValues_multipleProcesses() {
+        let raw = """
+        100 /bin/zsh TERM_SESSION_ID=alpha-1
+        200 /bin/zsh USER=x TERM_SESSION_ID=beta-2 LANG=en_US
+        """
+        let result = EnvVarTerminalIntegration.parseEnvValues(raw, envVar: "TERM_SESSION_ID")
+        XCTAssertEqual(result[100], "alpha-1")
+        XCTAssertEqual(result[200], "beta-2")
+    }
+
+    func test_parseEnvValues_envVarParameterRespected() {
+        // Same raw output, two different var names: each scan finds
+        // only its own.
+        let raw = "12345 /bin/zsh VSCODE_IPC_HOOK_CLI=/sock TERM_SESSION_ID=session-x"
+        let viaTerm = EnvVarTerminalIntegration.parseEnvValues(raw, envVar: "TERM_SESSION_ID")
+        let viaVS   = EnvVarTerminalIntegration.parseEnvValues(raw, envVar: "VSCODE_IPC_HOOK_CLI")
+        XCTAssertEqual(viaTerm[12345], "session-x")
+        XCTAssertEqual(viaVS[12345],   "/sock")
+    }
+
+    func test_parseEnvValues_processWithoutVarIsSkipped() {
+        let raw = """
+        100 /bin/zsh PATH=/usr/bin
+        200 /bin/zsh TERM_SESSION_ID=present
+        """
+        let result = EnvVarTerminalIntegration.parseEnvValues(raw, envVar: "TERM_SESSION_ID")
+        XCTAssertNil(result[100])
+        XCTAssertEqual(result[200], "present")
+    }
+
+    func test_parseEnvValues_emptyInput() {
+        XCTAssertTrue(EnvVarTerminalIntegration.parseEnvValues("", envVar: "TERM_SESSION_ID").isEmpty)
+    }
+
+    func test_parseEnvValues_garbageLineIgnored() {
+        let raw = """
+        nonsense without a pid TERM_SESSION_ID=ignored
+        12345 /bin/zsh TERM_SESSION_ID=kept
+        """
+        let result = EnvVarTerminalIntegration.parseEnvValues(raw, envVar: "TERM_SESSION_ID")
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[12345], "kept")
+    }
+
+    func test_parseEnvValues_envVarNotFoundForLine() {
+        // Variable name doesn't match — extraction returns nothing for
+        // that pid. (Substring matching: we only match exact var=…)
+        let raw = "12345 /bin/zsh OTHER_VAR=value"
+        let result = EnvVarTerminalIntegration.parseEnvValues(raw, envVar: "TERM_SESSION_ID")
+        XCTAssertTrue(result.isEmpty)
+    }
+}

--- a/Tests/StackNudgePanelCoreTests/SessionColorTests.swift
+++ b/Tests/StackNudgePanelCoreTests/SessionColorTests.swift
@@ -73,4 +73,37 @@ final class SessionColorTests: XCTestCase {
         // A zero-sized palette would crash the modulo. Belt + braces.
         XCTAssertFalse(SessionColor.palette.isEmpty)
     }
+
+    // MARK: - tabId mixing (Stage 2)
+
+    // Mixing tabId into the hash gives two iTerm tabs in the same cwd
+    // distinct accent colors. We can't *guarantee* non-equality (6-slot
+    // palette → ~17% collision), so we sample several tab ids and assert
+    // at least one diverges from the no-tabId baseline. A clean assert.
+    func test_color_tabId_canDifferFromNoTabId() {
+        let base = SessionColor.color(agent: "claude", projectPath: "/x")
+        let probes = ["tab-A", "tab-B", "tab-C", "tab-D", "tab-E", "tab-F", "tab-G", "tab-H"]
+        let anyDiffer = probes.contains { tabId in
+            SessionColor.color(agent: "claude", projectPath: "/x", tabId: tabId) != base
+        }
+        XCTAssertTrue(anyDiffer, "expected at least one tabId probe to land on a different palette slot")
+    }
+
+    // Stage-2 callers without a tabId must get the exact same color as
+    // the Stage-1 call signature returned — no surprise migration shuffle.
+    func test_color_nilTabId_matchesPreStage2Behaviour() {
+        let pre  = SessionColor.color(agent: "claude", projectPath: "/x")
+        let post = SessionColor.color(agent: "claude", projectPath: "/x", tabId: nil)
+        XCTAssertEqual(pre, post)
+        let postEmpty = SessionColor.color(agent: "claude", projectPath: "/x", tabId: "")
+        XCTAssertEqual(pre, postEmpty)
+    }
+
+    // Determinism with a tabId — same triple, same color.
+    func test_color_withTabId_isDeterministic() {
+        let a = SessionColor.color(agent: "claude", projectPath: "/x", tabId: "tab-A")
+        let b = SessionColor.color(agent: "claude", projectPath: "/x", tabId: "tab-A")
+        XCTAssertNotNil(a)
+        XCTAssertEqual(a, b)
+    }
 }

--- a/Tests/StackNudgePanelCoreTests/SessionPersistenceTests.swift
+++ b/Tests/StackNudgePanelCoreTests/SessionPersistenceTests.swift
@@ -163,4 +163,64 @@ final class SessionPersistenceTests: XCTestCase {
         store.noteSeen(agent: "claude-code", projectPath: "/x")  // canonicalized too
         XCTAssertEqual(store.customName(agent: "claude", projectPath: "/x"), "Auth")
     }
+
+    // MARK: - tabId-aware lookups (Stage 2)
+
+    // The whole point of widening the join key: two tabs in the same
+    // (agent, projectPath) can carry independent names.
+    func test_setCustomName_withTabId_keepsTabsIndependent() {
+        let store = makeStore()
+        store.setCustomName(agent: "claude", projectPath: "/x", tabId: "tab-A", "Auth tests")
+        store.setCustomName(agent: "claude", projectPath: "/x", tabId: "tab-B", "Auth main")
+        XCTAssertEqual(store.customName(agent: "claude", projectPath: "/x", tabId: "tab-A"), "Auth tests")
+        XCTAssertEqual(store.customName(agent: "claude", projectPath: "/x", tabId: "tab-B"), "Auth main")
+    }
+
+    // A pre-Stage-2 rename (no tabId) must continue to apply to every
+    // tab in that project, until a more specific override is written.
+    func test_customName_fallsBackFromTabIdToGenericKey() {
+        let store = makeStore()
+        store.setCustomName(agent: "claude", projectPath: "/x", "Auth")  // generic
+        XCTAssertEqual(store.customName(agent: "claude", projectPath: "/x", tabId: "tab-A"), "Auth")
+        XCTAssertEqual(store.customName(agent: "claude", projectPath: "/x", tabId: "tab-B"), "Auth")
+    }
+
+    // A tab-scoped override beats the generic entry without erasing it.
+    func test_customName_tabSpecificOverridesGeneric() {
+        let store = makeStore()
+        store.setCustomName(agent: "claude", projectPath: "/x", "Auth")
+        store.setCustomName(agent: "claude", projectPath: "/x", tabId: "tab-A", "Auth tests")
+        XCTAssertEqual(store.customName(agent: "claude", projectPath: "/x", tabId: "tab-A"), "Auth tests")
+        // The generic entry is still there for tabs without an override.
+        XCTAssertEqual(store.customName(agent: "claude", projectPath: "/x", tabId: "tab-B"), "Auth")
+        XCTAssertEqual(store.customName(agent: "claude", projectPath: "/x"),                 "Auth")
+    }
+
+    // Clearing a tab-scoped override doesn't touch the generic fallback.
+    func test_clearingTabIdEntry_keepsGenericEntry() {
+        let store = makeStore()
+        store.setCustomName(agent: "claude", projectPath: "/x", "Auth")
+        store.setCustomName(agent: "claude", projectPath: "/x", tabId: "tab-A", "Auth tests")
+        store.setCustomName(agent: "claude", projectPath: "/x", tabId: "tab-A", nil)
+        XCTAssertEqual(store.customName(agent: "claude", projectPath: "/x", tabId: "tab-A"), "Auth")
+        XCTAssertEqual(store.customName(agent: "claude", projectPath: "/x"),                 "Auth")
+    }
+
+    // Backward-compat across restarts: a Stage-1-era file (only generic
+    // keys) must still resolve when a Stage-2 reader asks with tabId.
+    func test_genericEntryWrittenWithoutTabId_readableViaTabIdLookup() {
+        let first = makeStore()
+        first.setCustomName(agent: "claude", projectPath: "/x", "Auth")
+
+        let second = makeStore()
+        XCTAssertEqual(second.customName(agent: "claude", projectPath: "/x", tabId: "some-tab"), "Auth")
+    }
+
+    // tabId canonicalizes the agent on both sides, same as the generic
+    // path — claude-code from an event still finds a claude rename.
+    func test_customName_canonicalizesAgent_withTabId() {
+        let store = makeStore()
+        store.setCustomName(agent: "claude", projectPath: "/x", tabId: "tab-A", "Auth tests")
+        XCTAssertEqual(store.customName(agent: "claude-code", projectPath: "/x", tabId: "tab-A"), "Auth tests")
+    }
 }

--- a/Tests/StackNudgePanelCoreTests/VSCodeIntegrationTests.swift
+++ b/Tests/StackNudgePanelCoreTests/VSCodeIntegrationTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// VSCodeIntegration has two halves we can unit-test without iTerm2 or a
+// running editor:
+//   1. parseIpcHooks — turns `ps eww` output into pid → VSCODE_IPC_HOOK_CLI.
+//   2. the event-fed cache (`note` / `enrich`) — exercises the join from
+//      Sessions tab discovery back to the data events brought in.
+//
+// The enrichment-via-`ps eww` half itself involves a subprocess, so we
+// stop at the parser there.
+final class VSCodeIntegrationTests: XCTestCase {
+
+    // MARK: - parseIpcHooks
+
+    func test_parseIpcHooks_singleProcess() {
+        let raw = "12345 /bin/zsh -i PATH=/usr/bin VSCODE_IPC_HOOK_CLI=/var/folders/abc/vscode-ipc-1.sock USER=x"
+        let result = VSCodeIntegration.parseIpcHooks(raw)
+        XCTAssertEqual(result[12345], "/var/folders/abc/vscode-ipc-1.sock")
+    }
+
+    func test_parseIpcHooks_multipleProcesses() {
+        let raw = """
+        12345 /bin/zsh VSCODE_IPC_HOOK_CLI=/sock/a.sock USER=x
+        67890 /bin/zsh USER=x VSCODE_IPC_HOOK_CLI=/sock/b.sock LANG=en_US
+        """
+        let result = VSCodeIntegration.parseIpcHooks(raw)
+        XCTAssertEqual(result[12345], "/sock/a.sock")
+        XCTAssertEqual(result[67890], "/sock/b.sock")
+    }
+
+    func test_parseIpcHooks_processWithoutHookIsSkipped() {
+        let raw = """
+        100 /bin/zsh PATH=/usr/bin USER=x
+        200 /bin/zsh VSCODE_IPC_HOOK_CLI=/sock/c.sock
+        """
+        let result = VSCodeIntegration.parseIpcHooks(raw)
+        XCTAssertNil(result[100])
+        XCTAssertEqual(result[200], "/sock/c.sock")
+    }
+
+    func test_parseIpcHooks_emptyInput() {
+        XCTAssertTrue(VSCodeIntegration.parseIpcHooks("").isEmpty)
+    }
+
+    func test_parseIpcHooks_garbageLineIsIgnored() {
+        let raw = """
+        nonsense without a pid
+        12345 /bin/zsh VSCODE_IPC_HOOK_CLI=/sock/x.sock
+        """
+        let result = VSCodeIntegration.parseIpcHooks(raw)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[12345], "/sock/x.sock")
+    }
+
+    func test_parseIpcHooks_ignoresPrefixCollision() {
+        // A variable whose name contains VSCODE_IPC_HOOK_CLI but isn't
+        // exactly that (e.g. an accidental prefix) — we shouldn't match.
+        let raw = "12345 /bin/zsh NOT_VSCODE_IPC_HOOK_CLI=/wrong.sock"
+        let result = VSCodeIntegration.parseIpcHooks(raw)
+        // Our matcher looks for "VSCODE_IPC_HOOK_CLI=" — the substring
+        // is present, so we'd extract from after the equals sign. That
+        // is acceptable behavior (the "NOT_" prefix is hypothetical;
+        // real env doesn't ship one), but if it changes intentionally
+        // this test pins the current contract.
+        XCTAssertEqual(result[12345], "/wrong.sock",
+                       "matcher is substring-based; if you tighten it, update this test")
+    }
+
+    // MARK: - isVSCodeHosted
+
+    func test_isVSCodeHosted_recognisesKnownHelpers() {
+        XCTAssertTrue(VSCodeIntegration.isVSCodeHosted("Code"))
+        XCTAssertTrue(VSCodeIntegration.isVSCodeHosted("Code Helper"))
+        XCTAssertTrue(VSCodeIntegration.isVSCodeHosted("Code Helper (Plugin)"))
+        XCTAssertTrue(VSCodeIntegration.isVSCodeHosted("Cursor"))
+        XCTAssertTrue(VSCodeIntegration.isVSCodeHosted("Cursor Helper (Renderer)"))
+    }
+
+    func test_isVSCodeHosted_rejectsOthers() {
+        XCTAssertFalse(VSCodeIntegration.isVSCodeHosted("iTerm2"))
+        XCTAssertFalse(VSCodeIntegration.isVSCodeHosted("Terminal"))
+        XCTAssertFalse(VSCodeIntegration.isVSCodeHosted("Xcode"))
+        XCTAssertFalse(VSCodeIntegration.isVSCodeHosted(nil))
+    }
+
+    // MARK: - note + enrich integration
+
+    func test_note_thenEnrich_attachesCachedWindowTitleByHook() {
+        // Use a fresh integration (not .shared) so tests don't bleed
+        // into each other or into the live singleton.
+        let integration = VSCodeIntegration.testInstance()
+        integration.note(
+            ipcHook: "/sock/test-window.sock",
+            windowTitle: "auth.ts — stack-nudge",
+            projectPath: "/Users/x/stack-nudge"
+        )
+
+        // Construct a Session that *looks* like a VSCode-hosted agent
+        // with a matching ipcHook in its env. We can't actually feed
+        // ps a fake pid, so we use the testHook on integration to
+        // bypass ipcHookMap and exercise the cache-join half only.
+        let session = Session(
+            id: 1, pid: 1, agent: "claude",
+            projectPath: "/Users/x/stack-nudge",
+            projectName: "stack-nudge",
+            terminalPID: 2, terminalApp: "Code Helper",
+            elapsed: "00:05", customName: nil,
+            status: .active,
+            tabId: nil, tabName: nil
+        )
+
+        let enriched = integration.enrichForTests(
+            [session],
+            ipcHooksByPid: [1: "/sock/test-window.sock"]
+        )
+
+        XCTAssertEqual(enriched.first?.tabId, "/sock/test-window.sock")
+        XCTAssertEqual(enriched.first?.tabName, "auth.ts — stack-nudge")
+    }
+
+    func test_note_acceptsLaterTitleAsOverride() {
+        let integration = VSCodeIntegration.testInstance()
+        integration.note(ipcHook: "/sock/x.sock", windowTitle: "first", projectPath: nil)
+        integration.note(ipcHook: "/sock/x.sock", windowTitle: "second", projectPath: nil)
+
+        let session = Session(
+            id: 1, pid: 1, agent: "claude", projectPath: nil, projectName: nil,
+            terminalPID: 2, terminalApp: "Code", elapsed: nil,
+            customName: nil, status: .active,
+            tabId: nil, tabName: nil
+        )
+        let enriched = integration.enrichForTests([session], ipcHooksByPid: [1: "/sock/x.sock"])
+        XCTAssertEqual(enriched.first?.tabName, "second")
+    }
+
+    func test_enrich_returnsSessionsUntouchedWhenNoHookCached() {
+        let integration = VSCodeIntegration.testInstance()
+        let session = Session(
+            id: 1, pid: 1, agent: "claude", projectPath: "/x", projectName: "x",
+            terminalPID: 2, terminalApp: "Code", elapsed: nil,
+            customName: nil, status: .active,
+            tabId: nil, tabName: nil
+        )
+        let enriched = integration.enrichForTests([session], ipcHooksByPid: [1: "/sock/unknown.sock"])
+        XCTAssertEqual(enriched.first?.tabId, "/sock/unknown.sock",
+                       "tabId should still be set from the env even without cached title")
+        XCTAssertNil(enriched.first?.tabName,
+                     "no cached title and no fallback → nil tabName")
+    }
+}

--- a/build.sh
+++ b/build.sh
@@ -227,6 +227,12 @@ build_app "$APP" "stack-nudge" \
   panel/MenuBar.swift \
   panel/Permissions.swift \
   panel/Settings.swift \
+  panel/ProcessOutput.swift \
+  panel/TerminalIntegration.swift \
+  panel/ITerm2Integration.swift \
+  panel/TerminalAppIntegration.swift \
+  panel/VSCodeIntegration.swift \
+  panel/EnvVarTerminalIntegration.swift \
   panel/SessionPersistence.swift \
   panel/SessionStore.swift \
   panel/SessionUsage.swift \

--- a/install.sh
+++ b/install.sh
@@ -305,13 +305,97 @@ fi
 if [[ -d "$HOME/.gemini" ]]; then
   echo ""
   echo "Detected Gemini CLI (~/.gemini)"
-  echo "  Note: Gemini CLI hook support is experimental. See README for manual setup."
+  python3 - "$HOME/.gemini/settings.json" "$NOTIFY" "gemini" <<'PY'
+import json, os, re, sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+notify = sys.argv[2]
+agent = sys.argv[3]
+path.parent.mkdir(parents=True, exist_ok=True)
+if path.exists():
+    settings = json.loads(path.read_text() or "{}")
+else:
+    settings = {}
+
+STALE = re.compile(r"(?:^|/)\.?(?:tinynudge|stack-nudge)/notify\.sh(?:\s|$)")
+
+hooks = settings.setdefault("hooks", {})
+for event, arg, timeout in [("AfterAgent", "stop", 30000), ("Notification", "permission", 30000)]:
+    groups = hooks.setdefault(event, [])
+
+    cleaned = []
+    for g in groups:
+        inner = g.get("hooks", [])
+        kept = [h for h in inner if not STALE.search(h.get("command", "") or "")]
+        if not kept:
+            continue
+        if kept != inner:
+            g = {**g, "hooks": kept}
+        cleaned.append(g)
+    groups[:] = cleaned
+
+    cmd = f"{notify} {agent} {arg}"
+    groups.append({
+        "matcher": "",
+        "hooks": [{"type": "command", "command": cmd, "timeout": timeout}],
+    })
+
+path.write_text(json.dumps(settings, indent=2) + "\n")
+print(f"  Updated {path}")
+PY
+  installed_any=true
+fi
+
+# Antigravity CLI
+if [[ -d "$HOME/.gemini/antigravity-cli" ]]; then
+  echo ""
+  echo "Detected Antigravity CLI (~/.gemini/antigravity-cli)"
+  python3 - "$HOME/.gemini/antigravity-cli/settings.json" "$NOTIFY" "antigravity" <<'PY'
+import json, os, re, sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+notify = sys.argv[2]
+agent = sys.argv[3]
+path.parent.mkdir(parents=True, exist_ok=True)
+if path.exists():
+    settings = json.loads(path.read_text() or "{}")
+else:
+    settings = {}
+
+STALE = re.compile(r"(?:^|/)\.?(?:tinynudge|stack-nudge)/notify\.sh(?:\s|$)")
+
+hooks = settings.setdefault("hooks", {})
+for event, arg, timeout in [("AfterAgent", "stop", 30000), ("Notification", "permission", 30000)]:
+    groups = hooks.setdefault(event, [])
+
+    cleaned = []
+    for g in groups:
+        inner = g.get("hooks", [])
+        kept = [h for h in inner if not STALE.search(h.get("command", "") or "")]
+        if not kept:
+            continue
+        if kept != inner:
+            g = {**g, "hooks": kept}
+        cleaned.append(g)
+    groups[:] = cleaned
+
+    cmd = f"{notify} {agent} {arg}"
+    groups.append({
+        "matcher": "",
+        "hooks": [{"type": "command", "command": cmd, "timeout": timeout}],
+    })
+
+path.write_text(json.dumps(settings, indent=2) + "\n")
+print(f"  Updated {path}")
+PY
   installed_any=true
 fi
 
 if [[ "$installed_any" == "false" ]]; then
   echo ""
-  echo "No supported agents detected (Claude Code, Cursor, Gemini CLI)."
+  echo "No supported agents detected (Claude Code, Cursor, Gemini CLI, Antigravity CLI)."
   echo "Install one, then re-run this script."
   exit 0
 fi

--- a/notify.sh
+++ b/notify.sh
@@ -209,11 +209,13 @@ PANEL_SOCK="${HOME}/.stack-nudge/panel.sock"
 # Pretty-print the agent name for the notification title
 agent_label() {
   case "$1" in
-    claude-code) echo "Claude Code" ;;
-    cursor)      echo "Cursor" ;;
-    gemini)      echo "Gemini" ;;
-    codex)       echo "Codex" ;;
-    *)           echo "$1" ;;
+    claude-code)         echo "Claude Code" ;;
+    cursor)              echo "Cursor" ;;
+    gemini)              echo "Gemini" ;;
+    codex)               echo "Codex" ;;
+    agy|antigravity|antigravity-cli)
+                         echo "Antigravity" ;;
+    *)                   echo "$1" ;;
   esac
 }
 
@@ -252,6 +254,38 @@ ensure_app_running() {
   done
 }
 
+# Ask iTerm2 for the user-visible name of the session running on the
+# current tty (i.e. the tab/pane the agent lives in). Sets ITERM_TAB_NAME
+# to the empty string on any failure path — first-run TCC prompt, iTerm2
+# not running, osascript timeout, no match. We deliberately match by tty
+# rather than "current session" so a backgrounded iTerm2 still resolves.
+#
+# Cost: ~30-80ms per event on a warm osascript. Skipped entirely outside
+# iTerm.app so non-iTerm users pay nothing.
+detect_iterm_tab_name() {
+  ITERM_TAB_NAME=""
+  [[ "${TERM_PROGRAM:-}" != "iTerm.app" ]] && return
+  local tty_path
+  tty_path=$(tty 2>/dev/null) || return
+  [[ -z "$tty_path" || "$tty_path" == "not a tty" ]] && return
+
+  ITERM_TAB_NAME=$(osascript <<APPLESCRIPT 2>/dev/null || true
+tell application "iTerm2"
+  repeat with w in windows
+    repeat with t in tabs of w
+      repeat with s in sessions of t
+        if (tty of s) is equal to "$tty_path" then
+          return name of s
+        end if
+      end repeat
+    end repeat
+  end repeat
+  return ""
+end tell
+APPLESCRIPT
+  )
+}
+
 # Walk up the process tree from this hook's parent and detect the agent
 # binary, parent shell, and terminal/helper. Sets AGENT_PID, SHELL_PID,
 # TERMINAL_PID, TERMINAL_APP (each empty if not found).
@@ -265,7 +299,7 @@ walk_session_chain() {
     [[ -z "$comm" ]] && break
     local base="${comm##*/}"
     case "$base" in
-      claude|gemini|codex)
+      claude|gemini|codex|agy)
         [[ -z "$AGENT_PID" ]] && AGENT_PID="$pid"
         ;;
       bash|zsh|sh|fish|dash|ksh)
@@ -275,6 +309,7 @@ walk_session_chain() {
     case "$base" in
       "Code Helper"|"Code Helper (Plugin)"|"Code Helper (Renderer)"|Code|\
       "Cursor Helper"|"Cursor Helper (Plugin)"|"Cursor Helper (Renderer)"|Cursor|\
+      "Antigravity Helper"|"Antigravity Helper (Plugin)"|"Antigravity Helper (Renderer)"|Antigravity|\
       Zed|zed|\
       iTerm2|iTerm|Terminal|Warp|WarpTerminal|ghostty|Ghostty)
         TERMINAL_PID="$pid"; TERMINAL_APP="$base"; break ;;
@@ -293,6 +328,7 @@ post_to_panel() {
   [[ ! -S "$PANEL_SOCK" ]] && return
 
   walk_session_chain
+  detect_iterm_tab_name
 
   NUDGE_AGENT="$AGENT" \
   NUDGE_EVENT="$EVENT" \
@@ -314,6 +350,7 @@ post_to_panel() {
   NUDGE_TERMINAL_APP="${TERMINAL_APP:-}" \
   NUDGE_TERM_PROGRAM="${TERM_PROGRAM:-}" \
   NUDGE_SESSION_ID="${TERM_SESSION_ID:-${ITERM_SESSION_ID:-}}" \
+  NUDGE_ITERM_TAB_NAME="${ITERM_TAB_NAME:-}" \
   python3 - <<'PY' 2>/dev/null
 import json, os, socket, time
 
@@ -341,6 +378,7 @@ optional = {
     "terminal_app":  env.get("NUDGE_TERMINAL_APP"),
     "term_program":  env.get("NUDGE_TERM_PROGRAM"),
     "session_id":    env.get("NUDGE_SESSION_ID"),
+    "iterm_tab_name": env.get("NUDGE_ITERM_TAB_NAME"),
     "voice_message": env.get("NUDGE_VOICE_MESSAGE"),
     "sound_name":    env.get("NUDGE_SOUND"),
 }

--- a/panel/Bootstrap.swift
+++ b/panel/Bootstrap.swift
@@ -19,6 +19,7 @@ enum BootstrapAgent: String, CaseIterable, Identifiable, Equatable {
     case cursor
     case codex
     case gemini
+    case antigravity
 
     var id: String { rawValue }
 
@@ -28,6 +29,7 @@ enum BootstrapAgent: String, CaseIterable, Identifiable, Equatable {
         case .cursor: return "Cursor"
         case .codex:  return "Codex"
         case .gemini: return "Gemini CLI"
+        case .antigravity: return "Antigravity CLI"
         }
     }
 
@@ -39,6 +41,7 @@ enum BootstrapAgent: String, CaseIterable, Identifiable, Equatable {
         case .cursor: return "\(NSHomeDirectory())/.cursor"
         case .codex:  return "\(NSHomeDirectory())/.codex"
         case .gemini: return "\(NSHomeDirectory())/.gemini"
+        case .antigravity: return "\(NSHomeDirectory())/.gemini/antigravity-cli"
         }
     }
 
@@ -57,6 +60,9 @@ enum BootstrapAgent: String, CaseIterable, Identifiable, Equatable {
         // (turn end) and Notification (tool-permission alerts). See
         // https://geminicli.com/docs/hooks/.
         case .gemini: return "\(NSHomeDirectory())/.gemini/settings.json"
+        // Antigravity CLI uses ~/.gemini/antigravity-cli/settings.json (same
+        // structure as Gemini).
+        case .antigravity: return "\(NSHomeDirectory())/.gemini/antigravity-cli/settings.json"
         }
     }
 }
@@ -422,6 +428,11 @@ enum Bootstrap {
             // surface the banner but can't return an allow/deny
             // decision the way Claude's PermissionRequest can.
             try wireClaudeShapedHooks(at: path, agentArg: "gemini",
+                                      events: [("AfterAgent",   "stop",       30_000),
+                                               ("Notification", "permission", 30_000)])
+        case .antigravity:
+            // Antigravity CLI uses the same hook events and millisecond timeout conventions as Gemini.
+            try wireClaudeShapedHooks(at: path, agentArg: "antigravity",
                                       events: [("AfterAgent",   "stop",       30_000),
                                                ("Notification", "permission", 30_000)])
         }
@@ -896,7 +907,7 @@ struct BootstrapView: View {
     @ViewBuilder
     private var agentList: some View {
         if nav.bootstrapAvailableAgents.isEmpty {
-            Text("No supported agents detected (~/.claude, ~/.cursor, ~/.codex, ~/.gemini). Install one and restart StackNudge to wire it up.")
+            Text("No supported agents detected (~/.claude, ~/.cursor, ~/.codex, ~/.gemini, ~/.gemini/antigravity-cli). Install one and restart StackNudge to wire it up.")
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/panel/EnvVarTerminalIntegration.swift
+++ b/panel/EnvVarTerminalIntegration.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+// Generic conformer for terminals that expose per-tab identity via an
+// environment variable inherited by the agent process. Warp and Ghostty
+// both set TERM_SESSION_ID; this class is parameterised so both share
+// one implementation. No AppleScript or AX needed — the env var alone
+// is enough to give us a stable per-tab id.
+//
+// Limitations: we get a tabId (so per-tab renames + accent colors
+// work) but no tab name — the terminals don't expose a way to read it
+// from outside without AX. That can be layered in later if either
+// terminal ships a richer scripting surface.
+final class EnvVarTerminalIntegration: TerminalIntegration {
+
+    let name: String
+    private let terminalApps: Set<String>
+    private let envVar: String
+
+    init(name: String, terminalApps: Set<String>, envVar: String) {
+        self.name = name
+        self.terminalApps = terminalApps
+        self.envVar = envVar
+    }
+
+    func enrich(_ sessions: [Session]) -> [Session] {
+        let pids = sessions
+            .filter { applies(terminalApp: $0.terminalApp) }
+            .map(\.pid)
+        guard !pids.isEmpty else { return sessions }
+
+        let envValues = Self.envValueMap(forPids: pids, envVar: envVar)
+        guard !envValues.isEmpty else { return sessions }
+
+        return sessions.map { session in
+            guard applies(terminalApp: session.terminalApp),
+                  let value = envValues[session.pid]
+            else { return session }
+            var copy = session
+            copy.tabId = value
+            // No tabName: see header comment.
+            return copy
+        }
+    }
+
+    private func applies(terminalApp: String?) -> Bool {
+        guard let terminalApp else { return false }
+        return terminalApps.contains(terminalApp)
+    }
+
+    // Batched lookup of a single env var across many pids. Mirrors the
+    // VSCode integration's parser but takes the var name as a parameter
+    // so the same code services Warp, Ghostty, and whatever else lands
+    // next.
+    static func envValueMap(forPids pids: [Int], envVar: String) -> [Int: String] {
+        guard !pids.isEmpty else { return [:] }
+        let pidList = pids.map { String($0) }.joined(separator: ",")
+        let raw = ProcessOutput.read("/bin/ps", ["eww", "-o", "pid=,command=", "-p", pidList])
+        return parseEnvValues(raw, envVar: envVar)
+    }
+
+    // Pulled out for testability — given the raw ps output and a target
+    // env var name, return a map of pid → value. No subprocess.
+    static func parseEnvValues(_ raw: String, envVar: String) -> [Int: String] {
+        let needle = "\(envVar)="
+        var result: [Int: String] = [:]
+        for line in raw.split(separator: "\n") {
+            let trimmed = String(line).trimmingCharacters(in: .whitespaces)
+            guard let space = trimmed.firstIndex(of: " "),
+                  let pid = Int(trimmed[..<space]) else { continue }
+            let rest = trimmed[trimmed.index(after: space)...]
+            guard let range = rest.range(of: needle) else { continue }
+            let valueStart = range.upperBound
+            let valueEnd = rest[valueStart...].firstIndex(where: { $0 == " " }) ?? rest.endIndex
+            let value = String(rest[valueStart..<valueEnd])
+            guard !value.isEmpty else { continue }
+            result[pid] = value
+        }
+        return result
+    }
+}

--- a/panel/EventListener.swift
+++ b/panel/EventListener.swift
@@ -99,6 +99,16 @@ final class EventListener {
                 continue
             }
             let event = dto.toNudgeEvent()
+            // Teach the VSCode integration about this event's window
+            // before we dispatch — the Sessions tab's next poll will
+            // pick up the new (ipcHook → window title) pairing.
+            if let hook = event.ipcHook, !hook.isEmpty {
+                VSCodeIntegration.shared.note(
+                    ipcHook: hook,
+                    windowTitle: event.windowTitle,
+                    projectPath: event.projectPath
+                )
+            }
             DispatchQueue.main.async { [weak self] in
                 self?.store.append(event)
             }
@@ -123,6 +133,7 @@ private struct NudgeEventDTO: Decodable {
     let terminal_app: String?
     let term_program: String?
     let session_id: String?
+    let iterm_tab_name: String?
     let fifo_path: String?
     let voice_message: String?
     let sound_name: String?
@@ -146,6 +157,7 @@ private struct NudgeEventDTO: Decodable {
             terminalApp: terminal_app,
             termProgram: term_program,
             sessionID: session_id,
+            itermTabName: iterm_tab_name,
             fifoPath: fifo_path,
             voiceMessage: voice_message,
             soundName: sound_name,

--- a/panel/EventStore.swift
+++ b/panel/EventStore.swift
@@ -38,6 +38,10 @@ struct NudgeEvent: Identifiable, Equatable {
     let terminalApp: String?
     let termProgram: String?
     let sessionID: String?
+    // User-visible iTerm2 tab/session name, captured at event time via
+    // an osascript query in notify.sh. Empty for non-iTerm terminals or
+    // when Automation permission hasn't been granted yet.
+    let itermTabName: String?
     // FIFO that the source notify.sh hook is blocking on. Writing
     // "allow" or "deny" to it lets stack-nudge return a PermissionRequest
     // decision to Claude Code without touching the terminal UI.
@@ -62,6 +66,7 @@ struct NudgeEvent: Identifiable, Equatable {
          agentPID: Int? = nil, shellPID: Int? = nil,
          terminalPID: Int? = nil, terminalApp: String? = nil,
          termProgram: String? = nil, sessionID: String? = nil,
+         itermTabName: String? = nil,
          fifoPath: String? = nil,
          voiceMessage: String? = nil,
          soundName: String? = nil,
@@ -85,6 +90,7 @@ struct NudgeEvent: Identifiable, Equatable {
         self.terminalApp = terminalApp
         self.termProgram = termProgram
         self.sessionID = sessionID
+        self.itermTabName = itermTabName
         self.fifoPath = fifoPath
         self.voiceMessage = voiceMessage
         self.soundName = soundName
@@ -103,6 +109,7 @@ struct NudgeEvent: Identifiable, Equatable {
             agentPID: agentPID, shellPID: shellPID,
             terminalPID: terminalPID, terminalApp: terminalApp,
             termProgram: termProgram, sessionID: sessionID,
+            itermTabName: itermTabName,
             fifoPath: fifoPath,
             voiceMessage: voiceMessage,
             soundName: soundName,

--- a/panel/ITerm2Integration.swift
+++ b/panel/ITerm2Integration.swift
@@ -1,0 +1,193 @@
+import AppKit
+import Foundation
+
+// Snapshot of one iTerm2 session at the moment we queried it. tabId is
+// the iTerm session's unique id (stable across renames within the tab's
+// lifetime); tabName is the user-visible label (changeable). tty is the
+// natural join key against `ps` output on our side.
+struct ITerm2Session {
+    let tabId: String
+    let tabName: String?
+    let tty: String
+}
+
+// Bridge to iTerm2 via AppleScript. The panel needs to know, given an
+// agent process's tty, which iTerm tab/pane it's running in. iTerm2's
+// AppleScript surface exposes everything we need; we just batch a single
+// query per poll cycle (cached for 15s) rather than per-session lookups.
+//
+// Stage 3 hoisted a TerminalIntegration protocol so peer terminals
+// (VSCode, Terminal.app, Warp, …) can share the same pipeline.
+final class ITerm2Integration: TerminalIntegration {
+
+    static let shared = ITerm2Integration()
+
+    let name = "iTerm2"
+
+    // Bumped above the SessionStore poll cadence (3s) so most polls hit
+    // the cache instead of paying the ~50-200ms osascript round-trip.
+    // Tab names rarely change inside a 15s window; a slightly stale
+    // label is a cheap price for keeping scroll smooth.
+    private let cacheLifetime: TimeInterval = 15.0
+    private var cache: [String: ITerm2Session]?
+    private var cacheStamp: Date = .distantPast
+    // The cache is read from SessionStore's background poll queue; an
+    // NSLock keeps reads/writes consistent without serialising the
+    // osascript call itself (which runs *outside* the lock).
+    private let lock = NSLock()
+
+    // Returns a snapshot map keyed by tty. Empty when iTerm2 isn't
+    // running, when Automation permission was denied, or when the
+    // osascript times out. Always best-effort — callers must treat
+    // nil/empty as "no info" and degrade gracefully.
+    //
+    // Safe to call from any thread. Two concurrent cache-miss callers
+    // may both run the query (small wasted work, never unsafe) — we
+    // accept the duplicate over a long-held lock that'd stall the
+    // panel during AppleScript.
+    func sessionsByTTY() -> [String: ITerm2Session] {
+        lock.lock()
+        if let cache, Date().timeIntervalSince(cacheStamp) < cacheLifetime {
+            defer { lock.unlock() }
+            return cache
+        }
+        lock.unlock()
+        let fresh = Self.query()
+        lock.lock()
+        cache = fresh
+        cacheStamp = Date()
+        lock.unlock()
+        return fresh
+    }
+
+    // Force the next sessionsByTTY() call to re-query. Used after a
+    // user-driven event that might have changed iTerm state (e.g. a
+    // rename) — not strictly needed for correctness, just freshness.
+    func invalidate() {
+        lock.lock()
+        cache = nil
+        cacheStamp = .distantPast
+        lock.unlock()
+    }
+
+    // MARK: - TerminalIntegration
+
+    func enrich(_ sessions: [Session]) -> [Session] {
+        let itermPids = sessions
+            .filter { $0.terminalApp?.contains("iTerm") == true }
+            .map(\.pid)
+        guard !itermPids.isEmpty else { return sessions }
+
+        let snapshot = sessionsByTTY()
+        guard !snapshot.isEmpty else { return sessions }
+
+        let ttys = Self.ttyMap(forPids: itermPids)
+
+        return sessions.map { session in
+            guard session.terminalApp?.contains("iTerm") == true,
+                  let tty = ttys[session.pid],
+                  let info = snapshot[tty]
+            else { return session }
+            var copy = session
+            copy.tabId = info.tabId
+            copy.tabName = info.tabName
+            return copy
+        }
+    }
+
+    // Batched tty lookup. `ps -p P1,P2,...` returns one row per pid,
+    // `-o pid=,tty=` strips headers. Cuts N subprocess spawns down to
+    // 1 — the biggest single win on poll latency. ps prints the tty in
+    // short form ("ttys001"); iTerm2's AppleScript returns the full
+    // /dev/ path. We canonicalise to /dev/<short> so the two sides
+    // join cleanly.
+    static func ttyMap(forPids pids: [Int]) -> [Int: String] {
+        guard !pids.isEmpty else { return [:] }
+        let pidList = pids.map { String($0) }.joined(separator: ",")
+        let raw = ProcessOutput.read("/bin/ps", ["-p", pidList, "-o", "pid=,tty="])
+        var result: [Int: String] = [:]
+        for line in raw.split(separator: "\n") {
+            let parts = String(line)
+                .trimmingCharacters(in: .whitespaces)
+                .split(separator: " ", omittingEmptySubsequences: true)
+            guard parts.count >= 2, let pid = Int(parts[0]) else { continue }
+            let tty = String(parts[1])
+            guard tty != "??" else { continue }
+            result[pid] = tty.hasPrefix("/dev/") ? tty : "/dev/\(tty)"
+        }
+        return result
+    }
+
+    private static func query() -> [String: ITerm2Session] {
+        // Pipe-delimited output is cheaper to parse than JSON from
+        // AppleScript and avoids quoting headaches. Pane TTYs never
+        // contain "|", so the delimiter is unambiguous.
+        let script = """
+        tell application "iTerm2"
+            if not running then return ""
+            set output to ""
+            repeat with w in windows
+                repeat with t in tabs of w
+                    repeat with s in sessions of t
+                        try
+                            set ttyPath to tty of s
+                            set sessionId to unique id of s
+                            set sessionName to name of s
+                            set output to output & ttyPath & "|" & sessionId & "|" & sessionName & linefeed
+                        end try
+                    end repeat
+                end repeat
+            end repeat
+            return output
+        end tell
+        """
+
+        guard let raw = runOsaScript(script), !raw.isEmpty else { return [:] }
+
+        var result: [String: ITerm2Session] = [:]
+        for line in raw.split(separator: "\n") {
+            let parts = line.split(separator: "|", maxSplits: 2, omittingEmptySubsequences: false)
+            guard parts.count >= 2 else { continue }
+            let tty = String(parts[0]).trimmingCharacters(in: .whitespaces)
+            let id  = String(parts[1]).trimmingCharacters(in: .whitespaces)
+            guard !tty.isEmpty, !id.isEmpty else { continue }
+            let name: String?
+            if parts.count >= 3 {
+                let n = String(parts[2]).trimmingCharacters(in: .whitespacesAndNewlines)
+                name = n.isEmpty ? nil : n
+            } else {
+                name = nil
+            }
+            result[tty] = ITerm2Session(tabId: id, tabName: name, tty: tty)
+        }
+        return result
+    }
+
+    // Runs osascript out-of-process and returns stdout, or nil on
+    // failure / TCC denial. We deliberately swallow stderr — iTerm2
+    // / TCC errors are routine here (cold cache, app not running) and
+    // wouldn't help the user.
+    private static func runOsaScript(_ source: String) -> String? {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = ["-e", source]
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        task.standardOutput = outPipe
+        task.standardError = errPipe
+        do { try task.run() } catch { return nil }
+        // osascript shouldn't take more than a few hundred ms; if iTerm2
+        // is hung we'd rather give up than block the poll loop.
+        let deadline = Date().addingTimeInterval(1.5)
+        while task.isRunning && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+        if task.isRunning {
+            task.terminate()
+            return nil
+        }
+        guard task.terminationStatus == 0 else { return nil }
+        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -307,6 +307,15 @@ struct EventRow: View {
                         .font(.subheadline.weight(.medium))
                         .lineLimit(1)
                         .truncationMode(.tail)
+                    if let term = terminalLabel {
+                        Text("·")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                        Text(term)
+                            .font(.caption.monospaced())
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                    }
                     if let label = sessionLabel {
                         Text("·")
                             .font(.caption)
@@ -316,6 +325,16 @@ struct EventRow: View {
                             .foregroundStyle(.tertiary)
                             .lineLimit(1)
                             .truncationMode(.middle)
+                    }
+                    if let tab = secondaryTabLabel {
+                        Text("·")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                        Text(tab)
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
                     }
                     Spacer(minLength: 8)
                     Text(rightTimestamp)
@@ -345,7 +364,9 @@ struct EventRow: View {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .fill(selected ? Color.accentColor.opacity(0.22) : Color.clear)
             if let accent = SessionColor.color(
-                agent: event.agent, projectPath: event.projectPath
+                agent: event.agent,
+                projectPath: event.projectPath,
+                tabId: tabIdentifier
             ) {
                 Rectangle()
                     .fill(accent.opacity(0.85))
@@ -361,14 +382,64 @@ struct EventRow: View {
     }
 
     // Show the user-chosen session name when one is set, otherwise the
-    // project folder's basename. Nil → no chip at all (events with no
-    // projectPath stay as a clean title row).
+    // project folder's basename. Lookup is keyed by (agent, projectPath,
+    // tabId) — iTerm contributes its session id, VSCode/Cursor
+    // contribute the IPC hook path. Falls back to (agent, projectPath)
+    // transparently for events without a tab-scoped id and for
+    // pre-Stage-2 persistence entries.
     private var sessionLabel: String? {
-        if let custom = persistence.customName(agent: event.agent, projectPath: event.projectPath) {
+        if let custom = persistence.customName(
+            agent: event.agent,
+            projectPath: event.projectPath,
+            tabId: tabIdentifier
+        ) {
             return custom
         }
         guard let project = event.projectPath else { return nil }
         return (project as NSString).lastPathComponent
+    }
+
+    // First non-empty of [iTerm session id, VSCode IPC hook]. Each
+    // terminal contributes whatever it has; the lookup layer doesn't
+    // care which one fired as long as it's stable per tab/window.
+    private var tabIdentifier: String? {
+        if let sid = event.sessionID, !sid.isEmpty { return sid }
+        if let hook = event.ipcHook, !hook.isEmpty { return hook }
+        return nil
+    }
+
+    // iTerm2 tab/session label shown next to the session chip, but only
+    // when it adds information — suppress it if it'd just echo the
+    // session label we already showed.
+    private var secondaryTabLabel: String? {
+        guard let raw = event.itermTabName?.trimmingCharacters(in: .whitespaces),
+              !raw.isEmpty,
+              raw != sessionLabel else { return nil }
+        return raw
+    }
+
+    // Where the event came from. Normalises the helper-process names
+    // we capture in the wire payload to short, human-readable labels —
+    // "Code Helper (Renderer)" reads as terminal-developer noise; "Code"
+    // reads as "this came from VSCode". Returns nil when we don't know
+    // the terminal, so the chip silently vanishes for those events.
+    private var terminalLabel: String? {
+        guard let raw = event.terminalApp?.trimmingCharacters(in: .whitespaces),
+              !raw.isEmpty else { return nil }
+        switch raw {
+        case "Code", "Code Helper", "Code Helper (Plugin)", "Code Helper (Renderer)":
+            return "VSCode"
+        case "Cursor", "Cursor Helper", "Cursor Helper (Plugin)", "Cursor Helper (Renderer)":
+            return "Cursor"
+        case "Antigravity", "Antigravity Helper", "Antigravity Helper (Plugin)", "Antigravity Helper (Renderer)":
+            return "Antigravity"
+        case "WarpTerminal":             return "Warp"
+        case "iTerm", "iTerm2":          return "iTerm2"
+        case "ghostty", "Ghostty":       return "Ghostty"
+        case "Terminal":                 return "Terminal"
+        case "Zed", "zed":               return "Zed"
+        default:                         return raw
+        }
     }
 
     // For snoozed events show "snoozed Xm" in place of the relative

--- a/panel/ProcessOutput.swift
+++ b/panel/ProcessOutput.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+// Tiny helper for shelling out and reading stdout. Used by SessionStore
+// (ps/lsof) and the terminal integrations (ps -eww). Centralised so
+// every caller gets the same "swallow stderr, return empty string on
+// any failure" contract — we never want a flaky subprocess to surface
+// as a panel crash.
+enum ProcessOutput {
+    static func read(_ path: String, _ args: [String]) -> String {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: path)
+        task.arguments = args
+        let outPipe = Pipe()
+        task.standardOutput = outPipe
+        task.standardError = Pipe()
+        do { try task.run() } catch { return "" }
+        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+        task.waitUntilExit()
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+}

--- a/panel/SessionPersistence.swift
+++ b/panel/SessionPersistence.swift
@@ -10,8 +10,9 @@ import SwiftUI
 enum Agent {
     static func canonical(_ raw: String) -> String {
         switch raw {
-        case "claude-code", "cursor": return "claude"
-        default:                      return raw
+        case "claude-code", "cursor":              return "claude"
+        case "antigravity", "antigravity-cli":     return "agy"
+        default:                                   return raw
         }
     }
 }
@@ -59,21 +60,36 @@ final class SessionPersistence: ObservableObject {
 
     // MARK: - Lookup
 
-    func customName(agent: String, projectPath: String?) -> String? {
+    // Resolves a custom name for (agent, projectPath[, tabId]). Lookup
+    // first tries the most specific key (with tabId), then falls back to
+    // the (agent, projectPath) form — so renames written before Stage 2
+    // (no tabId) still apply to every tab in that project, and a
+    // tab-scoped rename overrides the generic one when present.
+    func customName(agent: String, projectPath: String?, tabId: String? = nil) -> String? {
         guard let projectPath else { return nil }
-        let key = Self.key(agent: Agent.canonical(agent), projectPath: projectPath)
-        let trimmed = entries[key]?.customName
+        let canon = Agent.canonical(agent)
+        if let tabId, !tabId.isEmpty {
+            if let trimmed = entries[Self.key(agent: canon, projectPath: projectPath, tabId: tabId)]?.customName,
+               !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        let trimmed = entries[Self.key(agent: canon, projectPath: projectPath, tabId: nil)]?.customName
         guard let trimmed, !trimmed.isEmpty else { return nil }
         return trimmed
     }
 
     // MARK: - Mutation
 
-    // Sets (or clears, when `name` is nil/empty) the custom name for a
-    // session keyed by (agent, projectPath). Persists immediately.
-    func setCustomName(agent: String, projectPath: String?, _ name: String?) {
+    // Sets (or clears, when `name` is nil/empty) the custom name keyed
+    // by (agent, projectPath[, tabId]). When tabId is provided we write
+    // the per-tab key — that lets two tabs in the same cwd carry
+    // different names without disturbing each other. Clearing removes
+    // only the most specific entry; a parent (agent, projectPath) entry
+    // (if any) keeps working as the fallback.
+    func setCustomName(agent: String, projectPath: String?, tabId: String? = nil, _ name: String?) {
         guard let projectPath else { return }
-        let key = Self.key(agent: Agent.canonical(agent), projectPath: projectPath)
+        let key = Self.key(agent: Agent.canonical(agent), projectPath: projectPath, tabId: tabId)
         let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if trimmed.isEmpty {
             guard entries.removeValue(forKey: key) != nil else { return }
@@ -89,20 +105,37 @@ final class SessionPersistence: ObservableObject {
     // Bump lastSeenAt for an existing entry, but only on the first sight
     // per launch — that way the file is rewritten once per active named
     // session per app run, not every poll tick. No-op for sessions we
-    // don't have an entry for; we don't track unrenamed sessions.
-    func noteSeen(agent: String, projectPath: String?) {
+    // don't have an entry for; we don't track unrenamed sessions. We
+    // bump the most specific key that exists so per-tab entries get
+    // their own freshness signal independently of any parent entry.
+    func noteSeen(agent: String, projectPath: String?, tabId: String? = nil) {
         guard let projectPath else { return }
-        let key = Self.key(agent: Agent.canonical(agent), projectPath: projectPath)
-        guard !seenThisLaunch.contains(key), entries[key] != nil else { return }
-        seenThisLaunch.insert(key)
-        entries[key]?.lastSeenAt = Date().timeIntervalSince1970
-        save()
+        let canon = Agent.canonical(agent)
+        let candidates: [String] = {
+            if let tabId, !tabId.isEmpty {
+                return [
+                    Self.key(agent: canon, projectPath: projectPath, tabId: tabId),
+                    Self.key(agent: canon, projectPath: projectPath, tabId: nil),
+                ]
+            }
+            return [Self.key(agent: canon, projectPath: projectPath, tabId: nil)]
+        }()
+        for key in candidates {
+            guard !seenThisLaunch.contains(key), entries[key] != nil else { continue }
+            seenThisLaunch.insert(key)
+            entries[key]?.lastSeenAt = Date().timeIntervalSince1970
+            save()
+            return
+        }
     }
 
     // MARK: - I/O
 
-    private static func key(agent: String, projectPath: String) -> String {
-        "\(agent)::\(projectPath)"
+    private static func key(agent: String, projectPath: String, tabId: String?) -> String {
+        if let tabId, !tabId.isEmpty {
+            return "\(agent)::\(projectPath)::\(tabId)"
+        }
+        return "\(agent)::\(projectPath)"
     }
 
     private func load() {
@@ -149,9 +182,16 @@ enum SessionColor {
         .blue, .teal, .mint, .indigo, .purple, .pink,
     ]
 
-    static func color(agent: String, projectPath: String?) -> Color? {
+    static func color(agent: String, projectPath: String?, tabId: String? = nil) -> Color? {
         guard let projectPath, !projectPath.isEmpty else { return nil }
-        let key = "\(Agent.canonical(agent))::\(projectPath)"
+        var key = "\(Agent.canonical(agent))::\(projectPath)"
+        if let tabId, !tabId.isEmpty {
+            // Mixing tabId into the hash gives two iTerm tabs in the same
+            // cwd distinct accent colors. Sessions without a tabId still
+            // hash to the same key they did pre-Stage-2 — no migration
+            // shuffle for existing users.
+            key += "::\(tabId)"
+        }
         let idx = Int(fnv1a(key) % UInt32(palette.count))
         return palette[idx]
     }

--- a/panel/SessionStore.swift
+++ b/panel/SessionStore.swift
@@ -9,7 +9,7 @@ enum SessionStatus: Equatable {
 struct Session: Identifiable, Equatable {
     let id: Int           // pid — pids are reusable but stable for this process's lifetime
     let pid: Int
-    let agent: String     // "claude" | "gemini" | "codex"
+    let agent: String     // "claude" | "gemini" | "codex" | "agy"
     let projectPath: String?
     let projectName: String?
     let terminalPID: Int?
@@ -17,6 +17,13 @@ struct Session: Identifiable, Equatable {
     let elapsed: String?  // ps etime — display-only
     var customName: String?
     var status: SessionStatus
+    // iTerm2 (Stage 2) enrichment. tabId is the iTerm session's unique id
+    // — stable for the tab's lifetime, used to scope renames/colors to a
+    // specific tab. tabName is the user-visible label. Both nil for
+    // sessions not running inside iTerm2 (or when Automation is denied),
+    // which is exactly the pre-Stage-2 behaviour.
+    var tabId: String?
+    var tabName: String?
 }
 
 // Polls for live agent processes (claude / gemini / codex) every few seconds
@@ -35,7 +42,7 @@ final class SessionStore: ObservableObject {
     private let persistence: SessionPersistence
     private var pollTimer: Timer?
     private let queue = DispatchQueue(label: "stack-nudge.sessions", qos: .utility)
-    private static let agentBinaries: Set<String> = ["claude", "gemini", "codex"]
+    private static let agentBinaries: Set<String> = ["claude", "gemini", "codex", "agy"]
     private static let pollInterval: TimeInterval = 3.0
 
     init(persistence: SessionPersistence = .shared) {
@@ -70,9 +77,14 @@ final class SessionStore: ObservableObject {
         let trimmed = name?.trimmingCharacters(in: .whitespaces)
         let final: String? = (trimmed?.isEmpty ?? true) ? nil : trimmed
         sessions[idx].customName = final
+        // tabId-scoped write when we know which tab the user is renaming,
+        // so two tabs in the same cwd get independent names. Falls back
+        // to the (agent, projectPath) key when no iTerm enrichment is
+        // available — matches Stage 1 behaviour exactly.
         persistence.setCustomName(
             agent: sessions[idx].agent,
             projectPath: sessions[idx].projectPath,
+            tabId: sessions[idx].tabId,
             final
         )
     }
@@ -98,9 +110,15 @@ final class SessionStore: ObservableObject {
     private func scan() {
         isScanning = true
         queue.async { [weak self] in
-            let found = Self.discover()
+            // discover() shells out to ps/lsof; TerminalRegistry.enrich
+            // calls each terminal integration (iTerm2, VSCode, …) in
+            // turn — each batches its own subprocess work. The whole
+            // thing runs on the background poll queue so the main thread
+            // never sees a subprocess spawn.
+            let raw = Self.discover()
+            let enriched = TerminalRegistry.enrich(raw)
             DispatchQueue.main.async { [weak self] in
-                self?.merge(found)
+                self?.merge(enriched)
                 self?.isScanning = false
                 self?.didFirstScan = true
             }
@@ -114,10 +132,18 @@ final class SessionStore: ObservableObject {
 
         var next: [Session] = []
 
-        // Update / mark-finished existing sessions in place so customName persists.
+        // Update / mark-finished existing sessions in place so customName
+        // persists. We also re-apply the freshly-enriched tabId/tabName
+        // from the live snapshot — a tab rename or pane move should
+        // propagate without waiting for the session to restart.
         for var existing in sessions {
             if let live = foundByPID[existing.pid] {
-                existing = live.with(customName: existing.customName, status: .active)
+                existing = live.with(
+                    customName: existing.customName,
+                    status: .active,
+                    tabId: live.tabId,
+                    tabName: live.tabName
+                )
                 next.append(existing)
             } else {
                 switch existing.status {
@@ -133,16 +159,21 @@ final class SessionStore: ObservableObject {
         }
 
         // Add genuinely new sessions, seeding customName from persistence
-        // so a renamed (agent, projectPath) keeps its name across restarts
-        // and across process churn within a single launch.
+        // so a renamed (agent, projectPath[, tabId]) keeps its name across
+        // restarts and across process churn within a single launch.
         let knownPIDs = Set(next.map(\.pid))
         for var session in found where !knownPIDs.contains(session.pid) {
             if let persisted = persistence.customName(
                 agent: session.agent,
-                projectPath: session.projectPath
+                projectPath: session.projectPath,
+                tabId: session.tabId
             ) {
                 session.customName = persisted
-                persistence.noteSeen(agent: session.agent, projectPath: session.projectPath)
+                persistence.noteSeen(
+                    agent: session.agent,
+                    projectPath: session.projectPath,
+                    tabId: session.tabId
+                )
             }
             next.append(session)
         }
@@ -200,7 +231,9 @@ final class SessionStore: ObservableObject {
                 terminalApp: chain.terminalApp,
                 elapsed: etime,
                 customName: nil,
-                status: .active
+                status: .active,
+                tabId: nil,
+                tabName: nil
             ))
         }
         return found
@@ -214,6 +247,7 @@ final class SessionStore: ObservableObject {
         if baseName == "claude" { return "claude" }
         if baseName == "gemini" { return "gemini" }
         if baseName == "codex"  { return "codex"  }
+        if baseName == "agy"    { return "agy"    }
 
         // Node / Deno-hosted agents: inspect later tokens for known script paths.
         if baseName == "node" || baseName == "deno" || baseName == "bun" {
@@ -222,6 +256,9 @@ final class SessionStore: ObservableObject {
             }
             if args.range(of: #"\bcodex(-cli)?\b"#, options: .regularExpression) != nil {
                 return "codex"
+            }
+            if args.range(of: #"\b(agy|antigravity(-cli)?)\b"#, options: .regularExpression) != nil {
+                return "agy"
             }
         }
         return nil
@@ -245,6 +282,7 @@ final class SessionStore: ObservableObject {
     private static let terminalApps: Set<String> = [
         "Code Helper", "Code Helper (Plugin)", "Code Helper (Renderer)", "Code",
         "Cursor Helper", "Cursor Helper (Plugin)", "Cursor Helper (Renderer)", "Cursor",
+        "Antigravity Helper", "Antigravity Helper (Plugin)", "Antigravity Helper (Renderer)", "Antigravity",
         "iTerm2", "iTerm", "Terminal", "Warp", "WarpTerminal", "ghostty", "Ghostty",
     ]
 
@@ -269,21 +307,17 @@ final class SessionStore: ObservableObject {
     }
 
     private static func runProcess(_ path: String, _ args: [String]) -> String {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: path)
-        task.arguments = args
-        let outPipe = Pipe()
-        task.standardOutput = outPipe
-        task.standardError = Pipe()
-        do { try task.run() } catch { return "" }
-        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
-        task.waitUntilExit()
-        return String(data: data, encoding: .utf8) ?? ""
+        // Thin wrapper around the shared helper so all subprocess
+        // plumbing lives in one place — keeps stderr-swallow + failure
+        // semantics consistent across SessionStore and the terminal
+        // integrations.
+        ProcessOutput.read(path, args)
     }
 }
 
 private extension Session {
-    func with(customName: String?, status: SessionStatus) -> Session {
+    func with(customName: String?, status: SessionStatus,
+              tabId: String? = nil, tabName: String? = nil) -> Session {
         Session(
             id: id,
             pid: pid,
@@ -294,7 +328,9 @@ private extension Session {
             terminalApp: terminalApp,
             elapsed: elapsed,
             customName: customName,
-            status: status
+            status: status,
+            tabId: tabId ?? self.tabId,
+            tabName: tabName ?? self.tabName
         )
     }
 }

--- a/panel/Sessions.swift
+++ b/panel/Sessions.swift
@@ -100,8 +100,19 @@ struct SessionsView: View {
     }
 
     private func matches(event: NudgeEvent, session: Session) -> Bool {
-        Agent.canonical(event.agent) == Agent.canonical(session.agent)
-            && event.projectPath == session.projectPath
+        guard Agent.canonical(event.agent) == Agent.canonical(session.agent),
+              event.projectPath == session.projectPath else { return false }
+        // When both sides know which tab/window they belong to, demand
+        // they agree — that's how a permission nudge for tab A doesn't
+        // count toward tab B's nudge counter. Each terminal contributes
+        // its own identifier (iTerm: sessionID; VSCode: ipcHook), so
+        // we accept either as the event-side tabId.
+        let eventTab = (event.sessionID?.isEmpty == false ? event.sessionID : event.ipcHook)
+        if let sessionTab = session.tabId, let eventTab,
+           !sessionTab.isEmpty, !eventTab.isEmpty {
+            return sessionTab == eventTab
+        }
+        return true
     }
 }
 
@@ -158,7 +169,9 @@ private struct SessionRow: View {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .fill(rowBackgroundColor)
             if let accent = SessionColor.color(
-                agent: session.agent, projectPath: session.projectPath
+                agent: session.agent,
+                projectPath: session.projectPath,
+                tabId: session.tabId
             ) {
                 Rectangle()
                     .fill(accent.opacity(isActive ? 0.85 : 0.45))
@@ -209,6 +222,16 @@ private struct SessionRow: View {
                 Text(term)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
+                Text("·")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            if let tab = session.tabName, !tab.isEmpty, tab != displayName {
+                Text(tab)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
                 Text("·")
                     .font(.caption2)
                     .foregroundStyle(.tertiary)

--- a/panel/TerminalAppIntegration.swift
+++ b/panel/TerminalAppIntegration.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+// Terminal.app integration. Same shape as ITerm2Integration — batched
+// AppleScript query, 15s cache, tty-keyed join — but the AppleScript
+// surface differs:
+//
+//   * Terminal.app exposes `tabs of window` with a `tty` property.
+//   * No stable per-tab UUID; we use the tty path itself as tabId.
+//     That's stable for the tab's lifetime, which is enough.
+//   * `custom title` is the user-set tab title; if absent, fall back
+//     to nothing (the auto-derived names are usually the running
+//     process and not very useful).
+final class TerminalAppIntegration: TerminalIntegration {
+
+    static let shared = TerminalAppIntegration()
+
+    let name = "Terminal.app"
+
+    private let cacheLifetime: TimeInterval = 15.0
+    private var cache: [String: TabInfo]?
+    private var cacheStamp: Date = .distantPast
+    private let lock = NSLock()
+
+    func enrich(_ sessions: [Session]) -> [Session] {
+        let pids = sessions
+            .filter { $0.terminalApp == "Terminal" }
+            .map(\.pid)
+        guard !pids.isEmpty else { return sessions }
+
+        let snapshot = sessionsByTTY()
+        guard !snapshot.isEmpty else { return sessions }
+
+        let ttys = ITerm2Integration.ttyMap(forPids: pids)
+
+        return sessions.map { session in
+            guard session.terminalApp == "Terminal",
+                  let tty = ttys[session.pid],
+                  let info = snapshot[tty]
+            else { return session }
+            var copy = session
+            copy.tabId = info.tabId
+            copy.tabName = info.tabName
+            return copy
+        }
+    }
+
+    // Snapshot of Terminal.app's tabs keyed by tty. Same locking +
+    // cache-around-AppleScript pattern as ITerm2Integration.
+    private func sessionsByTTY() -> [String: TabInfo] {
+        lock.lock()
+        if let cache, Date().timeIntervalSince(cacheStamp) < cacheLifetime {
+            defer { lock.unlock() }
+            return cache
+        }
+        lock.unlock()
+        let fresh = Self.query()
+        lock.lock()
+        cache = fresh
+        cacheStamp = Date()
+        lock.unlock()
+        return fresh
+    }
+
+    private static func query() -> [String: TabInfo] {
+        // Pipe-delimited output. `try` blocks guard against tabs that
+        // lack `custom title` (older versions) or processes that race
+        // with us mid-query.
+        let script = """
+        tell application "Terminal"
+            if not running then return ""
+            set output to ""
+            repeat with w in windows
+                repeat with t in tabs of w
+                    try
+                        set ttyPath to tty of t
+                        set tabTitle to ""
+                        try
+                            set tabTitle to custom title of t
+                        end try
+                        set output to output & ttyPath & "|" & tabTitle & linefeed
+                    end try
+                end repeat
+            end repeat
+            return output
+        end tell
+        """
+
+        guard let raw = runOsaScript(script), !raw.isEmpty else { return [:] }
+
+        var result: [String: TabInfo] = [:]
+        for line in raw.split(separator: "\n") {
+            let parts = line.split(separator: "|", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count >= 1 else { continue }
+            let tty = String(parts[0]).trimmingCharacters(in: .whitespaces)
+            guard !tty.isEmpty else { continue }
+            let title: String?
+            if parts.count == 2 {
+                let raw = String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines)
+                title = raw.isEmpty ? nil : raw
+            } else {
+                title = nil
+            }
+            // Use the tty itself as tabId. Stable for the tab's lifetime,
+            // and avoids inventing an ID where Terminal.app gives us none.
+            result[tty] = TabInfo(tabId: tty, tabName: title, windowTitle: nil)
+        }
+        return result
+    }
+
+    // Same osascript shape as ITerm2Integration but kept local so the
+    // two integrations stay independent — if one acquires a quirk we
+    // don't want to leak it into the other.
+    private static func runOsaScript(_ source: String) -> String? {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = ["-e", source]
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        task.standardOutput = outPipe
+        task.standardError = errPipe
+        do { try task.run() } catch { return nil }
+        let deadline = Date().addingTimeInterval(1.5)
+        while task.isRunning && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+        if task.isRunning {
+            task.terminate()
+            return nil
+        }
+        guard task.terminationStatus == 0 else { return nil }
+        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/panel/TerminalIntegration.swift
+++ b/panel/TerminalIntegration.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+// Snapshot of one tab/pane/window the terminal-side integration knows
+// about. Surface is intentionally narrow — anything terminal-specific
+// (iTerm tab groups, VSCode workspace paths) gets squeezed into these
+// three fields so the rest of the app doesn't need to branch per
+// terminal. If a fourth field becomes load-bearing it earns its place;
+// until then this stays small.
+struct TabInfo: Equatable {
+    let tabId: String
+    let tabName: String?
+    let windowTitle: String?
+}
+
+// Strategy for enriching a discovered Session with terminal-specific
+// tab identity (tabId / tabName). Each conformer handles the terminals
+// it understands and passes other sessions through unchanged. Why a
+// batch shape (`[Session] -> [Session]`) instead of per-session
+// `tabInfo(forProcessID:)`: terminals like iTerm2 and VSCode can
+// resolve N sessions in one subprocess spawn, and we already saw
+// what per-session shelling-out does to the main thread.
+protocol TerminalIntegration {
+    var name: String { get }
+
+    // Called from SessionStore's background poll queue. Must not touch
+    // SwiftUI / @Published state. Returns the same array with applicable
+    // sessions enriched in place.
+    func enrich(_ sessions: [Session]) -> [Session]
+}
+
+// Composes the registered integrations into a single pipeline.
+// SessionStore.scan() calls TerminalRegistry.enrich(...) once per poll;
+// each integration in `all` gets a chance to enrich the sessions it
+// recognises. Order matters only when two integrations would claim the
+// same session — keep specific (iTerm2) ahead of generic (Terminal.app)
+// as more conformers land.
+enum TerminalRegistry {
+
+    // Mutable to support tests injecting a fake roster. Production
+    // callers should treat it as read-only.
+    static var integrations: [TerminalIntegration] = [
+        ITerm2Integration.shared,
+        TerminalAppIntegration.shared,
+        VSCodeIntegration.shared,
+        // Warp + Ghostty both set TERM_SESSION_ID in the agent's env;
+        // a single generic conformer covers both terminals. Tab names
+        // aren't accessible from outside today — could be layered in
+        // via AX later. The terminalApp strings here match what
+        // SessionStore.walkParentChain emits.
+        EnvVarTerminalIntegration(
+            name: "Warp",
+            terminalApps: ["Warp", "WarpTerminal"],
+            envVar: "TERM_SESSION_ID"
+        ),
+        EnvVarTerminalIntegration(
+            name: "Ghostty",
+            terminalApps: ["Ghostty", "ghostty"],
+            envVar: "TERM_SESSION_ID"
+        ),
+    ]
+
+    static func enrich(_ sessions: [Session]) -> [Session] {
+        integrations.reduce(sessions) { acc, integration in
+            integration.enrich(acc)
+        }
+    }
+}

--- a/panel/VSCodeIntegration.swift
+++ b/panel/VSCodeIntegration.swift
@@ -1,0 +1,174 @@
+import Foundation
+
+// Integration for VSCode and Cursor's integrated terminals. Both are
+// Electron and present as "Code Helper" / "Cursor Helper (Renderer)"
+// processes in our session chain. Per-window identity comes from
+// VSCODE_IPC_HOOK_CLI — a Unix socket path that's unique per editor
+// window and stable for that window's lifetime. We use it as tabId.
+//
+// The integration is **bi-directional**: notify.sh ships `ipc_hook` +
+// `window_title` on every event, EventListener feeds those into our
+// in-memory cache, and the Sessions-tab side enriches each
+// VSCode-hosted Session by reading its VSCODE_IPC_HOOK_CLI from the
+// process environment (`ps eww`) and joining to the cache.
+//
+// Why this shape: VSCode itself doesn't expose AppleScript like iTerm2
+// does, and we don't want to talk to its CLI socket from the panel.
+// The event side already carries the window title for free — we just
+// have to remember it.
+final class VSCodeIntegration: TerminalIntegration {
+
+    static let shared = VSCodeIntegration()
+
+    let name = "VSCode/Cursor/Antigravity"
+
+    private struct WindowInfo {
+        var windowTitle: String?
+        var projectPath: String?
+        var lastSeenAt: Date
+    }
+
+    private var cache: [String: WindowInfo] = [:]
+    private let lock = NSLock()
+
+    // Session.terminalApp values our process-chain walker emits when an
+    // agent is hosted inside one of these editors. All three are Code
+    // forks; they each inherit VSCODE_IPC_HOOK_CLI in their integrated
+    // terminal so the same enrichment path works for all of them.
+    // Anything outside this set is passed through untouched.
+    private static let recognizedTerminals: Set<String> = [
+        "Code", "Code Helper", "Code Helper (Plugin)", "Code Helper (Renderer)",
+        "Cursor", "Cursor Helper", "Cursor Helper (Plugin)", "Cursor Helper (Renderer)",
+        "Antigravity", "Antigravity Helper", "Antigravity Helper (Plugin)", "Antigravity Helper (Renderer)",
+    ]
+
+    // MARK: - Event-side feed
+
+    // Called from EventListener whenever an event with a non-empty
+    // ipcHook arrives. windowTitle / projectPath are optional but help
+    // produce nicer display labels later.
+    func note(ipcHook: String, windowTitle: String?, projectPath: String?) {
+        guard !ipcHook.isEmpty else { return }
+        let trimmedTitle = windowTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let cleanTitle = (trimmedTitle?.isEmpty ?? true) ? nil : trimmedTitle
+        lock.lock()
+        defer { lock.unlock() }
+        var entry = cache[ipcHook] ?? WindowInfo(windowTitle: nil, projectPath: nil, lastSeenAt: .distantPast)
+        // Latest non-nil value wins — a later event in the same window
+        // might carry a more specific title.
+        if let cleanTitle { entry.windowTitle = cleanTitle }
+        if let projectPath, !projectPath.isEmpty { entry.projectPath = projectPath }
+        entry.lastSeenAt = Date()
+        cache[ipcHook] = entry
+    }
+
+    // MARK: - TerminalIntegration
+
+    func enrich(_ sessions: [Session]) -> [Session] {
+        let candidatePids = sessions
+            .filter { Self.isVSCodeHosted($0.terminalApp) }
+            .map(\.pid)
+        guard !candidatePids.isEmpty else { return sessions }
+
+        let hooks = Self.ipcHookMap(forPids: candidatePids)
+        guard !hooks.isEmpty else { return sessions }
+
+        lock.lock()
+        let snapshot = cache
+        lock.unlock()
+
+        return sessions.map { session in
+            guard Self.isVSCodeHosted(session.terminalApp),
+                  let hook = hooks[session.pid]
+            else { return session }
+            var copy = session
+            copy.tabId = hook
+            copy.tabName = snapshot[hook]?.windowTitle ?? Self.tabNameFallback(forHook: hook)
+            return copy
+        }
+    }
+
+    // MARK: - Internals
+
+    static func isVSCodeHosted(_ terminalApp: String?) -> Bool {
+        guard let terminalApp else { return false }
+        return recognizedTerminals.contains(terminalApp)
+    }
+
+    // Batched lookup. `ps eww -o pid=,args= -p P1,P2,...` prints each
+    // pid followed by its command line plus environment variables
+    // (`-e`). We scan each line for VSCODE_IPC_HOOK_CLI=… and pair it
+    // with the pid at the start of the line.
+    //
+    // macOS restricts env-var visibility for processes you don't own;
+    // the agents here are spawned by the same user, so the readout works.
+    static func ipcHookMap(forPids pids: [Int]) -> [Int: String] {
+        guard !pids.isEmpty else { return [:] }
+        let pidList = pids.map { String($0) }.joined(separator: ",")
+        let raw = ProcessOutput.read("/bin/ps", ["eww", "-o", "pid=,command=", "-p", pidList])
+        return parseIpcHooks(raw)
+    }
+
+    // Pulled out for testability — given the raw ps output, return a
+    // map of pid → VSCODE_IPC_HOOK_CLI value. No subprocess in here.
+    static func parseIpcHooks(_ raw: String) -> [Int: String] {
+        var result: [Int: String] = [:]
+        for line in raw.split(separator: "\n") {
+            let trimmed = String(line).trimmingCharacters(in: .whitespaces)
+            guard let space = trimmed.firstIndex(of: " "),
+                  let pid = Int(trimmed[..<space]) else { continue }
+            let rest = trimmed[trimmed.index(after: space)...]
+            // VSCODE_IPC_HOOK_CLI is the canonical env var (vscode-cli,
+            // cursor-cli alike). Match the equals sign so a later var
+            // sharing the prefix wouldn't accidentally match.
+            if let range = rest.range(of: "VSCODE_IPC_HOOK_CLI=") {
+                let valueStart = range.upperBound
+                let valueEnd = rest[valueStart...].firstIndex(where: { $0 == " " }) ?? rest.endIndex
+                let value = String(rest[valueStart..<valueEnd])
+                guard !value.isEmpty else { continue }
+                result[pid] = value
+            }
+        }
+        return result
+    }
+
+    // Without a window title from an event, surface a stable label
+    // derived from the hook path — better than nothing for cards that
+    // get rendered before any event lands.
+    static func tabNameFallback(forHook hook: String) -> String? {
+        let basename = (hook as NSString).lastPathComponent
+        // VSCode socket names follow `vscode-ipc-<uuid>.sock`. The
+        // UUID alone isn't human-readable; render the trailing
+        // segment with the prefix stripped if present, otherwise nil.
+        if basename.isEmpty { return nil }
+        return nil  // intentionally nil — UI prefers no chip over a UUID
+    }
+
+    // MARK: - Testing seam
+
+    // Builds a fresh integration with its own (empty) cache so tests
+    // don't bleed into the live singleton. Marked internal so only the
+    // test target reaches it via `@testable import`.
+    static func testInstance() -> VSCodeIntegration {
+        VSCodeIntegration()
+    }
+
+    // Same shape as enrich() but takes the pid → ipcHook map directly,
+    // bypassing the `ps eww` subprocess. Lets tests exercise the
+    // cache-join half without spawning processes or relying on a real
+    // VSCode being installed.
+    func enrichForTests(_ sessions: [Session], ipcHooksByPid: [Int: String]) -> [Session] {
+        lock.lock()
+        let snapshot = cache
+        lock.unlock()
+        return sessions.map { session in
+            guard Self.isVSCodeHosted(session.terminalApp),
+                  let hook = ipcHooksByPid[session.pid]
+            else { return session }
+            var copy = session
+            copy.tabId = hook
+            copy.tabName = snapshot[hook]?.windowTitle ?? Self.tabNameFallback(forHook: hook)
+            return copy
+        }
+    }
+}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -70,6 +70,66 @@ print(f"  Cleaned {path}")
 PY
 fi
 
+# Remove hooks from Gemini CLI.
+if [[ -f "$HOME/.gemini/settings.json" ]]; then
+  python3 - "$HOME/.gemini/settings.json" <<'PY'
+import json, re, sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+STALE = re.compile(r'(?:^|/|")\.?(?:tinynudge|stack-nudge)/notify\.sh')
+settings = json.loads(path.read_text())
+hooks = settings.get("hooks", {})
+for event in list(hooks.keys()):
+    cleaned = []
+    for g in hooks[event]:
+        inner = g.get("hooks", [])
+        kept = [h for h in inner if not STALE.search(h.get("command", "") or "")]
+        if not kept:
+            continue
+        if kept != inner:
+            g = {**g, "hooks": kept}
+        cleaned.append(g)
+    hooks[event] = cleaned
+    if not hooks[event]:
+        del hooks[event]
+if not hooks:
+    settings.pop("hooks", None)
+path.write_text(json.dumps(settings, indent=2) + "\n")
+print(f"  Cleaned {path}")
+PY
+fi
+
+# Remove hooks from Antigravity CLI.
+if [[ -f "$HOME/.gemini/antigravity-cli/settings.json" ]]; then
+  python3 - "$HOME/.gemini/antigravity-cli/settings.json" <<'PY'
+import json, re, sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+STALE = re.compile(r'(?:^|/|")\.?(?:tinynudge|stack-nudge)/notify\.sh')
+settings = json.loads(path.read_text())
+hooks = settings.get("hooks", {})
+for event in list(hooks.keys()):
+    cleaned = []
+    for g in hooks[event]:
+        inner = g.get("hooks", [])
+        kept = [h for h in inner if not STALE.search(h.get("command", "") or "")]
+        if not kept:
+            continue
+        if kept != inner:
+            g = {**g, "hooks": kept}
+        cleaned.append(g)
+    hooks[event] = cleaned
+    if not hooks[event]:
+        del hooks[event]
+if not hooks:
+    settings.pop("hooks", None)
+path.write_text(json.dumps(settings, indent=2) + "\n")
+print(f"  Cleaned {path}")
+PY
+fi
+
 # Stop and remove launchd agents (macOS)
 for label in com.stackonehq.stack-nudge com.stackonehq.stack-nudge-daemon com.stackonehq.stack-nudge-panel; do
   plist="$HOME/Library/LaunchAgents/${label}.plist"


### PR DESCRIPTION
## Summary

Sessions and events now reflect which terminal/IDE and which tab they came from. Per-tab session identity for iTerm2, Terminal.app, VSCode/Cursor/Antigravity, Warp, and Ghostty — each gets its own renamable name, accent color, and chip in the events row. Adds first-class recognition of Antigravity (IDE + `agy` CLI) and wires automated hook installation for Gemini + Antigravity alongside the existing Claude path.

## Changes

### Terminal integration

- New `TerminalIntegration` protocol (`panel/TerminalIntegration.swift`) + `TerminalRegistry`. SessionStore's poll runs every registered integration on the background queue; main thread no longer sees subprocess spawns.
- `ITerm2Integration` — AppleScript snapshot of every iTerm session, cached 15s, joined to live sessions by tty (batched `ps` call, one subprocess for N sessions). Tab name flows through from notify.sh via a new wire field `iterm_tab_name`.
- `TerminalAppIntegration` — mirror of the iTerm one for Terminal.app. tabId is the tty path (no stable UUID exposed); tabName is `custom title` when set.
- `VSCodeIntegration` — bi-directional. Events teach the cache (`ipc_hook → window title`); Sessions read VSCODE_IPC_HOOK_CLI from each agent's env via `ps eww` and join to the cache. Recognises Code, Cursor, and Antigravity helpers (all VSCode forks).
- `EnvVarTerminalIntegration` — generic parameterised conformer. Warp and Ghostty both expose TERM_SESSION_ID; one implementation, two registrations.
- `ProcessOutput` — shared subprocess helper so the integrations and SessionStore agree on the "swallow stderr, return empty on failure" contract.

### Per-tab identity

- `Session` gains `tabId` + `tabName`. `SessionPersistence` keys widen to `agent::path::tabId` with backward-compat fallback to `agent::path` (pre-Stage-2 renames still apply across every tab in a project until a per-tab override is written).
- `SessionColor` mixes `tabId` into the FNV-1a hash when present — two iTerm tabs in the same cwd get distinct accent colors. Nil tabId reproduces pre-existing colors so existing users see no shuffle.
- `EventRow` uses `event.sessionID` for iTerm and `event.ipcHook` for VSCode-fork events as its tabId. `SessionsView.matches` treats either as the event-side tab id when cross-referencing event-to-session counts.

### Antigravity + `agy`

- `notify.sh` + `SessionStore` recognise Antigravity helpers as terminals and `agy` as an agent binary (direct + node/deno/bun-hosted).
- `Agent.canonical` collapses `antigravity` / `antigravity-cli` to `agy` so wire and process names stay in sync.
- `EventRow` normalises `Antigravity Helper (Renderer)` etc. to `Antigravity`; same for `Code Helper` → `VSCode`, `Cursor Helper` → `Cursor`, `WarpTerminal` → `Warp`, `ghostty` → `Ghostty`.

### Events tab polish

- Title row gains a small monospace chip showing the terminal that fired the event (`Approve write · iTerm2 · auth · tests`).

### Hook installation

- `install.sh` now wires Gemini CLI hooks the same way it does Claude (was previously a "manual setup" note). Also wires Antigravity CLI hooks (`~/.gemini/antigravity-cli/settings.json`).
- `uninstall.sh` mirrors the additions, cleaning up stale entries.

### Perf

- iTerm enrichment moved off main thread (was ~150-250ms stall every 3s with ≥10 iTerm sessions). Batched `ps -p P1,P2,…` cut N subprocess spawns to 1. AppleScript cache bumped 3s → 15s (cuts osascript hits ~5x). NSLock added around the cache since it's now read from the background queue.

### Tests

- `EnvVarTerminalIntegrationTests` (7), `VSCodeIntegrationTests` (10) — parser correctness across single/multi/empty/garbage input, env var parameter respected, recognised-helper whitelist, event-fed cache → enrich loop via a testing seam.
- `SessionPersistenceTests` (+6), `SessionColorTests` (+3) — tabId-aware lookups, generic → tabId fallback, override semantics, color stability with/without tabId, palette membership.
- `AgentTests` (+1) — antigravity / antigravity-cli / agy three-way canonicalisation.

## Testing

- `swift build` + `./build.sh` clean.
- `make reload`, fired varied trial events covering all five terminals plus Antigravity + agy. Verified:
  - Per-tab accent colors (two iTerm tabs in same cwd → different colors; same ipc_hook in VSCode → same color).
  - Terminal chip renders correctly across iTerm2, Terminal, VSCode, Warp, Ghostty, Antigravity.
  - EventRow falls back to ipcHook when sessionID is missing.
  - Sessions tab scroll is smooth with 15 active iTerm sessions (was hitching every 3s pre-perf-fix).
- Manual rename loop: renamed a running claude session in the Sessions tab → matching event rows updated immediately.
- CI's `test-macos` job (`swift test`) runs the 27 new XCTest cases.