### PR TITLE
feat(token-count): add Tickets tab for per-ticket usage

### DIFF
--- a/Tests/StackNudgePanelCoreTests/OutcomesViewTests.swift
+++ b/Tests/StackNudgePanelCoreTests/OutcomesViewTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// OutcomesView.groups rolls the handoff ledger up for the Tickets tab. These
+// pin the grouping key (ticket, falling back to branch), the token/session
+// aggregation, the tickets-before-branches ordering, and the recency sort
+// within a band.
+final class OutcomesViewTests: XCTestCase {
+
+    private func record(id: String,
+                        agent: String = "claude",
+                        repoRoot: String? = "/work/stack-nudge",
+                        branch: String? = nil,
+                        ticket: String? = nil,
+                        tokens: Int? = nil,
+                        updated: TimeInterval = 0) -> HandoffRecord {
+        let date = Date(timeIntervalSince1970: updated)
+        return HandoffRecord(
+            id: id, agent: agent, repoRoot: repoRoot, branch: branch, ticket: ticket,
+            model: nil, contextTokens: tokens, createdAt: date, updatedAt: date)
+    }
+
+    func test_groupsByTicket_sumsTokensAndCountsSessions() {
+        let groups = OutcomesView.groups(from: [
+            record(id: "a", ticket: "ENG-1", tokens: 100, updated: 1),
+            record(id: "b", ticket: "ENG-1", tokens: 200, updated: 2),
+        ])
+        XCTAssertEqual(groups.count, 1)
+        XCTAssertEqual(groups.first?.id, "ENG-1")
+        XCTAssertEqual(groups.first?.isTicket, true)
+        XCTAssertEqual(groups.first?.sessionCount, 2)
+        XCTAssertEqual(groups.first?.totalTokens, 300)
+    }
+
+    func test_branchUsedAsKeyWhenNoTicket() {
+        let groups = OutcomesView.groups(from: [
+            record(id: "a", branch: "feat/x", ticket: nil, tokens: 50),
+        ])
+        XCTAssertEqual(groups.first?.id, "feat/x")
+        XCTAssertEqual(groups.first?.isTicket, false)
+        XCTAssertEqual(groups.first?.totalTokens, 50)
+    }
+
+    func test_ticketsSortBeforeBranches_evenWhenBranchIsNewer() {
+        let groups = OutcomesView.groups(from: [
+            record(id: "a", branch: "feat/x", updated: 100),  // newest, but a branch
+            record(id: "b", ticket: "ENG-1", updated: 1),     // older, but a ticket
+        ])
+        XCTAssertEqual(groups.map(\.id), ["ENG-1", "feat/x"])
+    }
+
+    func test_withinTickets_sortedByMostRecentActivity() {
+        let groups = OutcomesView.groups(from: [
+            record(id: "a", ticket: "ENG-1", updated: 1),
+            record(id: "b", ticket: "ENG-2", updated: 5),
+        ])
+        XCTAssertEqual(groups.map(\.id), ["ENG-2", "ENG-1"])
+    }
+
+    func test_distinctAgentsPreservedInFirstSeenOrder() {
+        let groups = OutcomesView.groups(from: [
+            record(id: "a", agent: "claude", ticket: "ENG-1", updated: 1),
+            record(id: "b", agent: "codex",  ticket: "ENG-1", updated: 2),
+            record(id: "c", agent: "claude", ticket: "ENG-1", updated: 3),
+        ])
+        XCTAssertEqual(groups.first?.agents, ["Claude", "Codex"])
+    }
+
+    func test_noTicketNoBranch_fallsBackToPlaceholder() {
+        let groups = OutcomesView.groups(from: [record(id: "a", branch: nil)])
+        XCTAssertEqual(groups.first?.id, "—")
+        XCTAssertEqual(groups.first?.isTicket, false)
+    }
+
+    func test_lowercaseBranch_regroupsUnderTicket_evenWhenStoredTicketIsNil() {
+        // A record captured before the parser fix: ticket=nil, lowercase branch.
+        // The rollup re-derives ENG-75 from the branch so it groups as a ticket.
+        let groups = OutcomesView.groups(from: [
+            record(id: "a", branch: "eng-75/sync", ticket: nil, tokens: 100),
+        ])
+        XCTAssertEqual(groups.first?.id, "ENG-75")
+        XCTAssertEqual(groups.first?.isTicket, true)
+    }
+
+    func test_repos_distinctNamesFromRepoRoot() {
+        let groups = OutcomesView.groups(from: [
+            record(id: "a", repoRoot: "/work/stack-nudge", ticket: "ENG-1"),
+            record(id: "b", repoRoot: "/work/unified-cloud-api", ticket: "ENG-1"),
+            record(id: "c", repoRoot: "/work/stack-nudge", ticket: "ENG-1"),
+        ])
+        XCTAssertEqual(groups.first?.repos, ["stack-nudge", "unified-cloud-api"])
+    }
+
+    func test_ticketBranchBreakdown_perBranchHeaviestFirst() {
+        let groups = OutcomesView.groups(from: [
+            record(id: "a", branch: "ENG-1/backend",  ticket: "ENG-1", tokens: 100),
+            record(id: "b", branch: "ENG-1/frontend", ticket: "ENG-1", tokens: 900),
+            record(id: "c", branch: "ENG-1/backend",  ticket: "ENG-1", tokens: 100),
+        ])
+        let branches = groups.first?.branches ?? []
+        XCTAssertEqual(branches.map(\.branch), ["ENG-1/frontend", "ENG-1/backend"])
+        XCTAssertEqual(branches.first?.totalTokens, 900)
+        XCTAssertEqual(branches.last?.sessionCount, 2)
+    }
+
+    func test_branchGroup_hasNoBranchSubRows() {
+        let groups = OutcomesView.groups(from: [record(id: "a", branch: "feat/x")])
+        XCTAssertEqual(groups.first?.branches, [])
+    }
+}

--- a/Tests/StackNudgePanelCoreTests/TicketAttributionTests.swift
+++ b/Tests/StackNudgePanelCoreTests/TicketAttributionTests.swift
@@ -60,4 +60,19 @@ final class TicketAttributionTests: XCTestCase {
     func test_nonAnchoredBranchKey_foundViaFallback() {
         XCTAssertEqual(TicketAttribution.ticket(branch: "feature/ENG-77-thing"), "ENG-77")
     }
+
+    func test_lowercaseBranchKey_normalisedToUppercase() {
+        // Branches are commonly lowercased; the canonical Linear key is upper.
+        XCTAssertEqual(TicketAttribution.ticket(branch: "eng-75/connector-sync"), "ENG-75")
+    }
+
+    func test_mixedCaseBranchKey_normalisedToUppercase() {
+        XCTAssertEqual(TicketAttribution.ticket(branch: "Eng-75/x"), "ENG-75")
+    }
+
+    func test_lowercaseInCommitFallback_notMatched() {
+        // The fuzzy fallback stays uppercase-only so it can't catch shapes
+        // like "utf-8" that aren't tickets.
+        XCTAssertNil(TicketAttribution.ticket(branch: "spike", commitSubject: "bump to utf-8"))
+    }
 }

--- a/build.sh
+++ b/build.sh
@@ -248,6 +248,7 @@ build_app "$APP" "stack-nudge" \
   panel/TicketAttribution.swift \
   panel/Handoff.swift \
   panel/HandoffLedger.swift \
+  panel/OutcomesView.swift \
   panel/Sessions.swift \
   panel/CompactView.swift \
   panel/TranscriptStats.swift \

--- a/panel/OutcomesView.swift
+++ b/panel/OutcomesView.swift
@@ -1,0 +1,278 @@
+import AppKit
+import Foundation
+import SwiftUI
+
+// A single branch's slice of a ticket — shown as an indented sub-row so a
+// ticket that spans several branches reveals where its sessions/tokens went.
+struct BranchBreakdown: Identifiable, Equatable {
+    var id: String { branch }
+    let branch: String
+    let sessionCount: Int
+    let totalTokens: Int
+}
+
+// One aggregated row in the Tickets tab: every session that shares a grouping
+// key. The key is the derived Linear/Jira ticket when one was found, else the
+// git branch (so unticketed work-streams stay separate instead of collapsing
+// into one anonymous bucket). Tokens are summed across the group's sessions.
+struct TicketGroup: Identifiable, Equatable {
+    let id: String          // grouping key = ticket ?? branch ?? placeholder
+    let isTicket: Bool      // true when id is a real ticket key (gets the deep link)
+    let repos: [String]     // distinct repo names the sessions ran in
+    let sessionCount: Int
+    let totalTokens: Int
+    let agents: [String]    // distinct canonical agents, first-seen order
+    let branches: [BranchBreakdown]  // sub-rows; populated for ticket groups
+}
+
+// Tickets tab — the first slice of the usage-to-outcome dashboard. Reads the
+// handoff ledger, rolls token usage + session counts up per `ticket ?? branch`,
+// shows the repo each group ran in and (for tickets) the branches beneath it,
+// and deep-links each ticket row to its tracker when STACKNUDGE_TICKET_URL is
+// set. Pure read over data the ledger already holds; no capture, no network.
+struct OutcomesView: View {
+
+    @ObservedObject var nav: PanelNav
+
+    // STACKNUDGE_TICKET_URL template, e.g. "https://linear.app/acme/issue/{key}".
+    // Loaded once on appear; unset → ticket rows render without a link.
+    @State private var ticketURLTemplate: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            let groups = Self.groups(from: HandoffLedger.shared.all())
+            if groups.isEmpty {
+                emptyState
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 8) {
+                        ForEach(groups) { groupRow($0) }
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 14)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(ThinScrollers())
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .scrollIndicators(.visible)
+            }
+
+            PageFooter {
+                FooterHint(label: footerStatus(groups), keys: [])
+                if nav.compactMode { FooterHint(label: "Compact", keys: ["M"]) }
+                FooterHint(label: "Hide", keys: ["Esc"])
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .onAppear { ticketURLTemplate = ConfigFile.read()["STACKNUDGE_TICKET_URL"] }
+    }
+
+    // MARK: - Rows
+
+    private func groupRow(_ group: TicketGroup) -> some View {
+        let linkable = group.isTicket && ticketURL(for: group.id) != nil
+        return VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 6) {
+                Text(group.id)
+                    .font(.callout.weight(.semibold))
+                    .foregroundStyle(group.isTicket ? Color.primary : Color.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if linkable {
+                    Image(systemName: "arrow.up.right.square")
+                        .font(.caption)
+                        .foregroundStyle(Color.accentColor)
+                }
+                Spacer(minLength: 8)
+                if !group.repos.isEmpty {
+                    Text(group.repos.joined(separator: ", "))
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                        .fixedSize()
+                }
+            }
+            Text(detailLine(group))
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+            if !group.branches.isEmpty {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(group.branches) { branchRow($0) }
+                }
+                .padding(.top, 1)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(RoundedRectangle(cornerRadius: 6).fill(Color.primary.opacity(0.04)))
+        .contentShape(Rectangle())
+        .onTapGesture { if linkable { openTicket(group) } }
+        .help(linkable ? "Open \(group.id) in your tracker" : "")
+    }
+
+    private func branchRow(_ branch: BranchBreakdown) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "arrow.turn.down.right")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+            Text(branch.branch)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: 8)
+            Text(branchDetail(branch))
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.tertiary)
+                .fixedSize()
+        }
+        .padding(.leading, 12)
+    }
+
+    // "3 sessions · 218K tokens · Claude, Codex" — the tokens segment is
+    // dropped when no session in the group carried a token count.
+    private func detailLine(_ group: TicketGroup) -> String {
+        var parts = [Self.sessionsLabel(group.sessionCount)]
+        if group.totalTokens > 0 { parts.append("\(Self.shortTokens(group.totalTokens)) tokens") }
+        if !group.agents.isEmpty { parts.append(group.agents.joined(separator: ", ")) }
+        return parts.joined(separator: " · ")
+    }
+
+    // Compact sub-row trailing: "2 sessions · 600K".
+    private func branchDetail(_ branch: BranchBreakdown) -> String {
+        var parts = [Self.sessionsLabel(branch.sessionCount)]
+        if branch.totalTokens > 0 { parts.append(Self.shortTokens(branch.totalTokens)) }
+        return parts.joined(separator: " · ")
+    }
+
+    // MARK: - Deep link
+
+    private func ticketURL(for key: String) -> URL? {
+        guard let template = ticketURLTemplate, template.contains("{key}") else { return nil }
+        return URL(string: template.replacingOccurrences(of: "{key}", with: key))
+    }
+
+    private func openTicket(_ group: TicketGroup) {
+        guard let url = ticketURL(for: group.id) else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    // MARK: - Aggregation (pure, testable)
+
+    // Roll the ledger up by `ticket ?? branch`. The ticket is re-derived from
+    // the branch when the stored field is empty, so records captured before a
+    // parser fix (e.g. lowercase `eng-75/…`) still roll up under `ENG-75`.
+    // Tickets sort first (they're the unit the user tracks), then by most-recent
+    // activity within each band.
+    static func groups(from records: [HandoffRecord]) -> [TicketGroup] {
+        struct Resolved { let key: String; let isTicket: Bool; let record: HandoffRecord }
+        let resolved = records.map { record -> Resolved in
+            if let ticket = record.ticket ?? TicketAttribution.ticket(branch: record.branch) {
+                return Resolved(key: ticket, isTicket: true, record: record)
+            }
+            return Resolved(key: record.branch ?? "—", isTicket: false, record: record)
+        }
+
+        var keyOrder: [String] = []
+        var byKey: [String: [Resolved]] = [:]
+        for item in resolved {
+            if byKey[item.key] == nil { keyOrder.append(item.key) }
+            byKey[item.key, default: []].append(item)
+        }
+
+        let groups = keyOrder.map { key -> (group: TicketGroup, last: Date) in
+            let items = byKey[key] ?? []
+            let rows = items.map(\.record)
+            let isTicket = items.first?.isTicket ?? false
+            let tokens = rows.compactMap(\.contextTokens).reduce(0, +)
+            let agents = orderedDistinct(rows.map { displayAgent($0.agent) })
+            let repos = orderedDistinct(rows.compactMap { repoName($0.repoRoot) })
+            let last = rows.map(\.updatedAt).max() ?? .distantPast
+            let branches = isTicket ? branchBreakdown(rows) : []
+            return (TicketGroup(id: key, isTicket: isTicket, repos: repos,
+                                sessionCount: rows.count, totalTokens: tokens,
+                                agents: agents, branches: branches), last)
+        }
+        return groups.sorted {
+            if $0.group.isTicket != $1.group.isTicket { return $0.group.isTicket }
+            return $0.last > $1.last
+        }.map(\.group)
+    }
+
+    // Per-branch slices within a ticket, heaviest token use first.
+    static func branchBreakdown(_ rows: [HandoffRecord]) -> [BranchBreakdown] {
+        var order: [String] = []
+        var byBranch: [String: [HandoffRecord]] = [:]
+        for row in rows {
+            let branch = row.branch ?? "—"
+            if byBranch[branch] == nil { order.append(branch) }
+            byBranch[branch, default: []].append(row)
+        }
+        return order.map { branch -> BranchBreakdown in
+            let group = byBranch[branch] ?? []
+            let tokens = group.compactMap(\.contextTokens).reduce(0, +)
+            return BranchBreakdown(branch: branch, sessionCount: group.count, totalTokens: tokens)
+        }.sorted { $0.totalTokens > $1.totalTokens }
+    }
+
+    private static func orderedDistinct(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        return values.filter { seen.insert($0).inserted }
+    }
+
+    private static func repoName(_ repoRoot: String?) -> String? {
+        guard let repoRoot, !repoRoot.isEmpty else { return nil }
+        let name = (repoRoot as NSString).lastPathComponent
+        return name.isEmpty ? nil : name
+    }
+
+    private static func displayAgent(_ canonical: String) -> String {
+        switch canonical {
+        case "claude": return "Claude"
+        case "codex":  return "Codex"
+        case "agy":    return "Antigravity"
+        case "gemini": return "Gemini"
+        default:       return canonical.capitalized
+        }
+    }
+
+    private static func sessionsLabel(_ count: Int) -> String {
+        count == 1 ? "1 session" : "\(count) sessions"
+    }
+
+    private static func shortTokens(_ count: Int) -> String {
+        if count >= 1_000_000 { return String(format: "%.1fM", Double(count) / 1_000_000) }
+        if count >= 1_000 { return "\(Int((Double(count) / 1_000).rounded()))K" }
+        return "\(count)"
+    }
+
+    // MARK: - Footer + empty state
+
+    private func footerStatus(_ groups: [TicketGroup]) -> String {
+        guard !groups.isEmpty else { return "No tracked sessions" }
+        let sessions = groups.reduce(0) { $0 + $1.sessionCount }
+        let groupWord = groups.count == 1 ? "group" : "groups"
+        let sessionWord = sessions == 1 ? "session" : "sessions"
+        return "\(groups.count) \(groupWord) · \(sessions) \(sessionWord)"
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "tag")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+            Text("No tracked sessions yet")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Text("When an agent finishes a turn inside a git repo, stack-nudge records the session here — grouped by its Linear/Jira ticket, or the branch when there's no ticket.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 300)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.vertical, 24)
+    }
+}

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -27,6 +27,7 @@ private enum KeyCode {
     static let two:       UInt16 = 19
     static let three:     UInt16 = 20
     static let four:      UInt16 = 21
+    static let five:      UInt16 = 23
     static let nKey:      UInt16 = 45
     static let pKey:      UInt16 = 35
     static let mKey:      UInt16 = 46
@@ -124,6 +125,7 @@ struct PanelContentView: View {
                 case .events:   eventsBody
                 case .sessions: SessionsView(store: sessions, events: store, nav: nav)
                 case .usage:    UsageView(nav: nav)
+                case .outcomes: OutcomesView(nav: nav)
                 case .settings: SettingsView(nav: nav)
                 case .phrases:  PhrasesView(model: phrases) { nav.mode = .settings }
                 case .updateConfirm:
@@ -146,6 +148,14 @@ struct PanelContentView: View {
         }
     }
 
+    // Distinct ticket/branch groups in the ledger — the badge on the Tickets
+    // tab. Reads nav.handoffsRevision so the count refreshes when a Stop adds
+    // a session while the panel is open.
+    private var ticketGroupCount: Int {
+        _ = nav.handoffsRevision
+        return Set(HandoffLedger.shared.all().map { $0.ticket ?? $0.branch ?? "—" }).count
+    }
+
     private var tabStrip: some View {
         HStack(spacing: 4) {
             Image(systemName: "bell.badge.fill")
@@ -156,6 +166,7 @@ struct PanelContentView: View {
             tab(.events,   label: "Events",   count: store.events.count)
             tab(.sessions, label: "Sessions", count: sessions.sessions.filter { $0.status == .active }.count)
             tab(.usage,    label: "Usage",    count: 0)
+            tab(.outcomes, label: "Tickets",  count: ticketGroupCount)
             tab(.settings, label: "Settings", count: 0, dot: nav.updateAvailable != nil)
 
             Spacer()
@@ -164,7 +175,7 @@ struct PanelContentView: View {
             // uncluttered while still surfacing the shortcut range.
             HStack(spacing: 2) {
                 KeyCapView(symbol: "⌘")
-                KeyCapView(symbol: "1-4")
+                KeyCapView(symbol: "1-5")
             }
             .opacity(0.7)
         }
@@ -1218,8 +1229,9 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     // SwiftUI's ScrollView has no programmatic delta-scroll API, so walk the
     // AppKit hierarchy to the underlying NSScrollView and nudge its clip view.
     // Only one ScrollView is rendered at a time (mode-gated), so the first
-    // match is the Usage detail pane (used when focus is stepped into it).
-    private func scrollUsageBy(_ dy: CGFloat) {
+    // match is whichever detail pane is showing — the Usage tiers or the
+    // Tickets rollup.
+    private func scrollDetailBy(_ dy: CGFloat) {
         guard let scrollView = findScrollView(in: panel.contentView),
               let doc = scrollView.documentView else { return }
         let clip = scrollView.contentView
@@ -1485,7 +1497,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
             let commitSubject = Self.gitValue(cwd, ["log", "-1", "--format=%s"])
             let ticket = TicketAttribution.ticket(branch: branch, commitSubject: commitSubject)
             let stats = transcriptPath.flatMap { TranscriptReader.read(path: $0) }
-            DispatchQueue.main.async {
+            DispatchQueue.main.async { [weak self] in
                 HandoffLedger.shared.upsert(id: sessionID, agent: agent) { record in
                     record.repoRoot = repoRoot
                     record.branch = branch
@@ -1495,6 +1507,9 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                         record.contextTokens = stats.tokens
                     }
                 }
+                // Nudge the Tickets tab + its tab-strip count to re-read the
+                // ledger so a session shows up live while the panel is open.
+                self?.nav.handoffsRevision += 1
             }
         }
     }
@@ -2000,9 +2015,11 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
             case KeyCode.three:
                 nav.mode = .usage; return true
             case KeyCode.four:
+                nav.mode = .outcomes; return true
+            case KeyCode.five:
                 nav.mode = .settings; return true
             case KeyCode.leftArrow, KeyCode.rightArrow:
-                let tabs: [PanelMode] = [.events, .sessions, .usage, .settings]
+                let tabs: [PanelMode] = [.events, .sessions, .usage, .outcomes, .settings]
                 if let idx = tabs.firstIndex(of: nav.mode) {
                     let next = event.keyCode == KeyCode.leftArrow ? idx - 1 : idx + 1
                     if tabs.indices.contains(next) {
@@ -2227,9 +2244,9 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                 case KeyCode.leftArrow:
                     nav.usageDetailFocused = false
                 case KeyCode.upArrow:
-                    scrollUsageBy(-40)
+                    scrollDetailBy(-40)
                 case KeyCode.downArrow:
-                    scrollUsageBy(40)
+                    scrollDetailBy(40)
                 case KeyCode.rKey:
                     syncQuotaNow()
                 case KeyCode.pKey:
@@ -2259,6 +2276,27 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                 // after the keystroke — otherwise they'd wait for the next
                 // scheduled tick (up to the configured poll interval).
                 if nav.quotaTrackingEnabled { syncQuotaNow() }
+            case KeyCode.mKey:
+                enterCompactMode()
+            default:
+                break
+            }
+            return true
+        }
+
+        // Tickets tab: a single scrollable rollup, no sub-selection. ↑/↓ scroll
+        // it, M enters the widget, Esc hides. Other keys are swallowed so they
+        // don't leak through to the events store.
+        if nav.mode == .outcomes {
+            let plain = mods.intersection([.command, .control, .option, .shift]).isEmpty
+            guard plain else { return false }
+            switch event.keyCode {
+            case KeyCode.escape:
+                hidePanel()
+            case KeyCode.upArrow:
+                scrollDetailBy(-40)
+            case KeyCode.downArrow:
+                scrollDetailBy(40)
             case KeyCode.mKey:
                 enterCompactMode()
             default:

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -5,6 +5,7 @@ enum PanelMode {
     case events
     case sessions
     case usage
+    case outcomes
     case settings
     case phrases
     // Confirmation step after the user clicks the "Update available" row.
@@ -165,6 +166,11 @@ final class PanelNav: ObservableObject {
     // Antigravity (agy) usage from the running CLI's loopback RPC, populated by
     // AntigravityUsageProbe — the agy analogue of `quota`/`codexQuota`.
     @Published var antigravityQuota: AntigravityQuotaSnapshot?
+    // Bumped by PanelController after a handoff is upserted into the ledger so
+    // the Tickets tab (OutcomesView) and its tab-strip count re-read the
+    // in-memory HandoffLedger and reflect the new session live. The ledger
+    // isn't itself observable; this is the single change-signal that drives it.
+    @Published var handoffsRevision: Int = 0
     // Usage tab: which connected client's quota is shown (index into
     // availableUsageClients). ↑/↓ move it; read through clampedUsageClientIndex
     // so a client losing its data can't strand the selection out of range.

--- a/panel/TicketAttribution.swift
+++ b/panel/TicketAttribution.swift
@@ -13,9 +13,13 @@ enum TicketAttribution {
 
     /// Resolve a ticket key, first match wins by reliability:
     ///   1. `branch` anchored at the start — the convention puts the key first,
-    ///      so an anchored hit is trusted as-is (no prefix filtering).
+    ///      so an anchored hit is trusted as-is (no prefix filtering). Matched
+    ///      case-insensitively and normalised to uppercase, because branches
+    ///      are commonly lowercased (`eng-75/…`) while the canonical Linear/Jira
+    ///      key is uppercase (`ENG-75`).
     ///   2. otherwise, the first key found *anywhere* in branch / commit subject
-    ///      / PR head-ref-or-title.
+    ///      / PR head-ref-or-title — uppercase-only, since a case-insensitive
+    ///      free search would catch shapes like `utf-8` / `sha-1`.
     /// `allowedPrefixes` (e.g. `["ENG"]`) guards the fuzzier any-match fallback
     /// against shapes like `UTF-8`; `nil` accepts any prefix.
     /// Returns the bare key (e.g. `"ENG-12142"`) or `nil` when nothing matches.
@@ -23,20 +27,23 @@ enum TicketAttribution {
                        commitSubject: String? = nil,
                        pr: String? = nil,
                        allowedPrefixes: Set<String>? = nil) -> String? {
-        if let branch, let anchored = firstMatch(branch, anchored: true) {
-            return anchored
+        if let branch, let anchored = firstMatch(branch, anchored: true, caseInsensitive: true) {
+            return anchored.uppercased()
         }
         for source in [branch, commitSubject, pr].compactMap({ $0 }) {
-            if let hit = firstMatch(source, anchored: false), passes(hit, allowedPrefixes) {
+            if let hit = firstMatch(source, anchored: false, caseInsensitive: false),
+               passes(hit, allowedPrefixes) {
                 return hit
             }
         }
         return nil
     }
 
-    private static func firstMatch(_ string: String, anchored: Bool) -> String? {
+    private static func firstMatch(_ string: String, anchored: Bool, caseInsensitive: Bool) -> String? {
         let pattern = anchored ? "^(?:\(key))" : "\\b(?:\(key))\\b"
-        guard let range = string.range(of: pattern, options: .regularExpression) else { return nil }
+        var options: String.CompareOptions = .regularExpression
+        if caseInsensitive { options.insert(.caseInsensitive) }
+        guard let range = string.range(of: pattern, options: options) else { return nil }
         return String(string[range])
     }
 


### PR DESCRIPTION
## Summary

Adds the **Tickets** tab (⌘4) — the first slice of the usage-to-outcome
dashboard. It reads the handoff ledger from #84 and rolls usage up per
Linear/Jira ticket, falling back to the branch when no ticket is
identifiable.

## Changes

- **Tickets tab** (`OutcomesView`, ⌘4) — one row per `ticket ?? branch`
  group: session count, summed tokens, agents, and the repository.
  Tickets sort first (with a deep-link affordance); branch-only
  work-streams follow by recency. Settings moves ⌘4 → ⌘5.
- **Per-branch breakdown** — ticket groups expand into indented sub-rows,
  one per branch (heaviest token use first), so you can see where a
  ticket's work actually went.
- **Opt-in deep link** — set `STACKNUDGE_TICKET_URL`
  (e.g. `https://linear.app/acme/issue/{key}`) and ticket rows open the
  issue. Unset → no link; branch rows never link.
- **Live refresh** — a new `PanelNav.handoffsRevision`, bumped on each
  capture, re-reads the in-memory ledger so a session that lands while
  the tab is open shows up immediately (and updates the tab count).
- **Parser fix** — lowercase branch keys now normalise to the canonical
  uppercase key: `eng-75/…` → `ENG-75`. The branch-anchored match is
  case-insensitive; the fuzzy commit/PR fallback stays uppercase-only so
  it can't catch shapes like `utf-8`. The rollup also re-derives the
  ticket from the branch at display time, so sessions captured before
  this fix regroup without waiting for another Stop.
- Reused the Usage tab's keyboard-scroll helper for the new list
  (`scrollUsageBy` → `scrollDetailBy`).

## Testing

- `./build.sh` → Build complete.
- Aggregation logic (grouping by `ticket ?? branch`, repo extraction,
  branch-breakdown ordering) validated via a standalone `swiftc`
  harness — 8/8. Parser cases (lowercase normalisation, `utf-8`
  rejection, precedence) — 11/11. `swift test` needs Xcode locally; the
  committed XCTest suites run in CI.
- To eyeball: relaunch `build/StackNudge.app`, open ⌘4 — tracked
  sessions appear grouped by ticket/branch with their repo and branches.

## Related issues

Builds on #84 (merged) — the handoff ledger this tab reads.
