### PR TITLE
fix: Settings polish: check-for-updates, faster update interval, gated-row dimming, voice section reshuffle

### DIFF
--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -586,6 +586,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                 } ?? URL(string: "https://github.com/StackOneHQ/stack-nudge/releases")!
                 NSWorkspace.shared.open(url)
             },
+            checkForUpdates:  { [weak self] in self?.updateChecker?.check() },
             beginUpdate:      { [weak self] in self?.beginUpdateFlow() },
             runUpdate:        { [weak self] in self?.updater?.run() },
             beginUninstall:   { [weak self] in self?.beginUninstallFlow() },

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -586,7 +586,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                 } ?? URL(string: "https://github.com/StackOneHQ/stack-nudge/releases")!
                 NSWorkspace.shared.open(url)
             },
-            checkForUpdates:  { [weak self] in self?.updateChecker?.check() },
+            checkForUpdates:  { [weak self] in self?.runUserUpdateCheck() },
             beginUpdate:      { [weak self] in self?.beginUpdateFlow() },
             runUpdate:        { [weak self] in self?.updater?.run() },
             beginUninstall:   { [weak self] in self?.beginUninstallFlow() },
@@ -830,6 +830,35 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
 
     // Public hook for the Usage tab's "Sync now" keystroke.
     func syncQuotaNow() { runQuotaProbe() }
+
+    // User-triggered update check with transient row feedback. Sets
+    // .checking immediately, swaps to .upToDate / .failed on response
+    // (the .updateAvailable path doesn't need transient feedback — the
+    // pinned "Update to vX.Y.Z" row at the top is its own signal), and
+    // auto-clears back to .idle after a few seconds.
+    private func runUserUpdateCheck() {
+        nav.updateCheckStatus = .checking
+        updateChecker?.check { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .updateAvailable:
+                self.nav.updateCheckStatus = .idle
+            case .upToDate:
+                self.nav.updateCheckStatus = .upToDate
+            case .failed:
+                self.nav.updateCheckStatus = .failed
+            }
+            // Auto-clear so the row label returns to neutral on the
+            // next time the user opens Settings. 3s is long enough to
+            // notice, short enough not to mislead a later glance.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
+                guard let self else { return }
+                if self.nav.updateCheckStatus != .checking {
+                    self.nav.updateCheckStatus = .idle
+                }
+            }
+        }
+    }
 
     // Fire a banner each time a tier crosses into a new 5% bucket at or
     // above the user's configured threshold. With threshold=80, the user

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -838,23 +838,30 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     // auto-clears back to .idle after a few seconds.
     private func runUserUpdateCheck() {
         nav.updateCheckStatus = .checking
+        // Minimum visible duration for the "Checking…" flash. Without
+        // it, a sub-second network call would swap status faster than
+        // the user can perceive, leaving the click feeling silent.
+        let started = Date()
+        let minChecking: TimeInterval = 0.6
         updateChecker?.check { [weak self] result in
             guard let self else { return }
-            switch result {
-            case .updateAvailable:
-                self.nav.updateCheckStatus = .idle
-            case .upToDate:
-                self.nav.updateCheckStatus = .upToDate
-            case .failed:
-                self.nav.updateCheckStatus = .failed
-            }
-            // Auto-clear so the row label returns to neutral on the
-            // next time the user opens Settings. 3s is long enough to
-            // notice, short enough not to mislead a later glance.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
+            let elapsed = Date().timeIntervalSince(started)
+            let delay = max(0, minChecking - elapsed)
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
                 guard let self else { return }
-                if self.nav.updateCheckStatus != .checking {
-                    self.nav.updateCheckStatus = .idle
+                switch result {
+                case .updateAvailable: self.nav.updateCheckStatus = .updateAvailable
+                case .upToDate:        self.nav.updateCheckStatus = .upToDate
+                case .failed:          self.nav.updateCheckStatus = .failed
+                }
+                // Auto-clear so the row label returns to neutral on the
+                // next visit. 3s is long enough to notice, short enough
+                // not to mislead a later glance.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
+                    guard let self else { return }
+                    if self.nav.updateCheckStatus != .checking {
+                        self.nav.updateCheckStatus = .idle
+                    }
                 }
             }
         }

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -34,6 +34,7 @@ enum UpdateCheckStatus: Equatable {
     case idle
     case checking
     case upToDate
+    case updateAvailable
     case failed
 }
 

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -30,6 +30,13 @@ enum PanelMode {
 // Action callbacks the controller wires into nav so settings rows like
 // "Check permissions" / "Open config" / "Quit" can fire effects without the
 // SwiftUI view needing to know about windows or app-level state.
+enum UpdateCheckStatus: Equatable {
+    case idle
+    case checking
+    case upToDate
+    case failed
+}
+
 struct SettingsActions {
     let checkPermissions: () -> Void
     let openConfig:       () -> Void
@@ -104,6 +111,11 @@ final class PanelNav: ObservableObject {
     // True while a probe is in-flight. Set by PanelController around the
     // fetch call so the UI can swap the footer status to "Syncing…".
     @Published var quotaSyncing:     Bool = false
+    // Transient feedback for the "Check for updates…" action row.
+    // Set by PanelController around UpdateChecker.check(); cleared
+    // back to .idle a few seconds after a terminal result so the
+    // row reads "Check for updates…" again on subsequent visits.
+    @Published var updateCheckStatus: UpdateCheckStatus = .idle
     // Threshold-crossing notifications. quotaAlertsEnabled is the master
     // switch; quotaAlertThreshold is the single percent value used across
     // all tiers — banner fires once per period when any tier reaches it.

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -35,6 +35,7 @@ struct SettingsActions {
     let openConfig:       () -> Void
     let editPhrases:      () -> Void
     let openReleaseNotes: () -> Void
+    let checkForUpdates:  () -> Void
     let beginUpdate:      () -> Void
     let runUpdate:        () -> Void
     let beginUninstall:   () -> Void
@@ -187,7 +188,7 @@ final class PanelNav: ObservableObject {
     // when the offset is 1.
     var updateRowOffset: Int { updateAvailable != nil ? 1 : 0 }
 
-    var rowCount: Int { 21 + updateRowOffset }
+    var rowCount: Int { 22 + updateRowOffset }
 
     // Row layout (kept in one place so the controller, view, and indexing
     // logic all agree on what each row index means). When updateAvailable
@@ -212,8 +213,9 @@ final class PanelNav: ObservableObject {
     //  16  Check permissions…    action
     //  17  Open config file…     action
     //  18  View release notes…   action
-    //  19  Uninstall stack-nudge action
-    //  20  Quit panel            action
+    //  19  Check for updates…    action
+    //  20  Uninstall stack-nudge action
+    //  21  Quit panel            action
 
     // MARK: - Disk I/O
 
@@ -440,8 +442,9 @@ final class PanelNav: ObservableObject {
         case 16: actions?.checkPermissions()
         case 17: actions?.openConfig()
         case 18: actions?.openReleaseNotes()
-        case 19: actions?.beginUninstall()
-        case 20: actions?.quit()
+        case 19: actions?.checkForUpdates()
+        case 20: actions?.beginUninstall()
+        case 21: actions?.quit()
         default: applyCycle(forward: true)
         }
     }

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -209,13 +209,13 @@ final class PanelNav: ObservableObject {
     // shifts down by one — use `index - updateRowOffset` when matching:
     //   0  Hotkey                hotkey-record
     //   1  Banner notifications  toggle
-    //   2  Voice notifications   toggle
-    //   3  Mute when focused     toggle
-    //   4  Pin panel             toggle
-    //   5  Launch at login       toggle
-    //   6  Sound enabled         toggle      (gates rows 7 + 8)
-    //   7  Agent done sound      cycle
-    //   8  Permission sound      cycle
+    //   2  Mute when focused     toggle
+    //   3  Pin panel             toggle
+    //   4  Launch at login       toggle
+    //   5  Sound enabled         toggle      (gates rows 6 + 7)
+    //   6  Agent done sound      cycle
+    //   7  Permission sound      cycle
+    //   8  Voice notifications   toggle      (gates rows 9 + 10)
     //   9  Voice                 cycle       (or "Download model" action)
     //  10  Speed                 cycle
     //  11  Quota tracking        toggle      (master; gates rows 12-14)
@@ -495,15 +495,12 @@ final class PanelNav: ObservableObject {
             bannerEnabled.toggle()
             ConfigFile.write(key: "STACKNUDGE_BANNER", value: bannerEnabled ? "true" : "false")
         case 2:
-            voiceEnabled.toggle()
-            ConfigFile.write(key: "STACKNUDGE_VOICE", value: voiceEnabled ? "true" : "false")
-        case 3:
             muteWhenFocused.toggle()
             ConfigFile.write(key: "STACKNUDGE_MUTE_WHEN_FOCUSED", value: muteWhenFocused ? "true" : "false")
-        case 4:
+        case 3:
             panelPinned.toggle()
             ConfigFile.write(key: "STACKNUDGE_PANEL_PIN", value: panelPinned ? "true" : "false")
-        case 5:
+        case 4:
             // Optimistic UI flip; revert if launchctl fails so the toggle
             // never reports a state that disagrees with the plist on disk.
             let target = !launchAtLogin
@@ -515,13 +512,16 @@ final class PanelNav: ObservableObject {
                 FileHandle.standardError.write(Data(
                     "stack-nudge: setLaunchAtLogin(\(target)) failed: \(error)\n".utf8))
             }
-        case 6:
+        case 5:
             soundEnabled.toggle()
             ConfigFile.write(key: "STACKNUDGE_SOUND", value: soundEnabled ? "true" : "false")
-        case 7:
+        case 6:
             soundStop = step(soundStop, in: Self.macSounds, forward: forward, key: "STACKNUDGE_SOUND_STOP", preview: true)
-        case 8:
+        case 7:
             soundPermission = step(soundPermission, in: Self.macSounds, forward: forward, key: "STACKNUDGE_SOUND_PERMISSION", preview: true)
+        case 8:
+            voiceEnabled.toggle()
+            ConfigFile.write(key: "STACKNUDGE_VOICE", value: voiceEnabled ? "true" : "false")
         case 9:
             // Pre-download: the row is an action, not a cycle. Treat
             // left/right arrow as a trigger so a user discovering the

--- a/panel/Settings.swift
+++ b/panel/Settings.swift
@@ -80,8 +80,9 @@ struct SettingsView: View {
                             row(16 + off, label: "Check permissions…",    kind: .action, value: "")
                             row(17 + off, label: "Open config file…",     kind: .action, value: "")
                             row(18 + off, label: "View release notes…",   kind: .action, value: "")
-                            row(19 + off, label: "Uninstall StackNudge…", kind: .action, value: "")
-                            row(20 + off, label: "Quit panel",            kind: .action, value: "")
+                            row(19 + off, label: "Check for updates…",    kind: .action, value: "")
+                            row(20 + off, label: "Uninstall StackNudge…", kind: .action, value: "")
+                            row(21 + off, label: "Quit panel",            kind: .action, value: "")
                         }
 
                         aboutFooter

--- a/panel/Settings.swift
+++ b/panel/Settings.swift
@@ -47,22 +47,22 @@ struct SettingsView: View {
 
                         section("Toggles") {
                             row(1 + off, label: "Banner notifications", kind: .toggle, value: nav.bannerEnabled   ? "On" : "Off")
-                            row(2 + off, label: "Voice notifications",  kind: .toggle, value: nav.voiceEnabled    ? "On" : "Off")
-                            row(3 + off, label: "Mute when focused",    kind: .toggle, value: nav.muteWhenFocused ? "On" : "Off")
-                            row(4 + off, label: "Pin panel",            kind: .toggle, value: nav.panelPinned     ? "On" : "Off")
-                            row(5 + off, label: "Launch at login",      kind: .toggle, value: nav.launchAtLogin   ? "On" : "Off")
+                            row(2 + off, label: "Mute when focused",    kind: .toggle, value: nav.muteWhenFocused ? "On" : "Off")
+                            row(3 + off, label: "Pin panel",            kind: .toggle, value: nav.panelPinned     ? "On" : "Off")
+                            row(4 + off, label: "Launch at login",      kind: .toggle, value: nav.launchAtLogin   ? "On" : "Off")
                         }
 
                         section("Sounds") {
-                            row(6 + off, label: "Sound enabled", kind: .toggle, value: nav.soundEnabled ? "On" : "Off")
-                            row(7 + off, label: "Agent done",    kind: .cycle,  value: nav.soundStop,       enabled: nav.soundEnabled)
-                            row(8 + off, label: "Permission",    kind: .cycle,  value: nav.soundPermission, enabled: nav.soundEnabled)
+                            row(5 + off, label: "Sound enabled", kind: .toggle, value: nav.soundEnabled ? "On" : "Off")
+                            row(6 + off, label: "Agent done",    kind: .cycle,  value: nav.soundStop,       enabled: nav.soundEnabled)
+                            row(7 + off, label: "Permission",    kind: .cycle,  value: nav.soundPermission, enabled: nav.soundEnabled)
                         }
 
                         section("Voice") {
+                            row(8 + off, label: "Voice notifications", kind: .toggle, value: nav.voiceEnabled ? "On" : "Off")
                             if nav.voiceModelCached {
-                                row(9 + off,  label: "Voice", kind: .cycle, value: voiceLabel)
-                                row(10 + off, label: "Speed", kind: .cycle, value: String(format: "%.2f×", nav.voiceSpeed))
+                                row(9 + off,  label: "Voice", kind: .cycle, value: voiceLabel,                                  enabled: nav.voiceEnabled)
+                                row(10 + off, label: "Speed", kind: .cycle, value: String(format: "%.2f×", nav.voiceSpeed),     enabled: nav.voiceEnabled)
                             } else {
                                 voiceModelDownloadRow(index: 9 + off)
                             }

--- a/panel/Settings.swift
+++ b/panel/Settings.swift
@@ -289,6 +289,7 @@ struct SettingsView: View {
         case .idle:             return ""
         case .checking:         return "Checking…"
         case .upToDate:         return "Up to date"
+        case .updateAvailable:  return "Update available"
         case .failed:           return "Failed"
         }
     }

--- a/panel/Settings.swift
+++ b/panel/Settings.swift
@@ -55,8 +55,8 @@ struct SettingsView: View {
 
                         section("Sounds") {
                             row(6 + off, label: "Sound enabled", kind: .toggle, value: nav.soundEnabled ? "On" : "Off")
-                            row(7 + off, label: "Agent done",    kind: .cycle,  value: nav.soundStop)
-                            row(8 + off, label: "Permission",    kind: .cycle,  value: nav.soundPermission)
+                            row(7 + off, label: "Agent done",    kind: .cycle,  value: nav.soundStop,       enabled: nav.soundEnabled)
+                            row(8 + off, label: "Permission",    kind: .cycle,  value: nav.soundPermission, enabled: nav.soundEnabled)
                         }
 
                         section("Voice") {
@@ -70,9 +70,9 @@ struct SettingsView: View {
 
                         section("Usage") {
                             row(11 + off, label: "Quota tracking",  kind: .toggle, value: nav.quotaTrackingEnabled ? "On" : "Off")
-                            row(12 + off, label: "Quota alerts",    kind: .toggle, value: nav.quotaAlertsEnabled    ? "On" : "Off")
-                            row(13 + off, label: "Alert threshold", kind: .cycle,  value: "\(nav.quotaAlertThreshold)%")
-                            row(14 + off, label: "Poll frequency",  kind: .cycle,  value: "\(nav.quotaPollMinutes) min")
+                            row(12 + off, label: "Quota alerts",    kind: .toggle, value: nav.quotaAlertsEnabled    ? "On" : "Off", enabled: nav.quotaTrackingEnabled)
+                            row(13 + off, label: "Alert threshold", kind: .cycle,  value: "\(nav.quotaAlertThreshold)%",            enabled: nav.quotaTrackingEnabled && nav.quotaAlertsEnabled)
+                            row(14 + off, label: "Poll frequency",  kind: .cycle,  value: "\(nav.quotaPollMinutes) min",            enabled: nav.quotaTrackingEnabled)
                         }
 
                         section("Actions") {
@@ -370,13 +370,19 @@ struct SettingsView: View {
     }
 
     @ViewBuilder
-    private func row(_ index: Int, label: String, kind: SettingsKind, value: String) -> some View {
+    private func row(_ index: Int, label: String, kind: SettingsKind, value: String, enabled: Bool = true) -> some View {
         SettingsRowView(
             label: label,
             value: value,
             kind: kind,
             selected: nav.selectedSettingIndex == index
         )
+        // Visual-only dimming when a row is gated by another setting
+        // (Sound section's deps when Sound is off; Usage deps when
+        // Quota tracking is off). Keyboard navigation still lands on
+        // these rows so muscle memory isn't disrupted — the user just
+        // sees that the row is currently inert.
+        .opacity(enabled ? 1.0 : 0.4)
         .id(index)
         .onTapGesture {
             nav.selectedSettingIndex = index

--- a/panel/Settings.swift
+++ b/panel/Settings.swift
@@ -425,9 +425,17 @@ private struct SettingsRowView: View {
                 .font(.subheadline.monospaced())
                 .foregroundStyle(selected ? Color.primary : .secondary)
         case .action:
-            Image(systemName: "chevron.right")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
+            HStack(spacing: 8) {
+                if !value.isEmpty {
+                    Text(value)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .transition(.opacity)
+                }
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
         }
     }
 }

--- a/panel/Settings.swift
+++ b/panel/Settings.swift
@@ -80,7 +80,7 @@ struct SettingsView: View {
                             row(16 + off, label: "Check permissions…",    kind: .action, value: "")
                             row(17 + off, label: "Open config file…",     kind: .action, value: "")
                             row(18 + off, label: "View release notes…",   kind: .action, value: "")
-                            row(19 + off, label: "Check for updates…",    kind: .action, value: "")
+                            row(19 + off, label: "Check for updates…",    kind: .action, value: checkForUpdatesStatus)
                             row(20 + off, label: "Uninstall StackNudge…", kind: .action, value: "")
                             row(21 + off, label: "Quit panel",            kind: .action, value: "")
                         }
@@ -282,6 +282,15 @@ struct SettingsView: View {
         if nav.voicesLoading { return "Loading…" }
         if nav.voicesAvailable.isEmpty { return "Voices unavailable" }
         return nav.voice
+    }
+
+    private var checkForUpdatesStatus: String {
+        switch nav.updateCheckStatus {
+        case .idle:             return ""
+        case .checking:         return "Checking…"
+        case .upToDate:         return "Up to date"
+        case .failed:           return "Failed"
+        }
     }
 
     // Conditional top-of-list row. Pinned at index 0 when an update is

--- a/panel/UpdateChecker.swift
+++ b/panel/UpdateChecker.swift
@@ -33,7 +33,7 @@ final class UpdateChecker {
     private var timer: Timer?
     private let session: URLSession
 
-    init(nav: PanelNav, interval: TimeInterval = 6 * 60 * 60) {
+    init(nav: PanelNav, interval: TimeInterval = 2 * 60 * 60) {
         self.nav = nav
         self.interval = interval
         let config = URLSessionConfiguration.ephemeral

--- a/panel/UpdateChecker.swift
+++ b/panel/UpdateChecker.swift
@@ -54,20 +54,31 @@ final class UpdateChecker {
         timer = nil
     }
 
-    // Public so a "Check for updates now" action can force a refresh; ignored
-    // result — the publish-to-nav side effect is what matters.
-    func check() {
-        guard let current = Self.currentVersion() else { return }
+    // Result of a one-shot check — surfaced to the user-triggered
+    // "Check for updates…" action so the Settings row can flash
+    // status feedback. Background polls ignore it.
+    enum CheckResult { case upToDate, updateAvailable(String), failed }
+
+    // Public so a "Check for updates now" action can force a refresh.
+    // completion fires on the main thread when supplied; background
+    // polls call with no completion and rely on the nav side effect.
+    func check(completion: ((CheckResult) -> Void)? = nil) {
+        guard let current = Self.currentVersion() else {
+            DispatchQueue.main.async { completion?(.failed) }
+            return
+        }
         fetchReleaseJSON(url: Self.latestReleaseURL, ghAPIPath: Self.latestGHPath) { [weak self] json in
-            guard let self,
-                  let tag = json?["tag_name"] as? String
-            else { return }
+            guard let tag = json?["tag_name"] as? String else {
+                DispatchQueue.main.async { completion?(.failed) }
+                return
+            }
             let latest = Self.stripV(tag)
             let newer = Self.isNewer(latest, than: current)
             let body = json?["body"] as? String
             DispatchQueue.main.async {
-                self.nav?.updateAvailable = newer ? latest : nil
-                self.nav?.updateReleaseNotes = newer ? body : nil
+                self?.nav?.updateAvailable = newer ? latest : nil
+                self?.nav?.updateReleaseNotes = newer ? body : nil
+                completion?(newer ? .updateAvailable(latest) : .upToDate)
             }
         }
     }


### PR DESCRIPTION
## Summary

A bundle of small Settings-tab improvements landing after v1.10.0.

### Updates
- New **"Check for updates…"** action row (Settings → Actions). Triggers `UpdateChecker.check()` on demand with inline feedback in the row's value column: `Checking…` → `Up to date` / `Update available` / `Failed`, auto-cleared after 3s. `.checking` is held for at least 600ms so sub-second network calls still produce visible feedback.
- Default background interval lowered from **6h → 2h**. Users on auto-update pick up new releases meaningfully faster; the GitHub API call is cheap.

### Layout / UX
- **"Voice notifications"** toggle moved from the generic Toggles section into the Voice section, since it gates that whole section.
- **Gated rows dim** to ~40% opacity when their controlling toggle is off:
  - Sound section's Agent done + Permission when Sound is off.
  - Voice section's Voice + Speed when Voice notifications is off.
  - Usage section's Quota alerts, Alert threshold, Poll frequency when Quota tracking is off (Alert threshold additionally requires Quota alerts).
  Keyboard navigation is unchanged — dimming is visual-only so muscle memory and row counts stay stable.
- Action rows now render their `value` parameter inline (before the chevron) when non-empty — the underlying SettingsRowView template was previously ignoring it, which is why the check-for-updates status wasn't visible at first.

## Test plan
- [ ] Settings → Actions → "Check for updates…": observe `Checking…` for ~600ms, then `Up to date` / `Update available` / `Failed` for ~3s, then blank.
- [ ] Toggle Sound enabled off → Agent done + Permission dim. Toggle Voice notifications off → Voice + Speed dim. Toggle Quota tracking off → Quota alerts + Alert threshold + Poll frequency dim.
- [ ] Voice notifications row appears at the top of the Voice section (not in Toggles).
- [ ] Keyboard navigation lands on every row including dimmed ones; activating a dimmed row still toggles/cycles (no-op behavior aside).
- [ ] Background update check still fires on launch and now repeats every 2h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)