### PR TITLE
feat: Post-launch polish: launch-at-login toggle + OAuth token caching

### DIFF
--- a/panel/Bootstrap.swift
+++ b/panel/Bootstrap.swift
@@ -677,6 +677,37 @@ enum Bootstrap {
 
     // MARK: - Launchctl
 
+    // Toggle the panel LaunchAgent's "launch at login" behavior.
+    // Enable: ensure the plist is on disk and loaded into launchd (RunAtLoad
+    // makes the next login start the panel automatically). Disable: unload
+    // and delete the plist — without it, launchd has no record of the agent
+    // and skips it at login. The currently-running panel process is left
+    // alone in both cases; this only affects the next login.
+    //
+    // The daemon plist (com.stackonehq.stack-nudge-daemon) is intentionally
+    // untouched — voice playback is an independent concern and its loaded
+    // state shouldn't change when the user toggles the panel's auto-launch.
+    static func setLaunchAtLogin(_ enabled: Bool) throws {
+        let plistPath = "\(launchAgentsDir)/\(appLabel).plist"
+        if enabled {
+            if !FileManager.default.fileExists(atPath: plistPath) {
+                try writePanelPlist()
+            }
+            try loadLaunchdAgent(label: appLabel)
+        } else {
+            _ = try? runLaunchctl(["unload", plistPath])
+            try? FileManager.default.removeItem(atPath: plistPath)
+        }
+    }
+
+    // Whether the panel LaunchAgent plist currently exists on disk —
+    // the source of truth for the "Launch at login" toggle. Loaded state
+    // (launchctl list) drifts: launchd will report the agent as loaded
+    // for the rest of the session even after the plist is deleted.
+    static func isLaunchAtLoginEnabled() -> Bool {
+        FileManager.default.fileExists(atPath: "\(launchAgentsDir)/\(appLabel).plist")
+    }
+
     private static func loadLaunchdAgent(label: String) throws {
         let plist = "\(launchAgentsDir)/\(label).plist"
         // Unload first (no-op if not loaded) to handle the re-install case

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -27,6 +27,7 @@ private enum KeyCode {
     static let three:     UInt16 = 20
     static let four:      UInt16 = 21
     static let nKey:      UInt16 = 45
+    static let pKey:      UInt16 = 35
 }
 
 // Floating, non-activating panel. Shown via global hotkey; receives key
@@ -1575,6 +1576,13 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                 scrollUsageBy(40)
             case KeyCode.rKey:
                 syncQuotaNow()
+            case KeyCode.pKey:
+                nav.toggleQuotaTracking()
+                // Immediate probe on resume so the user sees fresh data
+                // right after the keystroke — otherwise they'd wait for
+                // the next scheduled tick (up to the configured poll
+                // interval, which could be 30 min).
+                if nav.quotaTrackingEnabled { syncQuotaNow() }
             default:
                 break
             }

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -574,6 +574,17 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                 self?.phrases.selectedRow = nil
                 self?.nav.mode = .phrases
             },
+            openReleaseNotes: {
+                // Versioned tag URL when we know the bundle version,
+                // otherwise the releases index. Tag URL falls through
+                // to /releases on 404, so a typo'd version still lands
+                // the user somewhere useful.
+                let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+                let url = version.flatMap {
+                    URL(string: "https://github.com/StackOneHQ/stack-nudge/releases/tag/v\($0)")
+                } ?? URL(string: "https://github.com/StackOneHQ/stack-nudge/releases")!
+                NSWorkspace.shared.open(url)
+            },
             beginUpdate:      { [weak self] in self?.beginUpdateFlow() },
             runUpdate:        { [weak self] in self?.updater?.run() },
             beginUninstall:   { [weak self] in self?.beginUninstallFlow() },
@@ -781,6 +792,10 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         return max(60, mins * 60)  // floor at 60s to avoid hammering the endpoint
     }
 
+    private var quotaTrackingEnabled: Bool {
+        ConfigFile.bool(ConfigFile.read(), "STACKNUDGE_QUOTA_TRACKING", default: true)
+    }
+
     private func startQuotaPolling() {
         runQuotaProbe()
         scheduleNextQuotaPoll()
@@ -788,6 +803,9 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
 
     private func scheduleNextQuotaPoll() {
         quotaTimer?.invalidate()
+        // Schedule unconditionally so a re-enable from Settings picks up
+        // again on the next tick without needing an explicit start call.
+        // The probe itself bails when tracking is off.
         let interval = panel.isVisible ? Self.quotaPollVisibleInterval : quotaPollHiddenInterval
         quotaTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: false) { [weak self] _ in
             self?.runQuotaProbe()
@@ -796,6 +814,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     }
 
     private func runQuotaProbe() {
+        guard quotaTrackingEnabled else { return }
         quotaProbe.fetch { [weak self] snapshot in
             guard let self, let snapshot else { return }
             self.nav.quota = snapshot

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -815,13 +815,19 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
 
     private func runQuotaProbe() {
         guard quotaTrackingEnabled else { return }
+        nav.quotaSyncing = true
         quotaProbe.fetch { [weak self] snapshot in
-            guard let self, let snapshot else { return }
+            guard let self else { return }
+            self.nav.quotaSyncing = false
+            guard let snapshot else { return }
             self.nav.quota = snapshot
             self.nav.quotaLastUpdated = Date()
             self.evaluateQuotaThresholds(snapshot)
         }
     }
+
+    // Public hook for the Usage tab's "Sync now" keystroke.
+    func syncQuotaNow() { runQuotaProbe() }
 
     // Fire a banner each time a tier crosses into a new 5% bucket at or
     // above the user's configured threshold. With threshold=80, the user
@@ -1567,6 +1573,8 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                 scrollUsageBy(-40)
             case KeyCode.downArrow:
                 scrollUsageBy(40)
+            case KeyCode.rKey:
+                syncQuotaNow()
             default:
                 break
             }

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -100,6 +100,9 @@ final class PanelNav: ObservableObject {
     // probe failed (e.g. user denied keychain access, 401, 429).
     @Published var quota:            QuotaSnapshot?
     @Published var quotaLastUpdated: Date?
+    // True while a probe is in-flight. Set by PanelController around the
+    // fetch call so the UI can swap the footer status to "Syncing…".
+    @Published var quotaSyncing:     Bool = false
     // Threshold-crossing notifications. quotaAlertsEnabled is the master
     // switch; quotaAlertThreshold is the single percent value used across
     // all tiers — banner fires once per period when any tier reaches it.

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -449,6 +449,21 @@ final class PanelNav: ObservableObject {
     func cycleForward()  { applyCycle(forward: true) }
     func cycleBackward() { applyCycle(forward: false) }
 
+    // Shared by Settings row 11 and the Usage tab's 'p' keystroke. On
+    // pause, drop the cached snapshot so the Usage tab doesn't sit on
+    // stale data; on resume, the caller is responsible for kicking off
+    // an immediate probe (so the user sees fresh data right after the
+    // shortcut, not after the next scheduled tick).
+    func toggleQuotaTracking() {
+        quotaTrackingEnabled.toggle()
+        ConfigFile.write(key: "STACKNUDGE_QUOTA_TRACKING",
+                         value: quotaTrackingEnabled ? "true" : "false")
+        if !quotaTrackingEnabled {
+            quota = nil
+            quotaLastUpdated = nil
+        }
+    }
+
     private func applyCycle(forward: Bool) {
         // Update row (when present at index 0) treats left/right arrows the
         // same as Enter — there's nothing to cycle, so just begin update.
@@ -508,16 +523,7 @@ final class PanelNav: ObservableObject {
             voiceSpeed = max(Self.speedMin, min(Self.speedMax, (next * 100).rounded() / 100))
             ConfigFile.write(key: "STACKNUDGE_VOICE_SPEED", value: String(format: "%.2f", voiceSpeed))
         case 11:
-            quotaTrackingEnabled.toggle()
-            ConfigFile.write(key: "STACKNUDGE_QUOTA_TRACKING",
-                             value: quotaTrackingEnabled ? "true" : "false")
-            // Drop the cached snapshot so the Usage tab doesn't sit on
-            // stale data while tracking is off — and so re-enabling shows
-            // the "Loading…" state rather than data from before the pause.
-            if !quotaTrackingEnabled {
-                quota = nil
-                quotaLastUpdated = nil
-            }
+            toggleQuotaTracking()
         case 12:
             quotaAlertsEnabled.toggle()
             ConfigFile.write(key: "STACKNUDGE_QUOTA_ALERTS",

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -34,6 +34,7 @@ struct SettingsActions {
     let checkPermissions: () -> Void
     let openConfig:       () -> Void
     let editPhrases:      () -> Void
+    let openReleaseNotes: () -> Void
     let beginUpdate:      () -> Void
     let runUpdate:        () -> Void
     let beginUninstall:   () -> Void
@@ -102,8 +103,15 @@ final class PanelNav: ObservableObject {
     // Threshold-crossing notifications. quotaAlertsEnabled is the master
     // switch; quotaAlertThreshold is the single percent value used across
     // all tiers — banner fires once per period when any tier reaches it.
-    @Published var quotaAlertsEnabled:  Bool = true
-    @Published var quotaAlertThreshold: Int  = 80
+    @Published var quotaTrackingEnabled: Bool = true
+    @Published var quotaAlertsEnabled:   Bool = true
+    @Published var quotaAlertThreshold:  Int  = 80
+    // Background poll interval in minutes when the panel is hidden.
+    // Visible-panel polling is fixed at 60s (see Panel.swift). Cycle
+    // values intentionally constrained — finer granularity isn't
+    // useful for a usage gauge that updates server-side every minute.
+    @Published var quotaPollMinutes:     Int  = 5
+    static let quotaPollMinuteOptions: [Int] = [1, 2, 5, 10, 15, 30]
     // First-launch bootstrap wizard state. Populated by PanelController
     // on launch when Bootstrap.isInstalled() returns false; drives
     // BootstrapView (mode = .bootstrap).
@@ -176,7 +184,7 @@ final class PanelNav: ObservableObject {
     // when the offset is 1.
     var updateRowOffset: Int { updateAvailable != nil ? 1 : 0 }
 
-    var rowCount: Int { 18 + updateRowOffset }
+    var rowCount: Int { 21 + updateRowOffset }
 
     // Row layout (kept in one place so the controller, view, and indexing
     // logic all agree on what each row index means). When updateAvailable
@@ -193,13 +201,16 @@ final class PanelNav: ObservableObject {
     //   8  Permission sound      cycle
     //   9  Voice                 cycle       (or "Download model" action)
     //  10  Speed                 cycle
-    //  11  Quota alerts          toggle
-    //  12  Alert threshold       cycle
-    //  13  Edit phrases…         action
-    //  14  Check permissions…    action
-    //  15  Open config file…     action
-    //  16  Uninstall stack-nudge action
-    //  17  Quit panel            action
+    //  11  Quota tracking        toggle      (master; gates rows 12-14)
+    //  12  Quota alerts          toggle
+    //  13  Alert threshold       cycle
+    //  14  Poll frequency        cycle
+    //  15  Edit phrases…         action
+    //  16  Check permissions…    action
+    //  17  Open config file…     action
+    //  18  View release notes…   action
+    //  19  Uninstall stack-nudge action
+    //  20  Quit panel            action
 
     // MARK: - Disk I/O
 
@@ -221,11 +232,15 @@ final class PanelNav: ObservableObject {
         soundPermission = config["STACKNUDGE_SOUND_PERMISSION"] ?? "Ping"
         voice           = config["STACKNUDGE_VOICE_NAME"]       ?? "af_aoede"
         voiceSpeed      = Double(config["STACKNUDGE_VOICE_SPEED"] ?? "") ?? 1.1
-        quotaAlertsEnabled  = ConfigFile.bool(config, "STACKNUDGE_QUOTA_ALERTS", default: true)
+        quotaTrackingEnabled = ConfigFile.bool(config, "STACKNUDGE_QUOTA_TRACKING", default: true)
+        quotaAlertsEnabled   = ConfigFile.bool(config, "STACKNUDGE_QUOTA_ALERTS",   default: true)
         // Coerce out-of-list values to the nearest valid threshold so a
         // hand-edited config can't desync the cycle row's selection.
         let rawThreshold = Int(config["STACKNUDGE_QUOTA_THRESHOLD"] ?? "") ?? 80
         quotaAlertThreshold = Self.quotaThresholds.min(by: { abs($0 - rawThreshold) < abs($1 - rawThreshold) }) ?? 80
+        // Same coercion for poll interval — snap to nearest valid option.
+        let rawPoll = Int(config["STACKNUDGE_USAGE_POLL_MIN"] ?? "") ?? 5
+        quotaPollMinutes = Self.quotaPollMinuteOptions.min(by: { abs($0 - rawPoll) < abs($1 - rawPoll) }) ?? 5
     }
 
     // MARK: - Agent reconciliation
@@ -418,11 +433,12 @@ final class PanelNav: ObservableObject {
             } else {
                 startVoiceModelDownload()
             }
-        case 13: actions?.editPhrases()
-        case 14: actions?.checkPermissions()
-        case 15: actions?.openConfig()
-        case 16: actions?.beginUninstall()
-        case 17: actions?.quit()
+        case 15: actions?.editPhrases()
+        case 16: actions?.checkPermissions()
+        case 17: actions?.openConfig()
+        case 18: actions?.openReleaseNotes()
+        case 19: actions?.beginUninstall()
+        case 20: actions?.quit()
         default: applyCycle(forward: true)
         }
     }
@@ -489,10 +505,14 @@ final class PanelNav: ObservableObject {
             voiceSpeed = max(Self.speedMin, min(Self.speedMax, (next * 100).rounded() / 100))
             ConfigFile.write(key: "STACKNUDGE_VOICE_SPEED", value: String(format: "%.2f", voiceSpeed))
         case 11:
+            quotaTrackingEnabled.toggle()
+            ConfigFile.write(key: "STACKNUDGE_QUOTA_TRACKING",
+                             value: quotaTrackingEnabled ? "true" : "false")
+        case 12:
             quotaAlertsEnabled.toggle()
             ConfigFile.write(key: "STACKNUDGE_QUOTA_ALERTS",
                              value: quotaAlertsEnabled ? "true" : "false")
-        case 12:
+        case 13:
             // Cycle through the static thresholds list. Index wraps in both
             // directions so the user can dial in either way.
             let list = Self.quotaThresholds
@@ -501,6 +521,13 @@ final class PanelNav: ObservableObject {
             quotaAlertThreshold = list[next]
             ConfigFile.write(key: "STACKNUDGE_QUOTA_THRESHOLD",
                              value: String(quotaAlertThreshold))
+        case 14:
+            let list = Self.quotaPollMinuteOptions
+            let idx = list.firstIndex(of: quotaPollMinutes) ?? 2
+            let next = forward ? (idx + 1) % list.count : (idx - 1 + list.count) % list.count
+            quotaPollMinutes = list[next]
+            ConfigFile.write(key: "STACKNUDGE_USAGE_POLL_MIN",
+                             value: String(quotaPollMinutes))
         default:
             break
         }

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -508,6 +508,13 @@ final class PanelNav: ObservableObject {
             quotaTrackingEnabled.toggle()
             ConfigFile.write(key: "STACKNUDGE_QUOTA_TRACKING",
                              value: quotaTrackingEnabled ? "true" : "false")
+            // Drop the cached snapshot so the Usage tab doesn't sit on
+            // stale data while tracking is off — and so re-enabling shows
+            // the "Loading…" state rather than data from before the pause.
+            if !quotaTrackingEnabled {
+                quota = nil
+                quotaLastUpdated = nil
+            }
         case 12:
             quotaAlertsEnabled.toggle()
             ConfigFile.write(key: "STACKNUDGE_QUOTA_ALERTS",

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -59,6 +59,7 @@ final class PanelNav: ObservableObject {
     @Published var voiceEnabled:    Bool = false
     @Published var muteWhenFocused: Bool = true
     @Published var panelPinned:     Bool = true
+    @Published var launchAtLogin:   Bool = true
     @Published var soundStop:       String = "Glass"
     @Published var soundPermission: String = "Ping"
     @Published var voice:           String = "af_aoede"
@@ -175,7 +176,7 @@ final class PanelNav: ObservableObject {
     // when the offset is 1.
     var updateRowOffset: Int { updateAvailable != nil ? 1 : 0 }
 
-    var rowCount: Int { 17 + updateRowOffset }
+    var rowCount: Int { 18 + updateRowOffset }
 
     // Row layout (kept in one place so the controller, view, and indexing
     // logic all agree on what each row index means). When updateAvailable
@@ -186,18 +187,19 @@ final class PanelNav: ObservableObject {
     //   2  Voice notifications   toggle
     //   3  Mute when focused     toggle
     //   4  Pin panel             toggle
-    //   5  Sound enabled         toggle      (gates rows 6 + 7)
-    //   6  Agent done sound      cycle
-    //   7  Permission sound      cycle
-    //   8  Voice                 cycle       (or "Download model" action)
-    //   9  Speed                 cycle
-    //  10  Quota alerts          toggle
-    //  11  Alert threshold       cycle
-    //  12  Edit phrases…         action
-    //  13  Check permissions…    action
-    //  14  Open config file…     action
-    //  15  Uninstall stack-nudge action
-    //  16  Quit panel            action
+    //   5  Launch at login       toggle
+    //   6  Sound enabled         toggle      (gates rows 7 + 8)
+    //   7  Agent done sound      cycle
+    //   8  Permission sound      cycle
+    //   9  Voice                 cycle       (or "Download model" action)
+    //  10  Speed                 cycle
+    //  11  Quota alerts          toggle
+    //  12  Alert threshold       cycle
+    //  13  Edit phrases…         action
+    //  14  Check permissions…    action
+    //  15  Open config file…     action
+    //  16  Uninstall stack-nudge action
+    //  17  Quit panel            action
 
     // MARK: - Disk I/O
 
@@ -209,6 +211,12 @@ final class PanelNav: ObservableObject {
         voiceEnabled    = ConfigFile.bool(config, "STACKNUDGE_VOICE",     default: false)
         muteWhenFocused = ConfigFile.bool(config, "STACKNUDGE_MUTE_WHEN_FOCUSED", default: true)
         panelPinned     = ConfigFile.bool(config, "STACKNUDGE_PANEL_PIN", default: true)
+        // Source of truth for the toggle is the plist's presence on disk
+        // (Bootstrap.isLaunchAtLoginEnabled) — the config key is just a
+        // mirror used for parity with the other toggles. If the two ever
+        // disagree (e.g. plist removed manually), trust the disk and
+        // re-sync the config the next time the user touches the toggle.
+        launchAtLogin   = Bootstrap.isLaunchAtLoginEnabled()
         soundStop       = config["STACKNUDGE_SOUND_STOP"]       ?? "Glass"
         soundPermission = config["STACKNUDGE_SOUND_PERMISSION"] ?? "Ping"
         voice           = config["STACKNUDGE_VOICE_NAME"]       ?? "af_aoede"
@@ -401,8 +409,8 @@ final class PanelNav: ObservableObject {
         }
         switch selectedSettingIndex - updateRowOffset {
         case 0: startRecordingHotkey()
-        case 8 where !voiceModelCached:
-            // Pre-download state: index 8 is the "Download voice model"
+        case 9 where !voiceModelCached:
+            // Pre-download state: index 9 is the "Download voice model"
             // action, not a cycle. Enter triggers (or cancels) the
             // download.
             if voiceModelDownloading {
@@ -410,11 +418,11 @@ final class PanelNav: ObservableObject {
             } else {
                 startVoiceModelDownload()
             }
-        case 12: actions?.editPhrases()
-        case 13: actions?.checkPermissions()
-        case 14: actions?.openConfig()
-        case 15: actions?.beginUninstall()
-        case 16: actions?.quit()
+        case 13: actions?.editPhrases()
+        case 14: actions?.checkPermissions()
+        case 15: actions?.openConfig()
+        case 16: actions?.beginUninstall()
+        case 17: actions?.quit()
         default: applyCycle(forward: true)
         }
     }
@@ -446,13 +454,25 @@ final class PanelNav: ObservableObject {
             panelPinned.toggle()
             ConfigFile.write(key: "STACKNUDGE_PANEL_PIN", value: panelPinned ? "true" : "false")
         case 5:
+            // Optimistic UI flip; revert if launchctl fails so the toggle
+            // never reports a state that disagrees with the plist on disk.
+            let target = !launchAtLogin
+            launchAtLogin = target
+            do {
+                try Bootstrap.setLaunchAtLogin(target)
+            } catch {
+                launchAtLogin = !target
+                FileHandle.standardError.write(Data(
+                    "stack-nudge: setLaunchAtLogin(\(target)) failed: \(error)\n".utf8))
+            }
+        case 6:
             soundEnabled.toggle()
             ConfigFile.write(key: "STACKNUDGE_SOUND", value: soundEnabled ? "true" : "false")
-        case 6:
-            soundStop = step(soundStop, in: Self.macSounds, forward: forward, key: "STACKNUDGE_SOUND_STOP", preview: true)
         case 7:
-            soundPermission = step(soundPermission, in: Self.macSounds, forward: forward, key: "STACKNUDGE_SOUND_PERMISSION", preview: true)
+            soundStop = step(soundStop, in: Self.macSounds, forward: forward, key: "STACKNUDGE_SOUND_STOP", preview: true)
         case 8:
+            soundPermission = step(soundPermission, in: Self.macSounds, forward: forward, key: "STACKNUDGE_SOUND_PERMISSION", preview: true)
+        case 9:
             // Pre-download: the row is an action, not a cycle. Treat
             // left/right arrow as a trigger so a user discovering the
             // row keyboard-only can still start the download.
@@ -464,15 +484,15 @@ final class PanelNav: ObservableObject {
             voice = step(voice, in: voicesAvailable, forward: forward, key: "STACKNUDGE_VOICE_NAME", preview: false)
             let phrase = Self.voicePreviewPhrases.randomElement() ?? "Hello."
             Speaker.speak(phrase, voice: voice, speed: String(format: "%.2f", voiceSpeed))
-        case 9:
+        case 10:
             let next = forward ? voiceSpeed + Self.speedStep : voiceSpeed - Self.speedStep
             voiceSpeed = max(Self.speedMin, min(Self.speedMax, (next * 100).rounded() / 100))
             ConfigFile.write(key: "STACKNUDGE_VOICE_SPEED", value: String(format: "%.2f", voiceSpeed))
-        case 10:
+        case 11:
             quotaAlertsEnabled.toggle()
             ConfigFile.write(key: "STACKNUDGE_QUOTA_ALERTS",
                              value: quotaAlertsEnabled ? "true" : "false")
-        case 11:
+        case 12:
             // Cycle through the static thresholds list. Index wraps in both
             // directions so the user can dial in either way.
             let list = Self.quotaThresholds

--- a/panel/SessionUsage.swift
+++ b/panel/SessionUsage.swift
@@ -41,6 +41,19 @@ final class QuotaProbe {
 
     private let session: URLSession
 
+    // In-memory cache of the OAuth token. Touched only from the main queue
+    // (fetch is invoked from PanelController's main-thread timer, and the
+    // 401-retry path hops back to main before clearing).
+    //
+    // Why cache: Claude Code rotates this keychain item periodically and
+    // each rotation wipes the trusted-app ACL we got from "Always Allow",
+    // so the next SecItemCopyMatching re-fires the password prompt. Most
+    // rotations happen well before the old token actually expires, so by
+    // holding the token in memory and only re-reading the keychain when
+    // the API rejects it (HTTP 401), we skip the prompts tied to rotations
+    // that didn't invalidate the token we already have.
+    private var cachedToken: String?
+
     init() {
         let cfg = URLSessionConfiguration.ephemeral
         cfg.timeoutIntervalForRequest  = 10
@@ -50,21 +63,45 @@ final class QuotaProbe {
 
     // One-shot probe. Calls completion on the main queue.
     func fetch(completion: @escaping (QuotaSnapshot?) -> Void) {
-        guard let token = readAccessToken() else {
+        fetch(retried: false, completion: completion)
+    }
+
+    private func fetch(retried: Bool, completion: @escaping (QuotaSnapshot?) -> Void) {
+        let token: String
+        if let cached = cachedToken {
+            token = cached
+        } else if let fresh = readAccessToken() {
+            cachedToken = fresh
+            token = fresh
+        } else {
             completion(nil)
             return
         }
+
         var request = URLRequest(url: Self.endpoint)
         request.setValue("Bearer \(token)",       forHTTPHeaderField: "Authorization")
         request.setValue("oauth-2025-04-20",      forHTTPHeaderField: "anthropic-beta")
         request.setValue("application/json",      forHTTPHeaderField: "Content-Type")
         request.setValue("stack-nudge",           forHTTPHeaderField: "User-Agent")
 
-        session.dataTask(with: request) { data, response, _ in
+        session.dataTask(with: request) { [weak self] data, response, _ in
             let http = response as? HTTPURLResponse
-            guard let data, http?.statusCode == 200,
+            let code = http?.statusCode
+
+            // 401 = the token we used is no longer valid (Claude Code rotated
+            // and the old token has actually expired, not just been replaced).
+            // Drop the cache and re-read the keychain exactly once.
+            if code == 401, !retried {
+                DispatchQueue.main.async {
+                    self?.cachedToken = nil
+                    self?.fetch(retried: true, completion: completion)
+                }
+                return
+            }
+
+            guard let data, code == 200,
                   let snapshot = Self.parse(data) else {
-                if let code = http?.statusCode, code != 200 {
+                if let code, code != 200 {
                     FileHandle.standardError.write(Data(
                         "stack-nudge: /api/oauth/usage returned \(code)\n".utf8))
                 }
@@ -79,8 +116,10 @@ final class QuotaProbe {
 
     // Read the Claude Code credentials JSON blob from the macOS Keychain and
     // extract `claudeAiOauth.accessToken`. macOS prompts the user the first
-    // time stack-nudge tries to read this entry — once approved (and once
-    // we're Developer-ID-signed), subsequent reads are silent.
+    // time stack-nudge reads this entry; subsequent reads are silent until
+    // Claude Code rotates the item, which wipes the ACL and re-fires the
+    // prompt. Callers cache the returned token and only re-invoke this on
+    // an API 401 to keep prompt frequency to a minimum.
     private func readAccessToken() -> String? {
         let query: [String: Any] = [
             kSecClass as String:            kSecClassGenericPassword,

--- a/panel/SessionUsage.swift
+++ b/panel/SessionUsage.swift
@@ -229,6 +229,9 @@ struct UsageView: View {
 
             PageFooter {
                 FooterHint(label: footerStatusLabel, keys: [])
+                if nav.quotaTrackingEnabled {
+                    FooterHint(label: "Sync now", keys: ["r"])
+                }
                 FooterHint(label: "Hide", keys: ["esc"])
             }
         }
@@ -319,7 +322,9 @@ struct UsageView: View {
     }
 
     private var footerStatusLabel: String {
-        guard let updated = nav.quotaLastUpdated else { return "Loading…" }
+        if !nav.quotaTrackingEnabled { return "Tracking off" }
+        if nav.quotaSyncing { return "Syncing…" }
+        guard let updated = nav.quotaLastUpdated else { return "Never synced" }
         return "Updated \(Self.relative(.abbreviated, updated))"
     }
 

--- a/panel/SessionUsage.swift
+++ b/panel/SessionUsage.swift
@@ -194,7 +194,9 @@ struct UsageView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if let snapshot = nav.quota, !isAllNil(snapshot) {
+            if !nav.quotaTrackingEnabled {
+                trackingDisabledState
+            } else if let snapshot = nav.quota, !isAllNil(snapshot) {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 14) {
                         if let tier = snapshot.fiveHour {
@@ -279,6 +281,25 @@ struct UsageView: View {
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
             Text("Requires Claude Code login. First read may prompt the system keychain.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 280)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.vertical, 24)
+    }
+
+    private var trackingDisabledState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "pause.circle")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+            Text("Quota tracking is off")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Text("Enable in Settings → Usage → Quota tracking to see your Claude usage here.")
                 .font(.caption)
                 .foregroundStyle(.tertiary)
                 .multilineTextAlignment(.center)

--- a/panel/SessionUsage.swift
+++ b/panel/SessionUsage.swift
@@ -232,6 +232,7 @@ struct UsageView: View {
                 if nav.quotaTrackingEnabled {
                     FooterHint(label: "Sync now", keys: ["r"])
                 }
+                FooterHint(label: nav.quotaTrackingEnabled ? "Pause" : "Resume", keys: ["p"])
                 FooterHint(label: "Hide", keys: ["esc"])
             }
         }

--- a/panel/Settings.swift
+++ b/panel/Settings.swift
@@ -69,16 +69,19 @@ struct SettingsView: View {
                         }
 
                         section("Usage") {
-                            row(11 + off, label: "Quota alerts",    kind: .toggle, value: nav.quotaAlertsEnabled ? "On" : "Off")
-                            row(12 + off, label: "Alert threshold", kind: .cycle,  value: "\(nav.quotaAlertThreshold)%")
+                            row(11 + off, label: "Quota tracking",  kind: .toggle, value: nav.quotaTrackingEnabled ? "On" : "Off")
+                            row(12 + off, label: "Quota alerts",    kind: .toggle, value: nav.quotaAlertsEnabled    ? "On" : "Off")
+                            row(13 + off, label: "Alert threshold", kind: .cycle,  value: "\(nav.quotaAlertThreshold)%")
+                            row(14 + off, label: "Poll frequency",  kind: .cycle,  value: "\(nav.quotaPollMinutes) min")
                         }
 
                         section("Actions") {
-                            row(13 + off, label: "Edit phrases…",         kind: .action, value: "")
-                            row(14 + off, label: "Check permissions…",    kind: .action, value: "")
-                            row(15 + off, label: "Open config file…",     kind: .action, value: "")
-                            row(16 + off, label: "Uninstall StackNudge…", kind: .action, value: "")
-                            row(17 + off, label: "Quit panel",            kind: .action, value: "")
+                            row(15 + off, label: "Edit phrases…",         kind: .action, value: "")
+                            row(16 + off, label: "Check permissions…",    kind: .action, value: "")
+                            row(17 + off, label: "Open config file…",     kind: .action, value: "")
+                            row(18 + off, label: "View release notes…",   kind: .action, value: "")
+                            row(19 + off, label: "Uninstall StackNudge…", kind: .action, value: "")
+                            row(20 + off, label: "Quit panel",            kind: .action, value: "")
                         }
 
                         aboutFooter

--- a/panel/Settings.swift
+++ b/panel/Settings.swift
@@ -50,34 +50,35 @@ struct SettingsView: View {
                             row(2 + off, label: "Voice notifications",  kind: .toggle, value: nav.voiceEnabled    ? "On" : "Off")
                             row(3 + off, label: "Mute when focused",    kind: .toggle, value: nav.muteWhenFocused ? "On" : "Off")
                             row(4 + off, label: "Pin panel",            kind: .toggle, value: nav.panelPinned     ? "On" : "Off")
+                            row(5 + off, label: "Launch at login",      kind: .toggle, value: nav.launchAtLogin   ? "On" : "Off")
                         }
 
                         section("Sounds") {
-                            row(5 + off, label: "Sound enabled", kind: .toggle, value: nav.soundEnabled ? "On" : "Off")
-                            row(6 + off, label: "Agent done",    kind: .cycle,  value: nav.soundStop)
-                            row(7 + off, label: "Permission",    kind: .cycle,  value: nav.soundPermission)
+                            row(6 + off, label: "Sound enabled", kind: .toggle, value: nav.soundEnabled ? "On" : "Off")
+                            row(7 + off, label: "Agent done",    kind: .cycle,  value: nav.soundStop)
+                            row(8 + off, label: "Permission",    kind: .cycle,  value: nav.soundPermission)
                         }
 
                         section("Voice") {
                             if nav.voiceModelCached {
-                                row(8 + off, label: "Voice",  kind: .cycle, value: voiceLabel)
-                                row(9 + off, label: "Speed",  kind: .cycle, value: String(format: "%.2f×", nav.voiceSpeed))
+                                row(9 + off,  label: "Voice", kind: .cycle, value: voiceLabel)
+                                row(10 + off, label: "Speed", kind: .cycle, value: String(format: "%.2f×", nav.voiceSpeed))
                             } else {
-                                voiceModelDownloadRow(index: 8 + off)
+                                voiceModelDownloadRow(index: 9 + off)
                             }
                         }
 
                         section("Usage") {
-                            row(10 + off, label: "Quota alerts",    kind: .toggle, value: nav.quotaAlertsEnabled ? "On" : "Off")
-                            row(11 + off, label: "Alert threshold", kind: .cycle,  value: "\(nav.quotaAlertThreshold)%")
+                            row(11 + off, label: "Quota alerts",    kind: .toggle, value: nav.quotaAlertsEnabled ? "On" : "Off")
+                            row(12 + off, label: "Alert threshold", kind: .cycle,  value: "\(nav.quotaAlertThreshold)%")
                         }
 
                         section("Actions") {
-                            row(12 + off, label: "Edit phrases…",         kind: .action, value: "")
-                            row(13 + off, label: "Check permissions…",    kind: .action, value: "")
-                            row(14 + off, label: "Open config file…",     kind: .action, value: "")
-                            row(15 + off, label: "Uninstall StackNudge…", kind: .action, value: "")
-                            row(16 + off, label: "Quit panel",            kind: .action, value: "")
+                            row(13 + off, label: "Edit phrases…",         kind: .action, value: "")
+                            row(14 + off, label: "Check permissions…",    kind: .action, value: "")
+                            row(15 + off, label: "Open config file…",     kind: .action, value: "")
+                            row(16 + off, label: "Uninstall StackNudge…", kind: .action, value: "")
+                            row(17 + off, label: "Quit panel",            kind: .action, value: "")
                         }
 
                         aboutFooter


### PR DESCRIPTION
## Summary

A bundle of small UX + behavior polish landing after the v1.9.1 launch.

### Settings
- **Launch at login** toggle (default On). Off unloads + deletes the panel LaunchAgent plist; On rewrites and reloads it. Daemon plist (voice) is intentionally untouched.
- **Quota tracking** master toggle (default On). Off disables the `/api/oauth/usage` poller entirely — hard kill switch for users who don't want keychain access for usage tracking.
- **Poll frequency** cycle (1 / 2 / 5 / 10 / 15 / 30 min) — surfaces `STACKNUDGE_USAGE_POLL_MIN` from config to the UI. Visible-panel cadence stays fixed at 60s.
- **View release notes…** action — opens `github.com/StackOneHQ/stack-nudge/releases/tag/v<version>` for the running bundle, falls back to `/releases` if version unknown.

### Usage tab
- **`r` keystroke**: sync now (immediate probe), with footer hint.
- **`p` keystroke**: pause / resume tracking without leaving the tab. On resume, fires an immediate probe so fresh data appears right away.
- **Richer footer status**: distinguishes `Tracking off` / `Syncing…` / `Never synced` / `Updated Ns ago` instead of just the relative time.
- **Explicit empty state when tracking is off**: clears the cached snapshot on toggle-off so the tab doesn't show stale data; renders a dedicated "Quota tracking is off" panel with a pointer back to Settings.

### Keychain prompt fix
- `QuotaProbe` now caches the OAuth token in memory and only re-reads the keychain on a 401. Claude Code rotates its keychain item periodically (which wipes the trusted-app ACL granted via "Always Allow"); caching means we only hit the keychain — and therefore only risk a prompt — when the current token actually stops working. Cuts prompt frequency to true-expiry cadence instead of rotation cadence.

## Test plan
- [ ] Settings: confirm new rows render in the right sections, row count = 21 (or 22 with update banner). Arrow-key navigation lands on each new row correctly.
- [ ] Toggle "Launch at login" off → plist removed from `~/Library/LaunchAgents/`. On → plist returns and `launchctl list | grep stackonehq` shows it loaded. Log out + back in to verify auto-launch behavior matches the toggle.
- [ ] Toggle "Quota tracking" off → Usage tab shows "Quota tracking is off" empty state; footer shows "Tracking off"; `r` and `Sync now` hint hidden. On → probe fires within the configured interval; footer shows fresh "Updated Ns ago".
- [ ] Cycle "Poll frequency" → next scheduled tick uses the new interval (no restart needed).
- [ ] "View release notes…" → opens the release page in browser for the running version.
- [ ] Usage tab: press `r` → footer briefly shows "Syncing…" then "Updated 0s ago". Press `p` → snapshot clears, footer says "Tracking off", hint flips to "Resume". Press `p` again → immediate probe fires.
- [ ] Leave panel open for >1h → no keychain password prompts at the Claude Code rotation cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)