### PR TITLE
feat(sessions): per-session context tracking + live names, busy/idle, context alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ When you press `⏎` on a permission event in a VS Code / Cursor terminal pane, 
 
 Live list of running agent processes (`claude`, `gemini`, `codex` — including node-hosted variants like `gemini-cli`). Polls every 3 seconds while visible. Sessions that exit linger for 30s with `ended Ns ago`.
 
+For Claude Code sessions specifically, stack-nudge reads `~/.claude/sessions/<pid>.json` (Claude Code's per-process sidecar) to surface live data without waiting for a hook event:
+
+- **Live status dot** — yellow for `busy` (turn in flight), green for `idle` (waiting for input).
+- **Session name** from the sidecar when set to anything other than the default `main-agent` (falls back to the project name otherwise).
+- **Context-window usage** — `293K tokens · opus-4-7` beneath the project path, updated on each Claude turn.
+
+Rows are ordered busy-first, then by most-recent activity. Status label reads `busy · 2 min ago` / `idle · 1 hr ago`.
+
 | Key | Action |
 |-----|--------|
 | `↑ ↓` | Move selection |
@@ -178,18 +186,28 @@ Bars are color-coded: green below 50%, yellow 50–80%, red 80%+. Reset times sh
 
 Data is fetched from the same endpoint Claude Code's own statusline uses (`/api/oauth/usage`), reading your OAuth token from the macOS Keychain. **The first time stack-nudge polls you'll see a keychain dialog — click "Always Allow"** to grant access (one-time, per release).
 
-Polls every 60 seconds while the panel is visible, or every 5 minutes (`STACKNUDGE_USAGE_POLL_MIN`) in the background.
+Polls every 60 seconds while the panel is visible, or every 5 minutes by default in the background (configurable via Settings → Usage → "Poll frequency"; underlying key `STACKNUDGE_USAGE_POLL_MIN`). On the Usage tab: `r` triggers a manual sync, `p` pauses/resumes the poller.
 
 #### Threshold-crossing notifications
 
-When any tier reaches your configured threshold, stack-nudge fires a banner — *"Weekly quota at 85% — resets May 17"* — once per period per tier, so you get a heads-up before hitting the cap. Configure in Settings → Usage:
+When any quota tier reaches your configured threshold, stack-nudge fires a banner — *"Weekly quota at 85% — resets May 17"* — once per period per tier, so you get a heads-up before hitting the cap. Configure in Settings → Usage:
 
-- **Quota alerts** — master switch (default on)
+- **Quota tracking** — master switch for the whole feature (default on; off disables polling entirely)
+- **Quota alerts** — banner toggle (default on)
 - **Alert threshold** — 50% / 70% / 80% / 90% / 95% (default 80%)
+- **Poll frequency** — 1 / 2 / 5 / 10 / 15 / 30 min (default 5)
+
+#### Per-session context alerts
+
+Independent of quota: stack-nudge can also fire a banner when an individual Claude Code session's context window fills past a threshold you pick. The banner names the session — *"Context filling up — classifier-evolution-2 — at 175K tokens (opus-4-7). Consider /compact."* — so you know exactly which one to act on.
+
+- **Context alert at** — `Off` / 100K / 150K / 175K / 200K / 300K / 500K / 750K (default Off)
+- Absolute tokens, not a percent — Claude 4.x context windows vary (Opus/Sonnet 1M, Haiku 200K, opt-in betas), and there's no reliable way to infer the limit from the model ID alone.
+- One banner per session per threshold; the dedup re-arms whenever the session's token count drops by ≥20K (the characteristic shape of a `/compact` or `/clear`), so refilling after a compact alerts you again.
 
 #### Settings tab
 
-Reachable from the tab strip or `Cmd+4`. Keyboard-driven rows for hotkey, banner/voice toggles, sound picks (with preview-on-cycle), voice picker (with preview-on-cycle using a random conversational phrase), speed, quota alert config, and shortcuts to the permissions checker, config file, phrase editor, and quit.
+Reachable from the tab strip or `Cmd+4`. Keyboard-driven rows for hotkey, behavior toggles (banner, mute when focused, pin panel, launch at login), sound picks (with preview-on-cycle), voice notifications + picker + speed (with preview-on-cycle using a random conversational phrase), usage config (quota tracking + alerts + threshold + poll frequency + context alert threshold), and action rows (edit phrases, check permissions, open config file, view release notes, check for updates, uninstall, quit).
 
 | Key | Action |
 |-----|--------|

--- a/build.sh
+++ b/build.sh
@@ -237,6 +237,8 @@ build_app "$APP" "stack-nudge" \
   panel/SessionStore.swift \
   panel/SessionUsage.swift \
   panel/Sessions.swift \
+  panel/TranscriptStats.swift \
+  panel/ModelLimits.swift \
   panel/Phrases.swift \
   panel/UpdateChecker.swift \
   panel/Updater.swift \

--- a/notify.sh
+++ b/notify.sh
@@ -351,6 +351,8 @@ post_to_panel() {
   NUDGE_TERM_PROGRAM="${TERM_PROGRAM:-}" \
   NUDGE_SESSION_ID="${TERM_SESSION_ID:-${ITERM_SESSION_ID:-}}" \
   NUDGE_ITERM_TAB_NAME="${ITERM_TAB_NAME:-}" \
+  NUDGE_CLAUDE_SESSION_ID="$(command -v jq &>/dev/null && [[ -n "$HOOK_JSON" ]] && printf '%s' "$HOOK_JSON" | jq -r '.session_id // empty' 2>/dev/null || true)" \
+  NUDGE_TRANSCRIPT_PATH="$(command -v jq &>/dev/null && [[ -n "$HOOK_JSON" ]] && printf '%s' "$HOOK_JSON" | jq -r '.transcript_path // empty' 2>/dev/null || true)" \
   python3 - <<'PY' 2>/dev/null
 import json, os, socket, time
 
@@ -379,6 +381,8 @@ optional = {
     "term_program":  env.get("NUDGE_TERM_PROGRAM"),
     "session_id":    env.get("NUDGE_SESSION_ID"),
     "iterm_tab_name": env.get("NUDGE_ITERM_TAB_NAME"),
+    "claude_session_id": env.get("NUDGE_CLAUDE_SESSION_ID"),
+    "transcript_path":   env.get("NUDGE_TRANSCRIPT_PATH"),
     "voice_message": env.get("NUDGE_VOICE_MESSAGE"),
     "sound_name":    env.get("NUDGE_SOUND"),
 }

--- a/panel/EventListener.swift
+++ b/panel/EventListener.swift
@@ -138,6 +138,11 @@ private struct NudgeEventDTO: Decodable {
     let voice_message: String?
     let sound_name: String?
     let bypass_mute: Bool?
+    // Claude Code's session UUID (distinct from session_id, which is the
+    // terminal/iTerm session id) and the path to its JSONL transcript.
+    // Populated only for Claude Code hook events; nil for other agents.
+    let claude_session_id: String?
+    let transcript_path: String?
 
     func toNudgeEvent() -> NudgeEvent {
         NudgeEvent(
@@ -161,7 +166,9 @@ private struct NudgeEventDTO: Decodable {
             fifoPath: fifo_path,
             voiceMessage: voice_message,
             soundName: sound_name,
-            bypassMute: bypass_mute ?? false
+            bypassMute: bypass_mute ?? false,
+            claudeSessionID: claude_session_id,
+            transcriptPath: transcript_path
         )
     }
 }

--- a/panel/EventStore.swift
+++ b/panel/EventStore.swift
@@ -58,6 +58,12 @@ struct NudgeEvent: Identifiable, Equatable {
     // the legacy install.sh `welcome` event, fired while the user is
     // staring at the install terminal.
     let bypassMute: Bool
+    // Claude Code's session UUID (distinct from `sessionID` which is the
+    // iTerm/terminal session id) and the JSONL transcript path. Used to
+    // compute per-session context-window usage. Populated only for Claude
+    // Code hook events; nil for other agents.
+    let claudeSessionID: String?
+    let transcriptPath: String?
 
     init(agent: String, kind: NudgeKind, title: String, message: String,
          projectPath: String? = nil, bundleID: String? = nil,
@@ -71,6 +77,8 @@ struct NudgeEvent: Identifiable, Equatable {
          voiceMessage: String? = nil,
          soundName: String? = nil,
          bypassMute: Bool = false,
+         claudeSessionID: String? = nil,
+         transcriptPath: String? = nil,
          snoozedUntil: Date? = nil,
          id: UUID = UUID()) {
         self.id = id
@@ -95,6 +103,8 @@ struct NudgeEvent: Identifiable, Equatable {
         self.voiceMessage = voiceMessage
         self.soundName = soundName
         self.bypassMute = bypassMute
+        self.claudeSessionID = claudeSessionID
+        self.transcriptPath = transcriptPath
         self.snoozedUntil = snoozedUntil
     }
 
@@ -114,6 +124,8 @@ struct NudgeEvent: Identifiable, Equatable {
             voiceMessage: voiceMessage,
             soundName: soundName,
             bypassMute: bypassMute,
+            claudeSessionID: claudeSessionID,
+            transcriptPath: transcriptPath,
             snoozedUntil: snoozedUntil,
             id: id  // preserve identity across snooze cycles
         )

--- a/panel/ModelLimits.swift
+++ b/panel/ModelLimits.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+// Static map from Anthropic model-name prefix → context window size in
+// tokens. Used to render "tokens / limit (xx%)" in the Sessions tab
+// when we recognise the model; new models gracefully fall through to
+// "tokens only" until this table is updated.
+//
+// Match by prefix because Anthropic suffixes model IDs with release
+// dates (e.g. "claude-sonnet-4-7-20250606") — checking the family
+// prefix lets one entry cover a whole minor-version run.
+enum ModelLimits {
+
+    // (prefix, limit) pairs. Order doesn't matter; longest match wins
+    // if you add overlapping entries.
+    private static let table: [(prefix: String, limit: Int)] = [
+        // Claude 4.x family — all default to 200K. The 1M-context
+        // Sonnet beta is opt-in via the anthropic-beta header and
+        // doesn't change the model id, so we can't distinguish it
+        // from the standard variant here. Users running 1M will see
+        // an inflated percent; documented as a known limitation.
+        ("claude-opus-4",   200_000),
+        ("claude-sonnet-4", 200_000),
+        ("claude-haiku-4",  200_000),
+        // Claude 3.x family — same 200K window.
+        ("claude-opus-3",   200_000),
+        ("claude-sonnet-3", 200_000),
+        ("claude-haiku-3",  200_000),
+    ]
+
+    static func limit(for model: String?) -> Int? {
+        guard let model else { return nil }
+        return table.first { model.hasPrefix($0.prefix) }?.limit
+    }
+}

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -103,7 +103,7 @@ struct PanelContentView: View {
 
                 switch nav.mode {
                 case .events:   eventsBody
-                case .sessions: SessionsView(store: sessions, events: store)
+                case .sessions: SessionsView(store: sessions, events: store, nav: nav)
                 case .usage:    UsageView(nav: nav)
                 case .settings: SettingsView(nav: nav)
                 case .phrases:  PhrasesView(model: phrases) { nav.mode = .settings }
@@ -600,7 +600,10 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
 
         startConfigWatcher()
         setupNotificationCenter()
-        store.onAppend = { [weak self] event in self?.postBannerIfNeeded(event) }
+        store.onAppend = { [weak self] event in
+            self?.postBannerIfNeeded(event)
+            self?.refreshTranscriptStats(for: event)
+        }
         nav.loadFromConfig()  // populate panelPinned + other live values up-front
         // Scan agent configs for missing wires (post-update / post-install
         // reconciliation). Surfaces a "Set up X" banner in Settings when
@@ -986,6 +989,22 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     // If STACKNUDGE_ACTIVATE_IMMEDIATELY is set, focus the source editor
     // right away without waiting for the user to click; we skip cues
     // entirely in that flow since the editor jump is the signal.
+    // Re-read the Claude Code transcript referenced by an incoming
+    // event and publish updated context-window stats to nav. Runs
+    // off-main since transcripts can be a few MB; the final assignment
+    // hops back to main so SwiftUI re-renders cleanly.
+    private func refreshTranscriptStats(for event: NudgeEvent) {
+        guard let sessionID = event.claudeSessionID,
+              let path = event.transcriptPath, !path.isEmpty
+        else { return }
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            guard let stats = TranscriptReader.read(path: path) else { return }
+            DispatchQueue.main.async {
+                self?.nav.claudeSessionStats[sessionID] = stats
+            }
+        }
+    }
+
     private func postBannerIfNeeded(_ event: NudgeEvent) {
         let config = PanelConfig.load()
 

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import SwiftUI
 import UserNotifications
 
@@ -480,6 +481,10 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     private var updater: Updater?
     private let quotaProbe = QuotaProbe()
     private var quotaTimer: Timer?
+    // Subscriptions to other ObservableObjects we react to from PanelController.
+    // Currently: SessionStore.sessions → refresh transcript stats proactively
+    // so threshold alerts fire even when no hook has arrived yet.
+    private var cancellables = Set<AnyCancellable>()
     // Tracks whether the banner has already fired this period per tier so
     // we don't refire on every poll. Reset when the tier's resets_at
     // advances (a new period started, fresh budget).
@@ -615,6 +620,16 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         updater = Updater(nav: nav)
 
         startQuotaPolling()
+
+        // Whenever SessionStore re-polls (~every 3s while polling, on
+        // panel-becomes-visible otherwise), refresh transcript stats for
+        // any claude session we now know the UUID for. This is what makes
+        // stats populate without waiting for a hook — and what lets
+        // threshold alerts fire for sessions the user isn't watching.
+        sessions.$sessions
+            .removeDuplicates()
+            .sink { [weak self] _ in self?.refreshAllClaudeStats() }
+            .store(in: &cancellables)
 
         // If a previous panel instance was pkilled mid-update by install.sh,
         // it left a status file behind. Read it now and surface a brief toast
@@ -993,6 +1008,36 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     // event and publish updated context-window stats to nav. Runs
     // off-main since transcripts can be a few MB; the final assignment
     // hops back to main so SwiftUI re-renders cleanly.
+    // Refresh transcript stats for every known claude session whose
+    // sidecar gave us a sessionId. Triggered on SessionStore updates so
+    // stats stay current with the 3s poll cadence even when the user
+    // isn't generating events.
+    private func refreshAllClaudeStats() {
+        for session in sessions.sessions
+            where session.agent == "claude" && session.status == .active
+        {
+            guard let id = session.claudeSessionID,
+                  let project = session.projectPath
+            else { continue }
+            let path = Self.transcriptPath(projectPath: project, sessionID: id)
+            DispatchQueue.global(qos: .utility).async { [weak self] in
+                guard let stats = TranscriptReader.read(path: path) else { return }
+                DispatchQueue.main.async {
+                    self?.nav.claudeSessionStats[id] = stats
+                    self?.evaluateContextThreshold(sessionID: id, stats: stats)
+                }
+            }
+        }
+    }
+
+    // Claude Code stores transcripts at:
+    //   ~/.claude/projects/<slug>/<session-uuid>.jsonl
+    // where the slug is the absolute project path with '/' replaced by '-'.
+    private static func transcriptPath(projectPath: String, sessionID: String) -> String {
+        let slug = projectPath.replacingOccurrences(of: "/", with: "-")
+        return "\(NSHomeDirectory())/.claude/projects/\(slug)/\(sessionID).jsonl"
+    }
+
     private func refreshTranscriptStats(for event: NudgeEvent) {
         guard let sessionID = event.claudeSessionID,
               let path = event.transcriptPath, !path.isEmpty
@@ -1001,8 +1046,71 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
             guard let stats = TranscriptReader.read(path: path) else { return }
             DispatchQueue.main.async {
                 self?.nav.claudeSessionStats[sessionID] = stats
+                self?.evaluateContextThreshold(sessionID: sessionID, stats: stats)
             }
         }
+    }
+
+    // Per-session state for context-threshold dedup. Lives on the
+    // controller (not nav) because it's pure bookkeeping for the
+    // alert pipeline, not anything the UI observes.
+    private var contextAlertLastTokens: [String: Int] = [:]
+    private var contextAlertFired: Set<String> = []
+    private static let contextCompactDropThreshold = 20_000
+
+    // Decide whether to fire a context-fill banner for this session.
+    // Rules:
+    //   - Off (threshold = 0) → never fire.
+    //   - First time crossing threshold → fire, mark as fired.
+    //   - Already fired → skip until re-armed.
+    //   - Re-arm: any single-reading drop of ≥20K tokens (compact /
+    //     /clear signal); next crossing fires again.
+    private func evaluateContextThreshold(sessionID: String, stats: TranscriptStats) {
+        let thresholdK = nav.contextAlertThresholdK
+        guard thresholdK > 0 else { return }
+        let threshold = thresholdK * 1_000
+        let current = stats.tokens
+
+        if let last = contextAlertLastTokens[sessionID],
+           last - current >= Self.contextCompactDropThreshold {
+            contextAlertFired.remove(sessionID)
+        }
+        contextAlertLastTokens[sessionID] = current
+
+        guard current >= threshold, !contextAlertFired.contains(sessionID) else { return }
+        contextAlertFired.insert(sessionID)
+        postContextBanner(tokens: current, model: stats.model,
+                          sessionLabel: labelForClaudeSession(id: sessionID))
+    }
+
+    // Find a user-recognisable label for the session crossing the threshold.
+    // Cascade mirrors what the Sessions row shows: customName → meaningful
+    // claudeName → project name. Falls back to "a session" if we know
+    // nothing (alert still useful, just less specific).
+    private func labelForClaudeSession(id: String) -> String {
+        guard let session = sessions.sessions.first(where: { $0.claudeSessionID == id })
+        else { return "a session" }
+        if let custom = session.customName, !custom.isEmpty { return custom }
+        if let name = session.claudeName,
+           !name.isEmpty, name != "main-agent" {
+            return name
+        }
+        return session.projectName ?? "a session"
+    }
+
+    private func postContextBanner(tokens: Int, model: String?, sessionLabel: String) {
+        let tokensFmt = "\(Int((Double(tokens) / 1_000).rounded()))K"
+        let content = UNMutableNotificationContent()
+        content.title = "Context filling up — \(sessionLabel)"
+        if let model {
+            content.body = "At \(tokensFmt) tokens (\(model)). Consider /compact."
+        } else {
+            content.body = "At \(tokensFmt) tokens. Consider /compact."
+        }
+        content.categoryIdentifier = "STOP"
+        let req = UNNotificationRequest(identifier: UUID().uuidString,
+                                        content: content, trigger: nil)
+        UNUserNotificationCenter.current().add(req, withCompletionHandler: nil)
     }
 
     private func postBannerIfNeeded(_ event: NudgeEvent) {

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -112,6 +112,12 @@ final class PanelNav: ObservableObject {
     // True while a probe is in-flight. Set by PanelController around the
     // fetch call so the UI can swap the footer status to "Syncing…".
     @Published var quotaSyncing:     Bool = false
+    // Per-Claude-session context-window stats. Keyed by Claude's
+    // session_id UUID (NudgeEvent.claudeSessionID), populated by
+    // PanelController whenever an event arrives with a transcript_path.
+    // Sessions.swift renders entries from this map alongside matched
+    // sessions in the Sessions tab.
+    @Published var claudeSessionStats: [String: TranscriptStats] = [:]
     // Transient feedback for the "Check for updates…" action row.
     // Set by PanelController around UpdateChecker.check(); cleared
     // back to .idle a few seconds after a terminal result so the

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -135,6 +135,13 @@ final class PanelNav: ObservableObject {
     // useful for a usage gauge that updates server-side every minute.
     @Published var quotaPollMinutes:     Int  = 5
     static let quotaPollMinuteOptions: [Int] = [1, 2, 5, 10, 15, 30]
+    // Threshold for per-Claude-session context-window alerts, in thousands
+    // of tokens. 0 = off (no banner ever). When a session's tokens cross
+    // this value, PanelController fires a one-shot banner; dedup re-arms
+    // when the session's tokens drop by ≥20K (compact signal). Absolute
+    // tokens (not %) because Claude 4.x context windows vary by model.
+    @Published var contextAlertThresholdK: Int = 0
+    static let contextAlertThresholdOptions: [Int] = [0, 100, 150, 175, 200, 300, 500, 750]
     // First-launch bootstrap wizard state. Populated by PanelController
     // on launch when Bootstrap.isInstalled() returns false; drives
     // BootstrapView (mode = .bootstrap).
@@ -207,7 +214,7 @@ final class PanelNav: ObservableObject {
     // when the offset is 1.
     var updateRowOffset: Int { updateAvailable != nil ? 1 : 0 }
 
-    var rowCount: Int { 22 + updateRowOffset }
+    var rowCount: Int { 23 + updateRowOffset }
 
     // Row layout (kept in one place so the controller, view, and indexing
     // logic all agree on what each row index means). When updateAvailable
@@ -228,13 +235,14 @@ final class PanelNav: ObservableObject {
     //  12  Quota alerts          toggle
     //  13  Alert threshold       cycle
     //  14  Poll frequency        cycle
-    //  15  Edit phrases…         action
-    //  16  Check permissions…    action
-    //  17  Open config file…     action
-    //  18  View release notes…   action
-    //  19  Check for updates…    action
-    //  20  Uninstall stack-nudge action
-    //  21  Quit panel            action
+    //  15  Context alert at      cycle       (per-session token thresholds)
+    //  16  Edit phrases…         action
+    //  17  Check permissions…    action
+    //  18  Open config file…     action
+    //  19  View release notes…   action
+    //  20  Check for updates…    action
+    //  21  Uninstall stack-nudge action
+    //  22  Quit panel            action
 
     // MARK: - Disk I/O
 
@@ -265,6 +273,8 @@ final class PanelNav: ObservableObject {
         // Same coercion for poll interval — snap to nearest valid option.
         let rawPoll = Int(config["STACKNUDGE_USAGE_POLL_MIN"] ?? "") ?? 5
         quotaPollMinutes = Self.quotaPollMinuteOptions.min(by: { abs($0 - rawPoll) < abs($1 - rawPoll) }) ?? 5
+        let rawCtx = Int(config["STACKNUDGE_CONTEXT_ALERT_THRESHOLD"] ?? "") ?? 0
+        contextAlertThresholdK = Self.contextAlertThresholdOptions.min(by: { abs($0 - rawCtx) < abs($1 - rawCtx) }) ?? 0
     }
 
     // MARK: - Agent reconciliation
@@ -457,13 +467,13 @@ final class PanelNav: ObservableObject {
             } else {
                 startVoiceModelDownload()
             }
-        case 15: actions?.editPhrases()
-        case 16: actions?.checkPermissions()
-        case 17: actions?.openConfig()
-        case 18: actions?.openReleaseNotes()
-        case 19: actions?.checkForUpdates()
-        case 20: actions?.beginUninstall()
-        case 21: actions?.quit()
+        case 16: actions?.editPhrases()
+        case 17: actions?.checkPermissions()
+        case 18: actions?.openConfig()
+        case 19: actions?.openReleaseNotes()
+        case 20: actions?.checkForUpdates()
+        case 21: actions?.beginUninstall()
+        case 22: actions?.quit()
         default: applyCycle(forward: true)
         }
     }
@@ -566,6 +576,13 @@ final class PanelNav: ObservableObject {
             quotaPollMinutes = list[next]
             ConfigFile.write(key: "STACKNUDGE_USAGE_POLL_MIN",
                              value: String(quotaPollMinutes))
+        case 15:
+            let list = Self.contextAlertThresholdOptions
+            let idx = list.firstIndex(of: contextAlertThresholdK) ?? 0
+            let next = forward ? (idx + 1) % list.count : (idx - 1 + list.count) % list.count
+            contextAlertThresholdK = list[next]
+            ConfigFile.write(key: "STACKNUDGE_CONTEXT_ALERT_THRESHOLD",
+                             value: String(contextAlertThresholdK))
         default:
             break
         }

--- a/panel/SessionStore.swift
+++ b/panel/SessionStore.swift
@@ -32,14 +32,17 @@ struct Session: Identifiable, Equatable {
     var claudeSessionID: String?
     var claudeName: String?           // "main-agent" (default) or user-set
     var claudeStatus: String?         // "busy" | "idle" | other
+    var claudeUpdatedAt: Date?        // last-activity timestamp from sidecar
 }
 
 // Decoded shape of ~/.claude/sessions/<pid>.json. Only the fields we
-// actually use; Claude Code emits more.
+// actually use; Claude Code emits more. updatedAt is milliseconds since
+// the Unix epoch; SessionStore converts to Date at discovery time.
 private struct ClaudeSessionSidecar: Decodable {
     let sessionId: String?
     let name: String?
     let status: String?
+    let updatedAt: Double?
 }
 
 // Polls for live agent processes (claude / gemini / codex) every few seconds
@@ -194,11 +197,24 @@ final class SessionStore: ObservableObject {
             next.append(session)
         }
 
-        // Sort: active first, then most-recently-finished, then by agent/pid.
+        // Sort: active first, busy above non-busy within active, then by
+        // most-recent claudeUpdatedAt (or process pid as tiebreaker so
+        // ordering stays stable when sidecar timestamps are absent).
+        // Distant past for sessions with no updatedAt sinks them below
+        // any timestamped session.
+        let distantPast = Date.distantPast
         next.sort { lhs, rhs in
             let lActive = lhs.status == .active
             let rActive = rhs.status == .active
             if lActive != rActive { return lActive && !rActive }
+
+            let lBusy = lhs.claudeStatus == "busy"
+            let rBusy = rhs.claudeStatus == "busy"
+            if lBusy != rBusy { return lBusy && !rBusy }
+
+            let lAt = lhs.claudeUpdatedAt ?? distantPast
+            let rAt = rhs.claudeUpdatedAt ?? distantPast
+            if lAt != rAt { return lAt > rAt }
             return lhs.pid < rhs.pid
         }
 
@@ -253,7 +269,8 @@ final class SessionStore: ObservableObject {
                 tabName: nil,
                 claudeSessionID: sidecar?.sessionId,
                 claudeName:      sidecar?.name,
-                claudeStatus:    sidecar?.status
+                claudeStatus:    sidecar?.status,
+                claudeUpdatedAt: sidecar?.updatedAt.map { Date(timeIntervalSince1970: $0 / 1000) }
             ))
         }
         return found
@@ -369,7 +386,8 @@ private extension Session {
             // from the previous poll.
             claudeSessionID: self.claudeSessionID,
             claudeName:      self.claudeName,
-            claudeStatus:    self.claudeStatus
+            claudeStatus:    self.claudeStatus,
+            claudeUpdatedAt: self.claudeUpdatedAt
         )
     }
 }

--- a/panel/SessionStore.swift
+++ b/panel/SessionStore.swift
@@ -24,6 +24,22 @@ struct Session: Identifiable, Equatable {
     // which is exactly the pre-Stage-2 behaviour.
     var tabId: String?
     var tabName: String?
+    // Read from ~/.claude/sessions/<pid>.json (one file per running claude
+    // process). Gives us authoritative session identity + state without
+    // needing a hook event to fire first. All optional — missing for
+    // non-claude agents, or if the sidecar doesn't exist yet for a freshly
+    // spawned process.
+    var claudeSessionID: String?
+    var claudeName: String?           // "main-agent" (default) or user-set
+    var claudeStatus: String?         // "busy" | "idle" | other
+}
+
+// Decoded shape of ~/.claude/sessions/<pid>.json. Only the fields we
+// actually use; Claude Code emits more.
+private struct ClaudeSessionSidecar: Decodable {
+    let sessionId: String?
+    let name: String?
+    let status: String?
 }
 
 // Polls for live agent processes (claude / gemini / codex) every few seconds
@@ -220,6 +236,7 @@ final class SessionStore: ObservableObject {
 
             let cwd = readCWD(pid: pid)
             let chain = walkParentChain(from: pid)
+            let sidecar = (agent == "claude") ? readClaudeSidecar(pid: pid) : nil
 
             found.append(Session(
                 id: pid,
@@ -233,7 +250,10 @@ final class SessionStore: ObservableObject {
                 customName: nil,
                 status: .active,
                 tabId: nil,
-                tabName: nil
+                tabName: nil,
+                claudeSessionID: sidecar?.sessionId,
+                claudeName:      sidecar?.name,
+                claudeStatus:    sidecar?.status
             ))
         }
         return found
@@ -262,6 +282,18 @@ final class SessionStore: ObservableObject {
             }
         }
         return nil
+    }
+
+    // Per-PID sidecar emitted by Claude Code (interactive runs) with the
+    // session UUID, user-facing name, and live busy/idle status. Reading
+    // this lets us bind a Session to its transcript immediately without
+    // waiting for a hook event to fire.
+    private static func readClaudeSidecar(pid: Int) -> ClaudeSessionSidecar? {
+        let path = "\(NSHomeDirectory())/.claude/sessions/\(pid).json"
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(ClaudeSessionSidecar.self, from: data)
     }
 
     private static func readCWD(pid: Int) -> String? {
@@ -330,7 +362,14 @@ private extension Session {
             customName: customName,
             status: status,
             tabId: tabId ?? self.tabId,
-            tabName: tabName ?? self.tabName
+            tabName: tabName ?? self.tabName,
+            // Preserve the live sidecar values from the freshly-discovered
+            // snapshot — these change turn-to-turn (status especially), so
+            // we want the merge to surface the latest, not the stale value
+            // from the previous poll.
+            claudeSessionID: self.claudeSessionID,
+            claudeName:      self.claudeName,
+            claudeStatus:    self.claudeStatus
         )
     }
 }

--- a/panel/Sessions.swift
+++ b/panel/Sessions.swift
@@ -106,22 +106,33 @@ struct SessionsView: View {
     // when the session has no Claude Code event yet (e.g. a Gemini-only
     // session, or a Claude session that hasn't fired a hook this run).
     private func transcriptStats(for session: Session) -> TranscriptStats? {
+        // events array is newest-first (EventStore.append inserts at 0),
+        // so .first gives the most recent matching event.
         guard let id = events.events
             .filter({ matches(event: $0, session: session) })
             .compactMap(\.claudeSessionID)
-            .last
+            .first
         else { return nil }
         return nav.claudeSessionStats[id]
     }
 
     private func matches(event: NudgeEvent, session: Session) -> Bool {
-        guard Agent.canonical(event.agent) == Agent.canonical(session.agent),
-              event.projectPath == session.projectPath else { return false }
-        // When both sides know which tab/window they belong to, demand
-        // they agree — that's how a permission nudge for tab A doesn't
-        // count toward tab B's nudge counter. Each terminal contributes
-        // its own identifier (iTerm: sessionID; VSCode: ipcHook), so
-        // we accept either as the event-side tabId.
+        guard Agent.canonical(event.agent) == Agent.canonical(session.agent) else {
+            return false
+        }
+        // Strongest disambiguator: notify.sh's walk_session_chain captures
+        // the agent process PID; SessionStore.pid is the same number. Trust
+        // it over projectPath because the event's project path (= shell
+        // $PWD when notify.sh ran) can disagree with the session's project
+        // path (= lsof cwd of the claude process). Zed sessions exhibit
+        // this — claude cwd stays at the workspace root while the user's
+        // shell can cd into a subdirectory.
+        if let eventPID = event.agentPID, eventPID > 0 {
+            return eventPID == session.pid
+        }
+        // Without a PID, fall back to projectPath + terminal-tab
+        // disambiguator. Same path required; tabId narrows when both have it.
+        guard event.projectPath == session.projectPath else { return false }
         let eventTab = (event.sessionID?.isEmpty == false ? event.sessionID : event.ipcHook)
         if let sessionTab = session.tabId, let eventTab,
            !sessionTab.isEmpty, !eventTab.isEmpty {
@@ -280,12 +291,28 @@ private struct SessionRow: View {
     }
 
     private func contextLabel(_ stats: TranscriptStats) -> String {
+        // Absolute tokens only. We dropped the %-of-limit display in
+        // Phase 1 after discovering that the 4.x family's context window
+        // varies (Opus/Sonnet on 1M context; Haiku on 200K; Sonnet 1M is
+        // opt-in beta), and there's no reliable way to disambiguate from
+        // the model ID. Showing the model name keeps the row honest.
         let tokens = Self.formatTokens(stats.tokens)
-        if let limit = ModelLimits.limit(for: stats.model) {
-            let pct = Int((Double(stats.tokens) / Double(limit) * 100).rounded())
-            return "\(tokens) · \(pct)%"
+        if let model = stats.model {
+            return "\(tokens) · \(Self.shortModel(model))"
         }
         return tokens
+    }
+
+    // Strip the date suffix Anthropic appends to model IDs
+    // (e.g. "claude-opus-4-7-20250606" → "opus-4-7") and the
+    // redundant "claude-" prefix.
+    private static func shortModel(_ id: String) -> String {
+        var s = id.hasPrefix("claude-") ? String(id.dropFirst("claude-".count)) : id
+        if let dash = s.range(of: "-2", options: .backwards),
+           s[dash.lowerBound...].dropFirst().allSatisfy(\.isNumber) {
+            s = String(s[..<dash.lowerBound])
+        }
+        return s
     }
 
     private static func formatTokens(_ n: Int) -> String {

--- a/panel/Sessions.swift
+++ b/panel/Sessions.swift
@@ -412,10 +412,15 @@ private struct SessionRow: View {
     private var statusLabel: String {
         switch session.status {
         case .active:
-            let elapsed = session.elapsed?.trimmingCharacters(in: .whitespaces) ?? ""
-            // Lead with claude's live status when we have one — it's far
-            // more useful than the process elapsed time alone.
+            // Lead with claude's live status (busy / idle). Append "last
+            // activity Nm ago" from the sidecar's updatedAt when available
+            // — more useful than process elapsed time, which only tells
+            // you how long ago the process was spawned.
             let head = session.claudeStatus ?? "active"
+            if let updated = session.claudeUpdatedAt {
+                return "\(head) · \(Self.timeFormatter.localizedString(for: updated, relativeTo: Date()))"
+            }
+            let elapsed = session.elapsed?.trimmingCharacters(in: .whitespaces) ?? ""
             return elapsed.isEmpty ? head : "\(head) · \(elapsed)"
         case .finished(let at):
             return "ended " + Self.timeFormatter.localizedString(for: at, relativeTo: Date())

--- a/panel/Sessions.swift
+++ b/panel/Sessions.swift
@@ -5,6 +5,7 @@ struct SessionsView: View {
 
     @ObservedObject var store: SessionStore
     @ObservedObject var events: EventStore
+    @ObservedObject var nav: PanelNav
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -48,6 +49,7 @@ struct SessionsView: View {
                             renameBuffer: $store.renameBuffer,
                             activeNudgeCount: nudgeCount(for: session),
                             lastNudgeAt: lastNudgeAt(for: session),
+                            transcriptStats: transcriptStats(for: session),
                             onCommit: { store.commitRename() },
                             onCancel: { store.cancelRename() }
                         )
@@ -99,6 +101,19 @@ struct SessionsView: View {
             .max()
     }
 
+    // Find the most recent NudgeEvent matching this session that carries a
+    // claudeSessionID, then look up its TranscriptStats in nav. Returns nil
+    // when the session has no Claude Code event yet (e.g. a Gemini-only
+    // session, or a Claude session that hasn't fired a hook this run).
+    private func transcriptStats(for session: Session) -> TranscriptStats? {
+        guard let id = events.events
+            .filter({ matches(event: $0, session: session) })
+            .compactMap(\.claudeSessionID)
+            .last
+        else { return nil }
+        return nav.claudeSessionStats[id]
+    }
+
     private func matches(event: NudgeEvent, session: Session) -> Bool {
         guard Agent.canonical(event.agent) == Agent.canonical(session.agent),
               event.projectPath == session.projectPath else { return false }
@@ -124,6 +139,7 @@ private struct SessionRow: View {
     @Binding var renameBuffer: String
     let activeNudgeCount: Int
     let lastNudgeAt: Date?
+    let transcriptStats: TranscriptStats?
     let onCommit: () -> Void
     let onCancel: () -> Void
 
@@ -148,6 +164,9 @@ private struct SessionRow: View {
             VStack(alignment: .leading, spacing: 3) {
                 titleRow
                 metaRow
+                if let stats = transcriptStats {
+                    contextRow(stats)
+                }
                 if showNudgeRow {
                     nudgeRow
                 }
@@ -242,6 +261,38 @@ private struct SessionRow: View {
                 .lineLimit(1)
                 .truncationMode(.middle)
         }
+    }
+
+    // Context-window usage row. Shows absolute tokens always; appends a
+    // percentage only when the model's context limit is in ModelLimits.
+    // The icon is intentionally muted — this is informational, not an
+    // alert (alerts come later, in Phase 2).
+    private func contextRow(_ stats: TranscriptStats) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "gauge.with.dots.needle.50percent")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+            Text(contextLabel(stats))
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+        .padding(.top, 1)
+    }
+
+    private func contextLabel(_ stats: TranscriptStats) -> String {
+        let tokens = Self.formatTokens(stats.tokens)
+        if let limit = ModelLimits.limit(for: stats.model) {
+            let pct = Int((Double(stats.tokens) / Double(limit) * 100).rounded())
+            return "\(tokens) · \(pct)%"
+        }
+        return tokens
+    }
+
+    private static func formatTokens(_ n: Int) -> String {
+        if n >= 1_000 {
+            return String(format: "%.0fK tokens", Double(n) / 1_000.0)
+        }
+        return "\(n) tokens"
     }
 
     private var nudgeRow: some View {

--- a/panel/Sessions.swift
+++ b/panel/Sessions.swift
@@ -106,8 +106,15 @@ struct SessionsView: View {
     // when the session has no Claude Code event yet (e.g. a Gemini-only
     // session, or a Claude session that hasn't fired a hook this run).
     private func transcriptStats(for session: Session) -> TranscriptStats? {
-        // events array is newest-first (EventStore.append inserts at 0),
-        // so .first gives the most recent matching event.
+        // Primary: direct lookup via the sidecar-supplied sessionId.
+        // This populates immediately on panel open — no hook required.
+        if let id = session.claudeSessionID,
+           let stats = nav.claudeSessionStats[id] {
+            return stats
+        }
+        // Fallback for sessions whose sidecar isn't readable (e.g. pre-2.1
+        // Claude Code): infer from the most recent matching event that
+        // carried a claudeSessionID. events array is newest-first.
         guard let id = events.events
             .filter({ matches(event: $0, session: session) })
             .compactMap(\.claudeSessionID)
@@ -357,6 +364,13 @@ private struct SessionRow: View {
 
     private var displayName: String {
         if let custom = session.customName, !custom.isEmpty { return custom }
+        // Prefer a user-set Claude session name when it's not the default
+        // ("main-agent" is what Claude Code assigns by default; treat it
+        // as not meaningful and fall through to project name).
+        if let claudeName = session.claudeName,
+           !claudeName.isEmpty, claudeName != "main-agent" {
+            return claudeName
+        }
         return session.projectName ?? "(no project)"
     }
 
@@ -376,8 +390,19 @@ private struct SessionRow: View {
 
     private var glyphColor: Color {
         switch session.status {
-        case .active:   return .green
         case .finished: return .secondary
+        case .active:
+            // For claude sessions we get a live busy/idle signal from the
+            // ~/.claude/sessions/<pid>.json sidecar; reflect it in the dot
+            // so a glance at the panel tells the user which agents are
+            // working vs. waiting. Other agents / unknown status default
+            // to the existing green.
+            switch session.claudeStatus {
+            case "busy": return .yellow
+            case "idle": return .green
+            case nil:    return .green
+            default:     return .green
+            }
         }
     }
 
@@ -388,7 +413,10 @@ private struct SessionRow: View {
         switch session.status {
         case .active:
             let elapsed = session.elapsed?.trimmingCharacters(in: .whitespaces) ?? ""
-            return elapsed.isEmpty ? "active" : "active · \(elapsed)"
+            // Lead with claude's live status when we have one — it's far
+            // more useful than the process elapsed time alone.
+            let head = session.claudeStatus ?? "active"
+            return elapsed.isEmpty ? head : "\(head) · \(elapsed)"
         case .finished(let at):
             return "ended " + Self.timeFormatter.localizedString(for: at, relativeTo: Date())
         }

--- a/panel/Settings.swift
+++ b/panel/Settings.swift
@@ -73,16 +73,17 @@ struct SettingsView: View {
                             row(12 + off, label: "Quota alerts",    kind: .toggle, value: nav.quotaAlertsEnabled    ? "On" : "Off", enabled: nav.quotaTrackingEnabled)
                             row(13 + off, label: "Alert threshold", kind: .cycle,  value: "\(nav.quotaAlertThreshold)%",            enabled: nav.quotaTrackingEnabled && nav.quotaAlertsEnabled)
                             row(14 + off, label: "Poll frequency",  kind: .cycle,  value: "\(nav.quotaPollMinutes) min",            enabled: nav.quotaTrackingEnabled)
+                            row(15 + off, label: "Context alert at", kind: .cycle, value: contextAlertLabel)
                         }
 
                         section("Actions") {
-                            row(15 + off, label: "Edit phrases…",         kind: .action, value: "")
-                            row(16 + off, label: "Check permissions…",    kind: .action, value: "")
-                            row(17 + off, label: "Open config file…",     kind: .action, value: "")
-                            row(18 + off, label: "View release notes…",   kind: .action, value: "")
-                            row(19 + off, label: "Check for updates…",    kind: .action, value: checkForUpdatesStatus)
-                            row(20 + off, label: "Uninstall StackNudge…", kind: .action, value: "")
-                            row(21 + off, label: "Quit panel",            kind: .action, value: "")
+                            row(16 + off, label: "Edit phrases…",         kind: .action, value: "")
+                            row(17 + off, label: "Check permissions…",    kind: .action, value: "")
+                            row(18 + off, label: "Open config file…",     kind: .action, value: "")
+                            row(19 + off, label: "View release notes…",   kind: .action, value: "")
+                            row(20 + off, label: "Check for updates…",    kind: .action, value: checkForUpdatesStatus)
+                            row(21 + off, label: "Uninstall StackNudge…", kind: .action, value: "")
+                            row(22 + off, label: "Quit panel",            kind: .action, value: "")
                         }
 
                         aboutFooter
@@ -282,6 +283,10 @@ struct SettingsView: View {
         if nav.voicesLoading { return "Loading…" }
         if nav.voicesAvailable.isEmpty { return "Voices unavailable" }
         return nav.voice
+    }
+
+    private var contextAlertLabel: String {
+        nav.contextAlertThresholdK == 0 ? "Off" : "\(nav.contextAlertThresholdK)K"
     }
 
     private var checkForUpdatesStatus: String {

--- a/panel/TranscriptStats.swift
+++ b/panel/TranscriptStats.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+// Per-session statistics derived from a Claude Code JSONL transcript.
+// `tokens` is the context window usage at the last assistant turn:
+// input_tokens + cache_creation_input_tokens + cache_read_input_tokens.
+// Output tokens are excluded — they belong to the next turn's prompt.
+// `model` is the assistant-reported model name (e.g.
+// "claude-sonnet-4-7-20250606"); used by ModelLimits to look up the
+// context limit, or shown verbatim when the model isn't recognised.
+struct TranscriptStats: Equatable {
+    let tokens: Int
+    let model: String?
+}
+
+enum TranscriptReader {
+
+    // Read the transcript at `path`, scan from the end for the most
+    // recent assistant message with a usage block, and return its
+    // stats. Returns nil for unreadable files, empty transcripts, or
+    // transcripts that don't yet contain an assistant message.
+    //
+    // We read the whole file rather than tail-seeking — Claude Code
+    // transcripts are typically a few MB even for long sessions, and
+    // tail-seeking JSONL safely requires byte-by-byte reverse scanning
+    // to find a newline boundary. If transcripts grow to tens of MB
+    // in practice we can revisit.
+    static func read(path: String) -> TranscriptStats? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path), options: .mappedIfSafe),
+              let text = String(data: data, encoding: .utf8)
+        else { return nil }
+
+        // Iterate lines in reverse; first assistant entry with a usage
+        // block wins. Reverse scan is cheap even on a few-thousand-line
+        // transcript and means we don't pay to parse the whole file.
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: true)
+        for line in lines.reversed() {
+            guard let lineData = line.data(using: .utf8),
+                  let obj = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any]
+            else { continue }
+            // Claude Code transcript entries have type=assistant for model
+            // turns; the usage block lives at .message.usage.
+            guard (obj["type"] as? String) == "assistant",
+                  let message = obj["message"] as? [String: Any],
+                  let usage   = message["usage"] as? [String: Any]
+            else { continue }
+            let input   = usage["input_tokens"]                  as? Int ?? 0
+            let cacheC  = usage["cache_creation_input_tokens"]   as? Int ?? 0
+            let cacheR  = usage["cache_read_input_tokens"]       as? Int ?? 0
+            let model   = message["model"] as? String
+            return TranscriptStats(tokens: input + cacheC + cacheR, model: model)
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
## Summary

Three layered additions to the Sessions tab:

### 1. Per-session context-window usage (Phase 1)
- `notify.sh` extracts Claude Code's `transcript_path` + `session_id` from the hook JSON and forwards them as new wire fields.
- `TranscriptReader` reverse-scans the JSONL for the latest assistant message and returns `(input_tokens + cache_creation + cache_read, model)`.
- Sessions tab renders a `293K tokens · opus-4-7` caption beneath each Claude row.

**Tokens, not %:** the 4.x family's context window varies (Opus/Sonnet on 1M, Haiku on 200K, opt-in betas), and there's no reliable way to infer the limit from the model ID. Percent was misleading (showed 146% on a real 1M-context Opus session). Absolute tokens are honest at any context size.

### 2. Sidecar-driven live data
- Reads `~/.claude/sessions/<pid>.json` during `SessionStore` polling — gives us `sessionId`, `name`, `status`, `updatedAt` per running claude process.
- **Live status dot**: yellow for `busy` (turn in flight), green for `idle`.
- **Real session names** when the user has set one (falls back to project name when it's the default `main-agent`).
- **Direct stats binding**: stats populate on panel open without waiting for a hook event.
- **Sort order**: busy first, then by last activity (most recent on top). Status label: `busy · 2 min ago` / `idle · 1 hr ago` from `updatedAt`.

### 3. Context-fill alerts (Phase 2)
- New \"Context alert at\" Settings row (Off / 100K / 150K / 175K / 200K / 300K / 500K / 750K, default Off).
- Banner names the session: *\"Context filling up — classifier-evolution-2 — at 175K tokens (opus-4-7). Consider /compact.\"*
- Dedup: one banner per `(session, threshold)`. Re-arms on any ≥20K single-reading drop — the characteristic shape of a `/compact` or `/clear`, so refilling after a compact alerts again.
- Fires for any session, whether the panel is visible or not (sidecar polling drives the evaluator).

### Wire / matching
- `agentPID` is now the primary event→session matcher. Falls back to projectPath + tab. Handles two cases the path-based matcher couldn't:
  - Multi-Claude-sessions-in-one-project under terminals without `TERM_SESSION_ID` (Zed, plain Terminal).
  - Session.projectPath (lsof cwd) vs event.projectPath (`\$PWD`) mismatch when the user has cd'd into a subdirectory of the workspace.

### Docs
- README updated: sessions tab live data, new settings rows, both quota and context threshold sections.

## Test plan
- [ ] Open panel → Sessions tab. Each Claude row shows `XXK tokens · model` beneath project path. Names show user-set names (e.g. `classifier-evolution-2`) or project name when claude name is the default `main-agent`.
- [ ] Status dot is yellow while a claude session is processing a turn, green when idle. Status label says `busy · Nm ago` or `idle · Nh ago`.
- [ ] Rows sort: busy on top, then by most-recent updatedAt.
- [ ] Multi-Claude-sessions-in-one-project: each row gets its own correct token count (PID matching).
- [ ] Settings → Usage → \"Context alert at\" → cycle to 150K. With a session above 150K, banner fires once and names the session. After `/compact`, refilling to 150K fires again.
- [ ] Sessions without a sidecar (non-Claude agents, or pre-2.1 Claude Code) still display their existing data — no caption, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)