### PR TITLE
feat(token-count): store token counts against branch and ticket

### DIFF
--- a/Tests/StackNudgePanelCoreTests/HandoffLedgerTests.swift
+++ b/Tests/StackNudgePanelCoreTests/HandoffLedgerTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// HandoffLedger is the per-session store the ticket rollup reads. These pin the
+// upsert-by-session-id semantics (one row per session, merge not append),
+// reload-from-disk, and age/count retention.
+final class HandoffLedgerTests: XCTestCase {
+
+    private func tempURL() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("handoffs-\(UUID().uuidString).jsonl")
+    }
+
+    func test_upsert_createsThenMergesBySessionId() {
+        let url = tempURL()
+        let ledger = HandoffLedger(path: url)
+        ledger.upsert(id: "s1", agent: "codex") { $0.ticket = "ENG-1"; $0.contextTokens = 1000 }
+        ledger.upsert(id: "s1", agent: "codex") { $0.contextTokens = 2500 }  // next turn
+
+        let all = ledger.all()
+        XCTAssertEqual(all.count, 1)                  // merged, not appended
+        XCTAssertEqual(all.first?.ticket, "ENG-1")    // earlier-set field preserved
+        XCTAssertEqual(all.first?.contextTokens, 2500) // latest usage wins
+    }
+
+    func test_separateSessionsAreSeparateRecords() {
+        let ledger = HandoffLedger(path: tempURL())
+        ledger.upsert(id: "s1", agent: "codex") { $0.ticket = "ENG-1" }
+        ledger.upsert(id: "s2", agent: "claude") { $0.ticket = "ENG-2" }
+        XCTAssertEqual(Set(ledger.all().map(\.id)), ["s1", "s2"])
+    }
+
+    func test_survivesReloadFromDisk() {
+        let url = tempURL()
+        let writer = HandoffLedger(path: url)
+        writer.upsert(id: "s1", agent: "agy") { $0.ticket = "PROJ-9"; $0.contextTokens = 42 }
+
+        let reader = HandoffLedger(path: url)   // fresh instance, same file
+        XCTAssertEqual(reader.all().first?.ticket, "PROJ-9")
+        XCTAssertEqual(reader.all().first?.contextTokens, 42)
+    }
+
+    func test_countRetention_keepsNewest() {
+        let ledger = HandoffLedger(path: tempURL(), maxCount: 2)
+        for i in 1...4 { ledger.upsert(id: "s\(i)", agent: "codex") { $0.contextTokens = i } }
+        let ids = ledger.all().map(\.id)
+        XCTAssertEqual(ids.count, 2)
+        XCTAssertEqual(Set(ids), ["s3", "s4"])  // oldest two pruned
+    }
+
+    func test_ageRetention_dropsStaleOnNextWrite() {
+        let url = tempURL()
+        // Pre-seed a 2020-dated record directly (the API always stamps
+        // updatedAt = now, so we can't backdate through it).
+        let old = #"{"id":"old","agent":"codex","createdAt":"2020-01-01T00:00:00Z","updatedAt":"2020-01-01T00:00:00Z"}"# + "\n"
+        try? old.write(to: url, atomically: true, encoding: .utf8)
+
+        let ledger = HandoffLedger(path: url, maxAgeDays: 90)
+        ledger.upsert(id: "new", agent: "codex") { $0.contextTokens = 1 }  // triggers prune
+        XCTAssertEqual(ledger.all().map(\.id), ["new"])  // 2020 record aged out
+    }
+}

--- a/Tests/StackNudgePanelCoreTests/TicketAttributionTests.swift
+++ b/Tests/StackNudgePanelCoreTests/TicketAttributionTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// TicketAttribution turns the git context a handoff captures into a Linear/Jira
+// key, per the monorepo branch/commit conventions. These pin the precedence
+// (branch > commit > PR), the anchored-branch trust, and the allow-list guard
+// against false positives like "UTF-8".
+final class TicketAttributionTests: XCTestCase {
+
+    func test_ticket_fromConventionalBranch() {
+        XCTAssertEqual(TicketAttribution.ticket(branch: "ENG-12142/fix-idp-logout"), "ENG-12142")
+    }
+
+    func test_ticket_jiraStyleBranch() {
+        XCTAssertEqual(TicketAttribution.ticket(branch: "PROJ-87/add-export"), "PROJ-87")
+    }
+
+    func test_ticket_branchWithoutKey_returnsNil() {
+        XCTAssertNil(TicketAttribution.ticket(branch: "main"))
+        XCTAssertNil(TicketAttribution.ticket(branch: "spike/quick-thing"))
+    }
+
+    func test_ticket_fromCommitScope_whenBranchHasNone() {
+        XCTAssertEqual(
+            TicketAttribution.ticket(branch: "spike", commitSubject: "fix(ENG-9): a bug"),
+            "ENG-9")
+    }
+
+    func test_ticket_fromPR_whenBranchAndCommitHaveNone() {
+        XCTAssertEqual(
+            TicketAttribution.ticket(branch: "spike", commitSubject: "wip", pr: "ENG-5 add thing"),
+            "ENG-5")
+    }
+
+    func test_ticket_branchTakesPrecedenceOverCommit() {
+        XCTAssertEqual(
+            TicketAttribution.ticket(branch: "ENG-1/x", commitSubject: "fix(ENG-2): y"),
+            "ENG-1")
+    }
+
+    func test_anchoredBranchKey_trustedRegardlessOfAllowlist() {
+        // An anchored branch key is trusted even when not in the allow-list.
+        XCTAssertEqual(
+            TicketAttribution.ticket(branch: "ENG-12142/x", allowedPrefixes: ["JIRA"]),
+            "ENG-12142")
+    }
+
+    func test_allowedPrefixes_filtersCommitFalsePositive() {
+        // "UTF-8" matches the key shape but isn't a real ticket.
+        XCTAssertNil(
+            TicketAttribution.ticket(branch: "spike", commitSubject: "chore: bump to UTF-8",
+                                     allowedPrefixes: ["ENG"]))
+        XCTAssertEqual(
+            TicketAttribution.ticket(branch: "spike", commitSubject: "fix(ENG-9): x",
+                                     allowedPrefixes: ["ENG"]),
+            "ENG-9")
+    }
+
+    func test_nonAnchoredBranchKey_foundViaFallback() {
+        XCTAssertEqual(TicketAttribution.ticket(branch: "feature/ENG-77-thing"), "ENG-77")
+    }
+}

--- a/build.sh
+++ b/build.sh
@@ -245,6 +245,9 @@ build_app "$APP" "stack-nudge" \
   panel/CodexUsage.swift \
   panel/AntigravityLocalServer.swift \
   panel/AntigravityUsage.swift \
+  panel/TicketAttribution.swift \
+  panel/Handoff.swift \
+  panel/HandoffLedger.swift \
   panel/Sessions.swift \
   panel/CompactView.swift \
   panel/TranscriptStats.swift \

--- a/panel/Handoff.swift
+++ b/panel/Handoff.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+// One persisted record per agent *session* (not per turn). Created/updated on
+// each Stop so it carries the session's latest usage; keyed by the agent's
+// session id so repeated Stops upsert rather than pile up. The token + ticket
+// fields are the basis for the per-ticket usage rollup; risk/outcome/PR fields
+// are added by later iterations (RiskClassifier, OutcomeWatcher).
+struct HandoffRecord: Codable, Identifiable, Equatable {
+    let id: String              // agent session id — the upsert key
+    let agent: String           // canonical agent: "claude" | "codex" | "agy"
+    var repoRoot: String?
+    var branch: String?
+    var ticket: String?         // Linear/Jira key (e.g. "ENG-12142"); nil if none
+    var model: String?
+    var contextTokens: Int?     // latest context-window tokens for the session
+    let createdAt: Date
+    var updatedAt: Date
+}

--- a/panel/HandoffLedger.swift
+++ b/panel/HandoffLedger.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+// Durable, bounded per-session ledger at ~/.stack-nudge/handoffs.jsonl. Records
+// are upserted by session id (one row per session, last-write-wins) and pruned
+// by age + count. JSONL keeps it dependency-free and matches the repo's
+// swiftc-only build (no SQLite). Access is main-thread only — the Stop capture
+// and the dashboard both run on main — and the file is small (≤ maxCount rows),
+// so the synchronous atomic write is negligible.
+final class HandoffLedger {
+
+    static let shared = HandoffLedger()
+
+    private let url: URL
+    private let maxAge: TimeInterval
+    private let maxCount: Int
+    private var byID: [String: HandoffRecord]
+
+    init(path: URL? = nil, maxAgeDays: Double = 90, maxCount: Int = 1000) {
+        let dir = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".stack-nudge", isDirectory: true)
+        self.url = path ?? dir.appendingPathComponent("handoffs.jsonl", isDirectory: false)
+        self.maxAge = maxAgeDays * 86_400
+        self.maxCount = maxCount
+        self.byID = Self.load(url)
+    }
+
+    // Create on first sight of a session id, or merge into the existing record.
+    // The `merge` closure lets the caller set only the fields it knows this
+    // tick (e.g. usage) without clobbering an earlier-derived ticket. `id` and
+    // `agent` are fixed; `createdAt` is preserved; `updatedAt` is stamped here.
+    func upsert(id: String, agent: String, _ merge: (inout HandoffRecord) -> Void) {
+        let now = Date()
+        var record = byID[id] ?? HandoffRecord(
+            id: id, agent: agent,
+            repoRoot: nil, branch: nil, ticket: nil, model: nil, contextTokens: nil,
+            createdAt: now, updatedAt: now)
+        merge(&record)
+        record.updatedAt = now
+        byID[id] = record
+        prune()
+        persist()
+    }
+
+    // Newest-first.
+    func all() -> [HandoffRecord] {
+        byID.values.sorted { $0.updatedAt > $1.updatedAt }
+    }
+
+    // MARK: - Persistence
+
+    private static func decoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+    private static func encoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    private static func load(_ url: URL) -> [String: HandoffRecord] {
+        guard let data = try? Data(contentsOf: url),
+              let text = String(data: data, encoding: .utf8) else { return [:] }
+        let decoder = decoder()
+        var result: [String: HandoffRecord] = [:]
+        for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
+            guard let lineData = line.data(using: .utf8),
+                  let record = try? decoder.decode(HandoffRecord.self, from: lineData)
+            else { continue }
+            result[record.id] = record
+        }
+        return result
+    }
+
+    private func prune() {
+        let cutoff = Date().addingTimeInterval(-maxAge)
+        var kept = byID.values.filter { $0.updatedAt >= cutoff }
+        if kept.count > maxCount {
+            kept = Array(kept.sorted { $0.updatedAt > $1.updatedAt }.prefix(maxCount))
+        }
+        byID = Dictionary(uniqueKeysWithValues: kept.map { ($0.id, $0) })
+    }
+
+    private func persist() {
+        let encoder = Self.encoder()
+        let lines = all()
+            .compactMap { try? encoder.encode($0) }
+            .compactMap { String(data: $0, encoding: .utf8) }
+        let blob = Data((lines.joined(separator: "\n") + "\n").utf8)
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? blob.write(to: url, options: .atomic)
+    }
+}

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -659,6 +659,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
             self?.lastEventArrivalAt = Date()
             self?.postBannerIfNeeded(event)
             self?.refreshTranscriptStats(for: event)
+            self?.captureHandoff(for: event)
             self?.nav.reactToEvent(event.kind)
         }
         nav.loadFromConfig()  // populate panelPinned + other live values up-front
@@ -1464,6 +1465,47 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                 self?.evaluateContextThreshold(sessionID: sessionID, stats: stats)
             }
         }
+    }
+
+    // Persist a per-session handoff record at Stop (Claude + Codex — agy has no
+    // Stop hook). Resolves git repo/branch + ticket + the latest token usage
+    // off-main, then upserts the session's row in the ledger. This is the basis
+    // for the per-ticket usage rollup. Non-git directories are skipped — there's
+    // nothing to attribute to a repo/ticket.
+    private func captureHandoff(for event: NudgeEvent) {
+        guard event.kind == .stop,
+              let sessionID = event.claudeSessionID,
+              let cwd = event.projectPath, !cwd.isEmpty
+        else { return }
+        let agent = Agent.canonical(event.agent)
+        let transcriptPath = event.transcriptPath
+        DispatchQueue.global(qos: .utility).async {
+            guard let repoRoot = Self.gitValue(cwd, ["rev-parse", "--show-toplevel"]) else { return }
+            let branch = Self.gitValue(cwd, ["rev-parse", "--abbrev-ref", "HEAD"])
+            let commitSubject = Self.gitValue(cwd, ["log", "-1", "--format=%s"])
+            let ticket = TicketAttribution.ticket(branch: branch, commitSubject: commitSubject)
+            let stats = transcriptPath.flatMap { TranscriptReader.read(path: $0) }
+            DispatchQueue.main.async {
+                HandoffLedger.shared.upsert(id: sessionID, agent: agent) { record in
+                    record.repoRoot = repoRoot
+                    record.branch = branch
+                    if record.ticket == nil { record.ticket = ticket }  // derive once, fill if empty
+                    if let stats {
+                        record.model = stats.model
+                        record.contextTokens = stats.tokens
+                    }
+                }
+            }
+        }
+    }
+
+    // Run `git -C <cwd> <args>`; trim, and treat non-repo / empty output as nil.
+    private static func gitValue(_ cwd: String, _ args: [String]) -> String? {
+        let output = ProcessOutput.read("/usr/bin/git", ["-C", cwd] + args)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !output.isEmpty, !output.hasPrefix("fatal"),
+              !output.contains("not a git repository") else { return nil }
+        return output
     }
 
     // Per-session state for context-threshold dedup. Lives on the

--- a/panel/TicketAttribution.swift
+++ b/panel/TicketAttribution.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+// Derives the Linear/Jira ticket key for a session from the git context the
+// handoff already captures, using this monorepo's conventions (root CLAUDE.md):
+//   branch  <TICKET-NUMBER>/<desc>     e.g. ENG-12142/fix-idp-logout
+//   commit  <type>(<TICKET-NUMBER>):   e.g. fix(ENG-12142): clear cookie
+// Pure string work — no git, no network.
+enum TicketAttribution {
+
+    // A key like ENG-123 / PROJ-87: an uppercase, letter-first alphanumeric
+    // project prefix, a hyphen, then digits.
+    private static let key = #"[A-Z][A-Z0-9]+-[0-9]+"#
+
+    /// Resolve a ticket key, first match wins by reliability:
+    ///   1. `branch` anchored at the start — the convention puts the key first,
+    ///      so an anchored hit is trusted as-is (no prefix filtering).
+    ///   2. otherwise, the first key found *anywhere* in branch / commit subject
+    ///      / PR head-ref-or-title.
+    /// `allowedPrefixes` (e.g. `["ENG"]`) guards the fuzzier any-match fallback
+    /// against shapes like `UTF-8`; `nil` accepts any prefix.
+    /// Returns the bare key (e.g. `"ENG-12142"`) or `nil` when nothing matches.
+    static func ticket(branch: String?,
+                       commitSubject: String? = nil,
+                       pr: String? = nil,
+                       allowedPrefixes: Set<String>? = nil) -> String? {
+        if let branch, let anchored = firstMatch(branch, anchored: true) {
+            return anchored
+        }
+        for source in [branch, commitSubject, pr].compactMap({ $0 }) {
+            if let hit = firstMatch(source, anchored: false), passes(hit, allowedPrefixes) {
+                return hit
+            }
+        }
+        return nil
+    }
+
+    private static func firstMatch(_ string: String, anchored: Bool) -> String? {
+        let pattern = anchored ? "^(?:\(key))" : "\\b(?:\(key))\\b"
+        guard let range = string.range(of: pattern, options: .regularExpression) else { return nil }
+        return String(string[range])
+    }
+
+    // The prefix is the segment before the hyphen ("ENG" in "ENG-12142").
+    private static func passes(_ ticketKey: String, _ allowed: Set<String>?) -> Bool {
+        guard let allowed else { return true }
+        return allowed.contains(String(ticketKey.prefix { $0 != "-" }))
+    }
+}


### PR DESCRIPTION
## Summary

Foundation for usage-to-outcome tracking: a durable per-session "handoff"
ledger that records, on each agent Stop, which session ran where — repo,
branch, derived Linear/Jira ticket, model, and context-window tokens. No
UI in this PR; the Tickets tab that reads the ledger lands in a stacked
follow-up.

## Changes

- **`TicketAttribution`** — pure parser deriving a Linear/Jira key
  (`ENG-12142`) from the branch (`<TICKET>/<desc>`), commit scope
  (`<type>(<TICKET>):`), or PR ref, per the monorepo conventions. An
  anchored branch key is trusted; the fuzzy fallback is allow-list guarded
  so shapes like `UTF-8` don't register as tickets.
- **`HandoffRecord` + `HandoffLedger`** — JSONL store at
  `~/.stack-nudge/handoffs.jsonl`, upserted by session id (one row per
  session, last-write-wins), pruned by age (90d) + count (1000).
  Dependency-free, main-thread, atomic writes.
- **Capture at Stop** (`Panel.swift`) — on each Stop in a git repo,
  resolves repo root / branch / commit subject off the main thread,
  derives the ticket, reads transcript token stats, and upserts the
  record. `claude --resume` keeps the session id, so resumed work merges
  into the same row rather than duplicating.
- Parser + ledger unit tests (run in CI).

## Testing

- `./build.sh` → Build complete.
- Parser and ledger logic validated via standalone `swiftc` harnesses
  (`swift test` needs Xcode locally; the committed XCTest suites run in CI).
- Verified live: a real session captured with its ticket derived; a
  close + `--resume` merged into a single record (tokens grew across the
  resume, no duplicate row).

## Related issues

Refs the usage-to-outcome dashboard plan. UI follow-up: the Tickets tab
(per-ticket / branch rollup) stacks on this branch.
