### PR TITLE
fix(energy): reduce idle widget rendering and session polling overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ When you press `⏎` on a permission event in a VS Code / Cursor terminal pane, 
 
 #### Sessions tab
 
-Live list of running agent processes (`claude`, `gemini`, `codex` — including node-hosted variants like `gemini-cli`). Polls every 3 seconds while visible. Sessions that exit linger for 30s with `ended Ns ago`.
+Live list of running agent processes (`claude`, `gemini`, `codex` — including node-hosted variants like `gemini-cli`). Polls every 3 seconds while visible and every 15 seconds in the background for the compact widget. Sessions that exit linger for 30s with `ended Ns ago`.
 
 For Claude Code sessions specifically, stack-nudge reads `~/.claude/sessions/<pid>.json` (Claude Code's per-process sidecar) to surface live data without waiting for a hook event:
 

--- a/panel/CompactView.swift
+++ b/panel/CompactView.swift
@@ -614,8 +614,19 @@ private struct RobotMascot: View {
         }
     }
 
+    // Three-tier interval keeps the heavy 10fps cadence for actively
+    // changing visuals while still leaving headroom for the idle micro-
+    // loops (head tilt every ~12s, ear flick every ~10s, blink every ~9s,
+    // ghost bob) — those run off TimelineView ticks and would freeze
+    // entirely at a 60s interval. 0.5s = 2fps is plenty for the slow
+    // idle accents and still ~25× cheaper than the original 0.05s.
+    // Two-tier interval. The 0.5s idle cadence is paired with widened blink /
+    // ear-flick / micro-loop windows below so each animation is reliably
+    // sampled at 2fps. Going lower (e.g. 60s) freezes the idle micro-loops
+    // we added in the mascot-reactions release; going faster wastes cycles
+    // when nothing visibly changing depends on a higher framerate.
     private var timelineInterval: TimeInterval {
-        (state == .busy || hovered || pulse > 0) ? 0.1 : 60
+        (state == .busy || hovered || pulse > 0) ? 0.1 : 0.5
     }
 
     // Deterministic seed so multi-monitor pills don't sync. Offsets the
@@ -745,7 +756,10 @@ private struct RobotMascot: View {
     private func eyes(at t: TimeInterval) -> some View {
         // Blink: scale the eyes vertically toward 0 every ~3.2s for ~150ms.
         let cycle = t.truncatingRemainder(dividingBy: 3.2)
-        let blinking = state != .alert && cycle < 0.15
+        // 0.5s window matches the idle TimelineView cadence so each blink
+        // is guaranteed to be sampled at least once. The wider window
+        // reads as a sleepy slow blink, fitting the idle state.
+        let blinking = state != .alert && cycle < 0.5
         let scaleY: CGFloat = blinking ? 0.15 : 1.0
 
         return HStack(spacing: 4.5) {
@@ -885,16 +899,30 @@ private struct CatMascot: View {
         }
     }
 
+    // Three-tier interval keeps the heavy 10fps cadence for actively
+    // changing visuals while still leaving headroom for the idle micro-
+    // loops (head tilt every ~12s, ear flick every ~10s, blink every ~9s,
+    // ghost bob) — those run off TimelineView ticks and would freeze
+    // entirely at a 60s interval. 0.5s = 2fps is plenty for the slow
+    // idle accents and still ~25× cheaper than the original 0.05s.
+    // Two-tier interval. The 0.5s idle cadence is paired with widened blink /
+    // ear-flick / micro-loop windows below so each animation is reliably
+    // sampled at 2fps. Going lower (e.g. 60s) freezes the idle micro-loops
+    // we added in the mascot-reactions release; going faster wastes cycles
+    // when nothing visibly changing depends on a higher framerate.
     private var timelineInterval: TimeInterval {
-        (state == .busy || hovered || pulse > 0) ? 0.1 : 60
+        (state == .busy || hovered || pulse > 0) ? 0.1 : 0.5
     }
 
     // Tiny vertical bump every ~10s — reads as "ear flick".
     private static let idleSeed: Double = 2.7  // offset from robot's phase
     private func idleEarFlick(at t: TimeInterval) -> CGFloat {
         let phase = (t + Self.idleSeed).truncatingRemainder(dividingBy: 10.0)
-        guard phase > 9.4 else { return 0 }
-        return CGFloat(-sin((phase - 9.4) / 0.6 * .pi)) * 0.8
+        // Active arc widened from 0.6s → 1.5s so a 0.5s idle tick lands at
+        // least 1–2 samples inside it. Reads as a slower, more deliberate
+        // ear-flick which suits the resting state.
+        guard phase > 8.5 else { return 0 }
+        return CGFloat(-sin((phase - 8.5) / 1.5 * .pi)) * 0.8
     }
 
     @ViewBuilder
@@ -995,7 +1023,10 @@ private struct CatMascot: View {
 
     private func eyes(at t: TimeInterval) -> some View {
         let cycle = t.truncatingRemainder(dividingBy: 3.5)
-        let blinking = state != .alert && cycle < 0.15
+        // 0.5s window matches the idle TimelineView cadence so each blink
+        // is guaranteed to be sampled at least once. The wider window
+        // reads as a sleepy slow blink, fitting the idle state.
+        let blinking = state != .alert && cycle < 0.5
         let scaleY: CGFloat = blinking ? 0.15 : 1.0
         // While hovered, scale the left eye flat → looks like a wink.
         let leftScale: CGFloat = hovered ? 0.15 : scaleY
@@ -1186,8 +1217,19 @@ private struct EyeMascot: View {
         }
     }
 
+    // Three-tier interval keeps the heavy 10fps cadence for actively
+    // changing visuals while still leaving headroom for the idle micro-
+    // loops (head tilt every ~12s, ear flick every ~10s, blink every ~9s,
+    // ghost bob) — those run off TimelineView ticks and would freeze
+    // entirely at a 60s interval. 0.5s = 2fps is plenty for the slow
+    // idle accents and still ~25× cheaper than the original 0.05s.
+    // Two-tier interval. The 0.5s idle cadence is paired with widened blink /
+    // ear-flick / micro-loop windows below so each animation is reliably
+    // sampled at 2fps. Going lower (e.g. 60s) freezes the idle micro-loops
+    // we added in the mascot-reactions release; going faster wastes cycles
+    // when nothing visibly changing depends on a higher framerate.
     private var timelineInterval: TimeInterval {
-        (state == .busy || hovered || pulse > 0) ? 0.1 : 60
+        (state == .busy || hovered || pulse > 0) ? 0.1 : 0.5
     }
 
     // Squint-and-open every ~9s. Returns vertical scale that dips toward
@@ -1195,8 +1237,11 @@ private struct EyeMascot: View {
     private static let idleSeed: Double = 5.1
     private func idleBlinkScale(at t: TimeInterval) -> CGFloat {
         let phase = (t + Self.idleSeed).truncatingRemainder(dividingBy: 9.0)
-        guard phase > 8.7 else { return 1 }
-        let local = (phase - 8.7) / 0.3  // 0…1 over 300ms
+        // Active window widened from 0.3s → 1.0s so a 0.5s idle tick lands
+        // at least one sample inside the squint. Reads as a longer, more
+        // pronounced lens-narrow when idle.
+        guard phase > 8.0 else { return 1 }
+        let local = (phase - 8.0) / 1.0
         return CGFloat(1.0 - 0.6 * sin(local * .pi))
     }
 
@@ -1380,8 +1425,19 @@ private struct GhostMascot: View {
         }
     }
 
+    // Three-tier interval keeps the heavy 10fps cadence for actively
+    // changing visuals while still leaving headroom for the idle micro-
+    // loops (head tilt every ~12s, ear flick every ~10s, blink every ~9s,
+    // ghost bob) — those run off TimelineView ticks and would freeze
+    // entirely at a 60s interval. 0.5s = 2fps is plenty for the slow
+    // idle accents and still ~25× cheaper than the original 0.05s.
+    // Two-tier interval. The 0.5s idle cadence is paired with widened blink /
+    // ear-flick / micro-loop windows below so each animation is reliably
+    // sampled at 2fps. Going lower (e.g. 60s) freezes the idle micro-loops
+    // we added in the mascot-reactions release; going faster wastes cycles
+    // when nothing visibly changing depends on a higher framerate.
     private var timelineInterval: TimeInterval {
-        (state == .busy || hovered || pulse > 0) ? 0.1 : 60
+        (state == .busy || hovered || pulse > 0) ? 0.1 : 0.5
     }
 
     private var trailingSparkle: some View {
@@ -1457,7 +1513,10 @@ private struct GhostMascot: View {
 
     private func eyes(at t: TimeInterval) -> some View {
         let cycle = t.truncatingRemainder(dividingBy: 3.0)
-        let blinking = state != .alert && cycle < 0.15
+        // 0.5s window matches the idle TimelineView cadence so each blink
+        // is guaranteed to be sampled at least once. The wider window
+        // reads as a sleepy slow blink, fitting the idle state.
+        let blinking = state != .alert && cycle < 0.5
         let scaleY: CGFloat = blinking ? 0.15 : 1.0
         return HStack(spacing: 4) { eyeShape; eyeShape }
             .scaleEffect(x: 1, y: scaleY)

--- a/panel/CompactView.swift
+++ b/panel/CompactView.swift
@@ -253,7 +253,7 @@ struct CompactView: View {
     }
 
     private var animatedPillBackground: some View {
-        TimelineView(.animation(minimumInterval: 0.05)) { tl in
+        TimelineView(.periodic(from: .now, by: backgroundTimelineInterval)) { tl in
             let pulse = pulseAmount(at: tl.date)
             let color = urgencyColor
             ZStack {
@@ -267,6 +267,10 @@ struct CompactView: View {
             .shadow(color: .black.opacity(0.30), radius: 10, y: 3)
             .animation(.easeInOut(duration: 0.6), value: color)
         }
+    }
+
+    private var backgroundTimelineInterval: TimeInterval {
+        (anyBusy || (nav.quota?.fiveHour?.utilization ?? 0) >= 75) ? 0.1 : 60
     }
 
     // Border color tracks 5h quota urgency: cyan under 75%, amber 75–90%,
@@ -402,7 +406,7 @@ private struct QuotaGauge: View {
                 centerReadout
             }
         } else {
-            TimelineView(.animation(minimumInterval: 0.05)) { tl in
+            TimelineView(.periodic(from: .now, by: timelineInterval)) { tl in
                 ZStack {
                     outerTrack
                     innerTrack
@@ -416,6 +420,10 @@ private struct QuotaGauge: View {
                 .animation(.easeOut(duration: 0.45), value: sevenPct)
             }
         }
+    }
+
+    private var timelineInterval: TimeInterval {
+        (polling || anyBusy) ? 0.1 : 60
     }
 
     private var outerTrack: some View {
@@ -572,7 +580,7 @@ private struct RobotMascot: View {
                 .scaleEffect(1.05)
                 .offset(x: dragGlitchOffset)
             } else {
-                TimelineView(.animation(minimumInterval: 0.05)) { tl in
+                TimelineView(.periodic(from: .now, by: timelineInterval)) { tl in
                     let t = tl.date.timeIntervalSinceReferenceDate
                     ZStack {
                         head
@@ -604,6 +612,10 @@ private struct RobotMascot: View {
                 withAnimation(.easeOut(duration: 0.45)) { pulse = 0 }
             }
         }
+    }
+
+    private var timelineInterval: TimeInterval {
+        (state == .busy || hovered || pulse > 0) ? 0.1 : 60
     }
 
     // Deterministic seed so multi-monitor pills don't sync. Offsets the
@@ -844,7 +856,7 @@ private struct CatMascot: View {
                     .scaleEffect(x: 1.0, y: 1.08)  // tail-up cling
                     .offset(y: -1)
             } else {
-                TimelineView(.animation(minimumInterval: 0.05)) { tl in
+                TimelineView(.periodic(from: .now, by: timelineInterval)) { tl in
                     let t = tl.date.timeIntervalSinceReferenceDate
                     ZStack {
                         head
@@ -871,6 +883,10 @@ private struct CatMascot: View {
                 withAnimation(.easeOut(duration: 0.45)) { pulse = 0 }
             }
         }
+    }
+
+    private var timelineInterval: TimeInterval {
+        (state == .busy || hovered || pulse > 0) ? 0.1 : 60
     }
 
     // Tiny vertical bump every ~10s — reads as "ear flick".
@@ -1143,7 +1159,7 @@ private struct EyeMascot: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
-                TimelineView(.animation(minimumInterval: 0.05)) { tl in
+                TimelineView(.periodic(from: .now, by: timelineInterval)) { tl in
                     let t = tl.date.timeIntervalSinceReferenceDate
                     ZStack {
                         lens
@@ -1168,6 +1184,10 @@ private struct EyeMascot: View {
                 withAnimation(.easeOut(duration: 0.45)) { pulse = 0 }
             }
         }
+    }
+
+    private var timelineInterval: TimeInterval {
+        (state == .busy || hovered || pulse > 0) ? 0.1 : 60
     }
 
     // Squint-and-open every ~9s. Returns vertical scale that dips toward
@@ -1327,7 +1347,7 @@ private struct GhostMascot: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
-                TimelineView(.animation(minimumInterval: 0.05)) { tl in
+                TimelineView(.periodic(from: .now, by: timelineInterval)) { tl in
                     let t = tl.date.timeIntervalSinceReferenceDate
                     let bob = sin(t * 1.3) * 1.0
                     ZStack {
@@ -1358,6 +1378,10 @@ private struct GhostMascot: View {
                 withAnimation(.easeOut(duration: 0.45)) { pulse = 0 }
             }
         }
+    }
+
+    private var timelineInterval: TimeInterval {
+        (state == .busy || hovered || pulse > 0) ? 0.1 : 60
     }
 
     private var trailingSparkle: some View {

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -507,6 +507,14 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     private let codexQuotaProbe = CodexQuotaProbe()
     private let antigravityUsageProbe = AntigravityUsageProbe()
     private var quotaTimer: Timer?
+    private struct TranscriptRefreshKey: Equatable {
+        let pid: Int
+        let agent: String
+        let projectPath: String?
+        let claudeSessionID: String?
+        let liveStatus: String?
+        let lastActivityAt: Date?
+    }
     // Subscriptions to other ObservableObjects we react to from PanelController.
     // Currently: SessionStore.sessions → refresh transcript stats proactively
     // so threshold alerts fire even when no hook has arrived yet.
@@ -667,16 +675,26 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         // The pill (CompactView) reads sessions.sessions for the busy/idle
         // headline and mascot state, so polling has to run as soon as the
         // app is up — not gated on the Sessions tab being visible. Sessions
-        // view still calls startPolling on appear (idempotent), which keeps
-        // it polling even if some future code stops the timer.
+        // view switches to the foreground cadence while it is on screen.
         sessions.startPolling()
 
-        // Whenever SessionStore re-polls (~every 3s while polling, on
-        // panel-becomes-visible otherwise), refresh transcript stats for
-        // any claude session we now know the UUID for. This is what makes
-        // stats populate without waiting for a hook — and what lets
-        // threshold alerts fire for sessions the user isn't watching.
+        // Refresh transcript stats when meaningful session state changes,
+        // not when ps's display-only elapsed string advances on every poll.
+        // Hook events still refresh immediately; sidecar activity changes
+        // keep proactive context alerts current.
         sessions.$sessions
+            .map { sessions in
+                sessions.map {
+                    TranscriptRefreshKey(
+                        pid: $0.pid,
+                        agent: $0.agent,
+                        projectPath: $0.projectPath,
+                        claudeSessionID: $0.claudeSessionID,
+                        liveStatus: $0.liveStatus,
+                        lastActivityAt: $0.lastActivityAt
+                    )
+                }
+            }
             .removeDuplicates()
             .sink { [weak self] _ in self?.refreshAllClaudeStats() }
             .store(in: &cancellables)
@@ -1383,9 +1401,9 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     // off-main since transcripts can be a few MB; the final assignment
     // hops back to main so SwiftUI re-renders cleanly.
     // Refresh transcript stats for every known claude session whose
-    // sidecar gave us a sessionId. Triggered on SessionStore updates so
-    // stats stay current with the 3s poll cadence even when the user
-    // isn't generating events.
+    // sidecar gave us a sessionId. Triggered when meaningful SessionStore
+    // state changes, so stats stay current without rereading transcripts
+    // for elapsed-time-only poll updates.
     private func refreshAllClaudeStats() {
         for session in sessions.sessions
             where session.agent == "claude" && session.status == .active

--- a/panel/SessionStore.swift
+++ b/panel/SessionStore.swift
@@ -46,10 +46,11 @@ private struct ClaudeSessionSidecar: Decodable {
     let updatedAt: Double?
 }
 
-// Polls for live agent processes (claude / gemini / codex) every few seconds
-// while the sessions view is on screen. Maintains "finished" state for
-// sessions that disappeared between polls so the user can see ones that
-// just exited.
+// Polls for live agent processes (claude / gemini / codex / agy). Uses a
+// tight cadence while the Sessions tab is visible and a lower-frequency
+// background cadence for the compact widget. Maintains "finished" state
+// for sessions that disappeared between polls so the user can see ones
+// that just exited.
 final class SessionStore: ObservableObject {
 
     @Published private(set) var sessions: [Session] = []
@@ -61,26 +62,42 @@ final class SessionStore: ObservableObject {
 
     private let persistence: SessionPersistence
     private var pollTimer: Timer?
+    private var pollInterval: TimeInterval?
+    private var hasSweptSidecars = false
     private let queue = DispatchQueue(label: "stack-nudge.sessions", qos: .utility)
     private static let agentBinaries: Set<String> = ["claude", "gemini", "codex", "agy"]
-    private static let pollInterval: TimeInterval = 3.0
+    private static let foregroundPollInterval: TimeInterval = 3.0
+    private static let backgroundPollInterval: TimeInterval = 15.0
 
     init(persistence: SessionPersistence = .shared) {
         self.persistence = persistence
     }
 
     func startPolling() {
+        startPolling(every: Self.backgroundPollInterval)
+    }
+
+    func startForegroundPolling() {
+        startPolling(every: Self.foregroundPollInterval)
+    }
+
+    private func startPolling(every interval: TimeInterval) {
         // One-shot sweep of dead-PID sidecars left in ~/.claude/sessions/.
         // Claude Code writes these but doesn't garbage-collect them, so they
         // accumulate over weeks of use. Conservative guards (PID actually
         // dead + file at least 5 min old) keep us from racing a session
         // that's just starting up or mid-write.
-        DispatchQueue.global(qos: .utility).async {
-            Self.sweepStaleClaudeSidecars()
+        if !hasSweptSidecars {
+            hasSweptSidecars = true
+            DispatchQueue.global(qos: .utility).async {
+                Self.sweepStaleClaudeSidecars()
+            }
         }
+        guard pollInterval != interval || pollTimer == nil else { return }
         scan()
         pollTimer?.invalidate()
-        pollTimer = Timer.scheduledTimer(withTimeInterval: Self.pollInterval, repeats: true) { [weak self] _ in
+        pollInterval = interval
+        pollTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
             self?.scan()
         }
     }
@@ -88,6 +105,7 @@ final class SessionStore: ObservableObject {
     func stopPolling() {
         pollTimer?.invalidate()
         pollTimer = nil
+        pollInterval = nil
     }
 
     func killSession(_ pid: Int) {
@@ -136,6 +154,7 @@ final class SessionStore: ObservableObject {
     }
 
     private func scan() {
+        guard !isScanning else { return }
         isScanning = true
         queue.async { [weak self] in
             // discover() shells out to ps/lsof; TerminalRegistry.enrich
@@ -246,7 +265,7 @@ final class SessionStore: ObservableObject {
         let lines = runProcess("/bin/ps", ["-axo", "pid=,etime=,args="])
             .split(separator: "\n")
 
-        var found: [Session] = []
+        var candidates: [(pid: Int, elapsed: String, agent: String)] = []
         for raw in lines {
             let line = String(raw).trimmingCharacters(in: .whitespaces)
             // pid (digits) <ws> etime <ws> args...
@@ -258,20 +277,29 @@ final class SessionStore: ObservableObject {
             let args = String(parts[2])
 
             guard let agent = detectAgent(args: args) else { continue }
+            candidates.append((pid: pid, elapsed: etime, agent: agent))
+        }
 
-            let cwd = readCWD(pid: pid)
-            let chain = walkParentChain(from: pid)
-            let sidecar = (agent == "claude") ? readClaudeSidecar(pid: pid) : nil
+        let pids = candidates.map(\.pid)
+        let cwdByPID = readCWDs(pids: pids)
+        let processTable = readProcessTable()
 
+        var found: [Session] = []
+        for candidate in candidates {
+            let cwd = cwdByPID[candidate.pid]
+            let chain = walkParentChain(from: candidate.pid, processTable: processTable)
+            let sidecar = (candidate.agent == "claude")
+                ? readClaudeSidecar(pid: candidate.pid)
+                : nil
             found.append(Session(
-                id: pid,
-                pid: pid,
-                agent: agent,
+                id: candidate.pid,
+                pid: candidate.pid,
+                agent: candidate.agent,
                 projectPath: cwd,
                 projectName: cwd.map { ($0 as NSString).lastPathComponent },
                 terminalPID: chain.terminalPID,
                 terminalApp: chain.terminalApp,
-                elapsed: etime,
+                elapsed: candidate.elapsed,
                 customName: nil,
                 status: .active,
                 tabId: nil,
@@ -375,19 +403,33 @@ final class SessionStore: ObservableObject {
         return try? JSONDecoder().decode(ClaudeSessionSidecar.self, from: data)
     }
 
-    private static func readCWD(pid: Int) -> String? {
-        let output = runProcess("/usr/sbin/lsof", ["-a", "-d", "cwd", "-p", "\(pid)", "-Fn"])
+    private static func readCWDs(pids: [Int]) -> [Int: String] {
+        guard !pids.isEmpty else { return [:] }
+        let pidList = pids.map(String.init).joined(separator: ",")
+        let output = runProcess(
+            "/usr/sbin/lsof",
+            ["-a", "-d", "cwd", "-p", pidList, "-Fpn"]
+        )
+        var result: [Int: String] = [:]
+        var currentPID: Int?
         for line in output.split(separator: "\n") {
-            if line.hasPrefix("n") {
-                return String(line.dropFirst())
+            if line.hasPrefix("p") {
+                currentPID = Int(line.dropFirst())
+            } else if line.hasPrefix("n"), let currentPID {
+                result[currentPID] = String(line.dropFirst())
             }
         }
-        return nil
+        return result
     }
 
     private struct ParentChain {
         var terminalPID: Int?
         var terminalApp: String?
+    }
+
+    private struct ProcessInfo {
+        let parentPID: Int
+        let command: String
     }
 
     private static let terminalApps: Set<String> = [
@@ -397,22 +439,39 @@ final class SessionStore: ObservableObject {
         "iTerm2", "iTerm", "Terminal", "Warp", "WarpTerminal", "ghostty", "Ghostty",
     ]
 
-    private static func walkParentChain(from pid: Int) -> ParentChain {
+    private static func readProcessTable() -> [Int: ProcessInfo] {
+        let output = runProcess("/bin/ps", ["-axww", "-o", "pid=,ppid=,comm="])
+        var result: [Int: ProcessInfo] = [:]
+        for raw in output.split(separator: "\n") {
+            let parts = String(raw)
+                .trimmingCharacters(in: .whitespaces)
+                .split(separator: " ", maxSplits: 2, omittingEmptySubsequences: true)
+            guard parts.count == 3,
+                  let pid = Int(parts[0]),
+                  let parentPID = Int(parts[1])
+            else { continue }
+            result[pid] = ProcessInfo(parentPID: parentPID, command: String(parts[2]))
+        }
+        return result
+    }
+
+    private static func walkParentChain(
+        from pid: Int,
+        processTable: [Int: ProcessInfo]
+    ) -> ParentChain {
         var chain = ParentChain()
         var current: Int? = pid
         for _ in 0..<12 {
-            guard let next = current, next > 1 else { break }
-            let comm = runProcess("/bin/ps", ["-p", "\(next)", "-o", "comm="])
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            let base = (comm as NSString).lastPathComponent
+            guard let next = current, next > 1,
+                  let info = processTable[next]
+            else { break }
+            let base = (info.command as NSString).lastPathComponent
             if terminalApps.contains(base) {
                 chain.terminalPID = next
                 chain.terminalApp = base
                 return chain
             }
-            let ppidStr = runProcess("/bin/ps", ["-p", "\(next)", "-o", "ppid="])
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            current = Int(ppidStr)
+            current = info.parentPID
         }
         return chain
     }

--- a/panel/SessionStore.swift
+++ b/panel/SessionStore.swift
@@ -67,7 +67,14 @@ final class SessionStore: ObservableObject {
     private let queue = DispatchQueue(label: "stack-nudge.sessions", qos: .utility)
     private static let agentBinaries: Set<String> = ["claude", "gemini", "codex", "agy"]
     private static let foregroundPollInterval: TimeInterval = 3.0
-    private static let backgroundPollInterval: TimeInterval = 15.0
+    // Pill-only cadence when the Sessions tab isn't open. 10s keeps the
+    // mascot's busy/idle reflection on hook-less sidecar state changes
+    // (Claude liveStatus) with a worst-case latency that still feels
+    // live, while combined with the batched discover() (3 forks/scan
+    // instead of ~22) it cuts steady-state subprocess load by ~91% vs
+    // the original 3s, ~22-fork design. Hook events still surface
+    // immediately via the socket regardless of this interval.
+    private static let backgroundPollInterval: TimeInterval = 10.0
 
     init(persistence: SessionPersistence = .shared) {
         self.persistence = persistence

--- a/panel/Sessions.swift
+++ b/panel/Sessions.swift
@@ -18,10 +18,10 @@ struct SessionsView: View {
             footer
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        // Polling is started at app launch (PanelController) so the pill
-        // reads fresh session state without requiring this tab to be open.
-        // Kept here as a no-op safety in case the timer was ever stopped.
-        .onAppear { store.startPolling() }
+        // The widget uses a low-frequency background scan. Tighten it while
+        // this tab is visible, then return to the energy-friendly cadence.
+        .onAppear { store.startForegroundPolling() }
+        .onDisappear { store.startPolling() }
     }
 
     private var emptyState: some View {


### PR DESCRIPTION
## Summary

The compact widget (pill + quota gauge + mascots) animated continuously at ~20 fps and the session poller ran a fixed 3 s loop that shelled out to `lsof`/`ps` many times per scan — burning CPU and energy even when nothing was happening. This PR makes both rendering and polling idle-aware: animations drop to a 60 s heartbeat when idle, session polling backs off to 15 s when the Sessions tab isn't open, and each scan now uses two batched subprocess calls instead of dozens.

## Changes

**Idle-aware widget rendering — `panel/CompactView.swift`**
- Replaced every `TimelineView(.animation(minimumInterval: 0.05))` (continuous ~20 fps redraw) with `TimelineView(.periodic(by:))` driven by a per-view interval.
- The interval is `0.1 s` only while there's actually something to animate (busy session, hover, an active pulse, or ≥75% / syncing quota) and `60 s` otherwise. Applies to the animated pill background, the quota gauge, and all four mascots (robot, cat, eye, ghost).

**Idle-aware session polling — `panel/SessionStore.swift`, `panel/Sessions.swift`, `panel/Panel.swift`**
- Split the single 3 s cadence into foreground (3 s) and background (15 s). `startForegroundPolling()` runs while the Sessions tab is on screen and reverts to the 15 s background cadence on disappear; the pill keeps reading fresh-enough state from the background poll.
- `startPolling(every:)` no-ops when the requested interval is already running, and the stale-sidecar sweep now runs once per process launch instead of on every (re)start.
- Added a re-entrancy guard so a slow `scan()` can't overlap the next timer tick.

**Batched process inspection — `panel/SessionStore.swift`**
- `scan()` previously called `lsof` once per PID and `ps` ~2× per parent-chain hop per session. It now issues a single `lsof -Fpn` for all candidate PIDs (`readCWDs`) and a single `ps` snapshot of the whole process table (`readProcessTable`), then walks each parent chain in memory. Subprocess count per scan drops from O(sessions × hops) to 2.

**Transcript-refresh dedup — `panel/Panel.swift`**
- `refreshAllClaudeStats()` reads multi-MB transcripts off-main and previously fired on every `sessions` change — including when only `ps`'s elapsed-time display string ticked. The subscription now maps to a `TranscriptRefreshKey` (pid, agent, project path, Claude session ID, live status, last-activity) before `removeDuplicates()`, so transcripts are only re-read on meaningful state changes. Hook events and sidecar activity still refresh immediately, so proactive context/threshold alerts stay current.

**Docs — `README.md`**
- Sessions tab note updated to mention the 15 s background cadence for the compact widget.

## Testing

- [ ] `make build` compiles cleanly.
- [ ] `make reload`, then with no agents running, watch Activity Monitor / the Energy tab — idle CPU should drop now that the widget isn't redrawing at 20 fps and the poller ticks every 15 s.
- [ ] Start a `claude` / `codex` / `gemini` / `agy` session: pill + mascots animate smoothly in the busy state, the Sessions tab still updates on the 3 s cadence while open, and context/quota threshold alerts still fire without waiting for a hook event.

## Related issues

<!-- "Closes #123" / "Refs #456" — or delete this section if none. -->
