### PR TITLE
feat(git-snapshot): check diff and branch status for session branches

### DIFF
--- a/Tests/StackNudgePanelCoreTests/GitSnapshotTests.swift
+++ b/Tests/StackNudgePanelCoreTests/GitSnapshotTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// GitSnapshot captures the uncommitted working-tree size at Stop. These pin the
+// numstat parsing (including binary "-" deltas) and the capture wiring, using an
+// injected git runner so no real repo is needed.
+final class GitSnapshotTests: XCTestCase {
+
+    func test_parseNumstat_sumsFilesAndLines() {
+        let actual = GitSnapshot.parseNumstat("10\t2\tpanel/A.swift\n5\t0\tpanel/B.swift\n")
+        XCTAssertEqual(actual.files, 2)
+        XCTAssertEqual(actual.insertions, 15)
+        XCTAssertEqual(actual.deletions, 2)
+    }
+
+    func test_parseNumstat_binaryFilesCountWithZeroDelta() {
+        let actual = GitSnapshot.parseNumstat("-\t-\tassets/logo.png\n3\t1\tREADME.md\n")
+        XCTAssertEqual(actual.files, 2)
+        XCTAssertEqual(actual.insertions, 3)
+        XCTAssertEqual(actual.deletions, 1)
+    }
+
+    func test_parseNumstat_emptyIsZero() {
+        let actual = GitSnapshot.parseNumstat("")
+        XCTAssertEqual(actual.files, 0)
+        XCTAssertEqual(actual.insertions, 0)
+        XCTAssertEqual(actual.deletions, 0)
+    }
+
+    func test_capture_combinesTrackedAndUntracked() {
+        let git: (String, [String]) -> String? = { _, args in
+            switch args.first {
+            case "rev-parse": return "abc1234"
+            case "diff":      return "10\t2\tA.swift\n5\t3\tB.swift\n"
+            case "ls-files":  return "new1.txt\nnew2.txt\n"
+            default:          return nil
+            }
+        }
+        let actual = GitSnapshot.capture(cwd: "/repo", git: git)
+        XCTAssertEqual(actual?.headCommit, "abc1234")
+        XCTAssertEqual(actual?.filesChanged, 4)   // 2 tracked + 2 untracked
+        XCTAssertEqual(actual?.insertions, 15)
+        XCTAssertEqual(actual?.deletions, 5)
+        XCTAssertEqual(actual?.isDirty, true)
+    }
+
+    func test_capture_nilWhenNoHead() {
+        XCTAssertNil(GitSnapshot.capture(cwd: "/notrepo") { _, _ in nil })
+    }
+
+    func test_capture_cleanTreeIsNotDirty() {
+        let actual = GitSnapshot.capture(cwd: "/repo") { _, args in
+            args.first == "rev-parse" ? "abc1234" : ""
+        }
+        XCTAssertEqual(actual?.filesChanged, 0)
+        XCTAssertEqual(actual?.isDirty, false)
+    }
+}

--- a/Tests/StackNudgePanelCoreTests/OutcomeWatcherTests.swift
+++ b/Tests/StackNudgePanelCoreTests/OutcomeWatcherTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// OutcomeWatcher derives "did it ship?" from current git state via an injected
+// runner. These drive each branch through the precedence ladder
+// (merged > pushed > committed > needsReview > clean) with a stub git that
+// answers rev-parse / merge-base for a small fake commit graph.
+final class OutcomeWatcherTests: XCTestCase {
+
+    // A tiny linear graph: base ← b1 ← b2. `refs` maps a ref to its tip sha;
+    // `ancestors[x]` is the set of shas reachable from x (x included), so
+    // merge-base(a, b) = a when a ∈ ancestors[b].
+    private func stubGit(refs: [String: String],
+                         ancestors: [String: Set<String>]) -> ([String]) -> String? {
+        { args in
+            switch args.first {
+            case "rev-parse":
+                // ["rev-parse", "--verify", "--quiet", <ref>]
+                guard let ref = args.last else { return nil }
+                return refs[ref]
+            case "merge-base":
+                // ["merge-base", <a>, <b>] → the one that's an ancestor of the other
+                let a = args[1], b = args[2]
+                if ancestors[b]?.contains(a) == true { return a }
+                if ancestors[a]?.contains(b) == true { return b }
+                return nil
+            default:
+                return nil
+            }
+        }
+    }
+
+    func test_merged_branchTipReachableFromBase() {
+        // base is at b2, branch tip b1 → b1 is an ancestor of base → merged.
+        let git = stubGit(
+            refs: ["origin/main": "b2", "ENG-1/x": "b1"],
+            ancestors: ["b2": ["base", "b1", "b2"], "b1": ["base", "b1"]])
+        XCTAssertEqual(OutcomeWatcher.derive(branch: "ENG-1/x", headCommit: "b1",
+                                             filesChangedAtStop: 0, git: git), .merged)
+    }
+
+    func test_pushed_remoteHasAllLocalCommits() {
+        // Not in base; remote branch tip == local tip → pushed.
+        let git = stubGit(
+            refs: ["origin/main": "base", "ENG-1/x": "b2", "origin/ENG-1/x": "b2"],
+            ancestors: ["base": ["base"], "b2": ["base", "b1", "b2"]])
+        XCTAssertEqual(OutcomeWatcher.derive(branch: "ENG-1/x", headCommit: "b2",
+                                             filesChangedAtStop: 0, git: git), .pushed)
+    }
+
+    func test_committed_localAheadOfRemote() {
+        // Remote at b1, local at b2 (ahead) → committed (unpushed commits).
+        let git = stubGit(
+            refs: ["origin/main": "base", "ENG-1/x": "b2", "origin/ENG-1/x": "b1"],
+            ancestors: ["base": ["base"], "b1": ["base", "b1"], "b2": ["base", "b1", "b2"]])
+        XCTAssertEqual(OutcomeWatcher.derive(branch: "ENG-1/x", headCommit: "b2",
+                                             filesChangedAtStop: 0, git: git), .committed)
+    }
+
+    func test_committed_noRemoteButCommitsBeyondBase() {
+        // No remote branch; branch has commits on top of base → committed.
+        let git = stubGit(
+            refs: ["origin/main": "base", "ENG-1/x": "b1"],
+            ancestors: ["base": ["base"], "b1": ["base", "b1"]])
+        XCTAssertEqual(OutcomeWatcher.derive(branch: "ENG-1/x", headCommit: "b1",
+                                             filesChangedAtStop: 0, git: git), .committed)
+    }
+
+    func test_needsReview_uncommittedWorkNoCommitsSinceStop() {
+        // Branch tip == base (no new commits), no remote, dirty work at Stop.
+        let git = stubGit(
+            refs: ["origin/main": "base", "ENG-1/x": "base"],
+            ancestors: ["base": ["base"]])
+        XCTAssertEqual(OutcomeWatcher.derive(branch: "ENG-1/x", headCommit: "base",
+                                             filesChangedAtStop: 7, git: git), .needsReview)
+    }
+
+    func test_clean_noPendingWorkOnBase() {
+        let git = stubGit(
+            refs: ["origin/main": "base", "ENG-1/x": "base"],
+            ancestors: ["base": ["base"]])
+        XCTAssertEqual(OutcomeWatcher.derive(branch: "ENG-1/x", headCommit: "base",
+                                             filesChangedAtStop: 0, git: git), .clean)
+    }
+
+    func test_deletedBranch_mergedIfHeadInBase() {
+        // Branch ref gone; recorded head is an ancestor of base → merged.
+        let git = stubGit(
+            refs: ["origin/main": "b2"],
+            ancestors: ["b2": ["base", "b1", "b2"]])
+        XCTAssertEqual(OutcomeWatcher.derive(branch: "ENG-1/x", headCommit: "b1",
+                                             filesChangedAtStop: 0, git: git), .merged)
+    }
+
+    func test_nilBranch_isClean() {
+        XCTAssertEqual(OutcomeWatcher.derive(branch: nil, headCommit: nil,
+                                             filesChangedAtStop: 5) { _ in nil }, .clean)
+    }
+}

--- a/Tests/StackNudgePanelCoreTests/OutcomesViewTests.swift
+++ b/Tests/StackNudgePanelCoreTests/OutcomesViewTests.swift
@@ -14,11 +14,15 @@ final class OutcomesViewTests: XCTestCase {
                         branch: String? = nil,
                         ticket: String? = nil,
                         tokens: Int? = nil,
+                        files: Int? = nil,
+                        insertions: Int? = nil,
+                        deletions: Int? = nil,
                         updated: TimeInterval = 0) -> HandoffRecord {
         let date = Date(timeIntervalSince1970: updated)
         return HandoffRecord(
             id: id, agent: agent, repoRoot: repoRoot, branch: branch, ticket: ticket,
-            model: nil, contextTokens: tokens, createdAt: date, updatedAt: date)
+            model: nil, contextTokens: tokens, headCommit: nil, filesChanged: files,
+            insertions: insertions, deletions: deletions, createdAt: date, updatedAt: date)
     }
 
     func test_groupsByTicket_sumsTokensAndCountsSessions() {
@@ -104,8 +108,35 @@ final class OutcomesViewTests: XCTestCase {
         XCTAssertEqual(branches.last?.sessionCount, 2)
     }
 
-    func test_branchGroup_hasNoBranchSubRows() {
+    func test_branchOnlyGroup_exposesItsOwnBranchSlice() {
+        // Branch-only groups carry their single slice (for the outcome rollup);
+        // the view just doesn't render it as a redundant sub-row.
         let groups = OutcomesView.groups(from: [record(id: "a", branch: "feat/x")])
-        XCTAssertEqual(groups.first?.branches, [])
+        XCTAssertEqual(groups.first?.isTicket, false)
+        XCTAssertEqual(groups.first?.branches.map(\.branch), ["feat/x"])
+    }
+
+    func test_branchDiff_usesLatestSnapshotNotSum() {
+        // Two sessions on one branch: the diff is the latest snapshot (current
+        // pending state), not the sum — uncommitted state is point-in-time.
+        let groups = OutcomesView.groups(from: [
+            record(id: "a", branch: "ENG-1/x", ticket: "ENG-1", files: 5, insertions: 50, deletions: 5, updated: 1),
+            record(id: "b", branch: "ENG-1/x", ticket: "ENG-1", files: 8, insertions: 80, deletions: 9, updated: 2),
+        ])
+        XCTAssertEqual(groups.first?.branches.first?.diff,
+                       DiffStat(filesChanged: 8, insertions: 80, deletions: 9))
+    }
+
+    func test_groupDiff_sumsLatestAcrossBranches() {
+        let groups = OutcomesView.groups(from: [
+            record(id: "a", branch: "ENG-1/be", ticket: "ENG-1", files: 3, insertions: 30, deletions: 1, updated: 1),
+            record(id: "b", branch: "ENG-1/fe", ticket: "ENG-1", files: 7, insertions: 70, deletions: 2, updated: 2),
+        ])
+        XCTAssertEqual(groups.first?.diff, DiffStat(filesChanged: 10, insertions: 100, deletions: 3))
+    }
+
+    func test_diff_emptyWhenNoSnapshotCaptured() {
+        let groups = OutcomesView.groups(from: [record(id: "a", ticket: "ENG-1")])
+        XCTAssertEqual(groups.first?.diff.isEmpty, true)
     }
 }

--- a/build.sh
+++ b/build.sh
@@ -246,6 +246,8 @@ build_app "$APP" "stack-nudge" \
   panel/AntigravityLocalServer.swift \
   panel/AntigravityUsage.swift \
   panel/TicketAttribution.swift \
+  panel/GitSnapshot.swift \
+  panel/OutcomeWatcher.swift \
   panel/Handoff.swift \
   panel/HandoffLedger.swift \
   panel/OutcomesView.swift \

--- a/panel/GitSnapshot.swift
+++ b/panel/GitSnapshot.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+// The uncommitted working-tree state of a repo at the moment an agent stopped:
+// what's changed vs HEAD but not yet committed. This is the MVP baseline for
+// outcome tracking — it answers "what did this session leave behind to review?".
+// Work the agent already committed shows as clean here (filesChanged == 0); the
+// later OutcomeWatcher is what detects committed/pushed/merged from headCommit.
+struct GitSnapshot: Equatable {
+    let headCommit: String?
+    let filesChanged: Int   // tracked changes vs HEAD + untracked files
+    let insertions: Int
+    let deletions: Int
+
+    var isDirty: Bool { filesChanged > 0 }
+
+    // Build a snapshot for `cwd`, running git through the injected closure
+    // (`git(cwd, args) -> stdout?`, nil on failure / non-repo). Injecting the
+    // runner keeps this testable without shelling out. Returns nil when the
+    // directory has no HEAD (not a repo, or a repo with no commits yet).
+    static func capture(cwd: String, git: (String, [String]) -> String?) -> GitSnapshot? {
+        guard let head = git(cwd, ["rev-parse", "HEAD"]) else { return nil }
+        let numstat = git(cwd, ["diff", "--numstat", "HEAD"]) ?? ""
+        let tracked = parseNumstat(numstat)
+        let untracked = git(cwd, ["ls-files", "--others", "--exclude-standard"]) ?? ""
+        let untrackedCount = untracked.split(separator: "\n").filter { !$0.isEmpty }.count
+        return GitSnapshot(
+            headCommit: head,
+            filesChanged: tracked.files + untrackedCount,
+            insertions: tracked.insertions,
+            deletions: tracked.deletions)
+    }
+
+    // Parse `git diff --numstat` output: one tab-separated `<ins>\t<del>\t<path>`
+    // line per changed file. Binary files report "-" for both counts, which we
+    // count as a changed file with zero line deltas.
+    static func parseNumstat(_ output: String) -> (files: Int, insertions: Int, deletions: Int) {
+        var files = 0, insertions = 0, deletions = 0
+        for line in output.split(separator: "\n") {
+            let columns = line.split(separator: "\t")
+            guard columns.count >= 3 else { continue }
+            files += 1
+            insertions += Int(columns[0]) ?? 0
+            deletions += Int(columns[1]) ?? 0
+        }
+        return (files, insertions, deletions)
+    }
+}

--- a/panel/Handoff.swift
+++ b/panel/Handoff.swift
@@ -13,6 +13,12 @@ struct HandoffRecord: Codable, Identifiable, Equatable {
     var ticket: String?         // Linear/Jira key (e.g. "ENG-12142"); nil if none
     var model: String?
     var contextTokens: Int?     // latest context-window tokens for the session
+    // Uncommitted working-tree diff at the latest Stop (vs HEAD, + untracked).
+    // Optional so records written before this field decode cleanly.
+    var headCommit: String?
+    var filesChanged: Int?
+    var insertions: Int?
+    var deletions: Int?
     let createdAt: Date
     var updatedAt: Date
 }

--- a/panel/HandoffLedger.swift
+++ b/panel/HandoffLedger.swift
@@ -33,6 +33,7 @@ final class HandoffLedger {
         var record = byID[id] ?? HandoffRecord(
             id: id, agent: agent,
             repoRoot: nil, branch: nil, ticket: nil, model: nil, contextTokens: nil,
+            headCommit: nil, filesChanged: nil, insertions: nil, deletions: nil,
             createdAt: now, updatedAt: now)
         merge(&record)
         record.updatedAt = now

--- a/panel/OutcomeWatcher.swift
+++ b/panel/OutcomeWatcher.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+// "Did it ship?" for a session's branch. Ordered most-shipped first so a single
+// value summarises the branch; the UI maps these to labels/colours.
+enum OutcomeStatus: String, Equatable {
+    case merged       // branch is fully contained in the base (origin/main, main, …)
+    case pushed       // remote branch has all local commits (pushed, not yet merged)
+    case committed    // local commits beyond base, not pushed
+    case needsReview  // uncommitted work left at Stop, no commits since
+    case clean        // nothing pending (on base / no net change / can't determine)
+}
+
+// Derives the outcome from *current* git state, read through an injected runner
+// (`git(args) -> stdout?`, bound to the repo by the caller; nil on failure).
+// Ref-based only — never checks out — so it's safe for any historical branch and
+// fully unit-testable with a stub. Precedence: merged > pushed > committed >
+// needsReview > clean.
+enum OutcomeWatcher {
+
+    // Local default branch first — it's the one the user keeps pulled, and in a
+    // fork workflow `origin/main` (the fork) can lag the real mainline. Falls
+    // back to the fork's, then the upstream's, default branch.
+    private static let baseCandidates = [
+        "main", "master",
+        "origin/main", "origin/master",
+        "upstream/main", "upstream/master",
+    ]
+
+    static func derive(branch: String?,
+                       headCommit: String?,
+                       filesChangedAtStop: Int,
+                       git: ([String]) -> String?) -> OutcomeStatus {
+        guard let branch, !branch.isEmpty else { return .clean }
+
+        // Branch ref is gone (deleted): shipped if the recorded head merged into
+        // the base, otherwise we can't tell — treat as clean.
+        guard let branchTip = revParse(branch, git) else {
+            if let head = headCommit, let base = resolveBaseSha(git), isAncestor(head, base, git) {
+                return .merged
+            }
+            return .clean
+        }
+
+        // A session run directly on the base branch isn't a feature branch, so
+        // the merged/committed ladder doesn't apply.
+        if branch == "main" || branch == "master" {
+            return pendingOrClean(branchTip: branchTip, headCommit: headCommit, filesChangedAtStop: filesChangedAtStop)
+        }
+
+        // Merged: the branch's tip is contained in the base *and* differs from
+        // it. The `!= base` guard stops a branch sitting exactly at base (no
+        // commits of its own) from reading as merged — it's clean/pending.
+        if let base = resolveBaseSha(git), branchTip != base, isAncestor(branchTip, base, git) {
+            return .merged
+        }
+        if let remoteTip = revParse("origin/\(branch)", git) {
+            return isAncestor(branchTip, remoteTip, git) ? .pushed : .committed
+        }
+        if let base = resolveBaseSha(git), base != branchTip, isAncestor(base, branchTip, git) {
+            return .committed   // commits beyond base, no remote branch
+        }
+        return pendingOrClean(branchTip: branchTip, headCommit: headCommit, filesChangedAtStop: filesChangedAtStop)
+    }
+
+    private static func pendingOrClean(branchTip: String, headCommit: String?, filesChangedAtStop: Int) -> OutcomeStatus {
+        (filesChangedAtStop > 0 && branchTip == headCommit) ? .needsReview : .clean
+    }
+
+    // Resolve the base branch's sha (local default first; see baseCandidates).
+    // Shared with handoff capture, which uses it to read only branch-local
+    // commits when deriving the ticket.
+    static func resolveBaseSha(_ git: ([String]) -> String?) -> String? {
+        for candidate in baseCandidates {
+            if let sha = revParse(candidate, git) { return sha }
+        }
+        return nil
+    }
+
+    private static func revParse(_ ref: String, _ git: ([String]) -> String?) -> String? {
+        let output = git(["rev-parse", "--verify", "--quiet", ref])?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let output, !output.isEmpty else { return nil }
+        return output
+    }
+
+    // `a` is an ancestor of `b` ⟺ merge-base(a, b) == a. Both must be resolved
+    // shas (callers pass rev-parse output) so the equality check is meaningful.
+    private static func isAncestor(_ a: String, _ b: String, _ git: ([String]) -> String?) -> Bool {
+        let mergeBase = git(["merge-base", a, b])?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return mergeBase == a
+    }
+}

--- a/panel/OutcomesView.swift
+++ b/panel/OutcomesView.swift
@@ -2,13 +2,28 @@ import AppKit
 import Foundation
 import SwiftUI
 
+// Uncommitted working-tree size, aggregated for display. Files are summed
+// across branches (each branch contributing its latest snapshot); line deltas
+// likewise. `isEmpty` lets the UI omit the segment when there's nothing pending.
+struct DiffStat: Equatable {
+    let filesChanged: Int
+    let insertions: Int
+    let deletions: Int
+
+    var isEmpty: Bool { filesChanged == 0 && insertions == 0 && deletions == 0 }
+}
+
 // A single branch's slice of a ticket — shown as an indented sub-row so a
 // ticket that spans several branches reveals where its sessions/tokens went.
+// `diff` is the branch's latest snapshot (pending work), not a sum across its
+// sessions — uncommitted state is point-in-time, so summing would double-count.
 struct BranchBreakdown: Identifiable, Equatable {
     var id: String { branch }
     let branch: String
+    let repoRoot: String?   // for the per-branch outcome lookup (repo+branch keyed)
     let sessionCount: Int
     let totalTokens: Int
+    let diff: DiffStat
 }
 
 // One aggregated row in the Tickets tab: every session that shares a grouping
@@ -22,7 +37,10 @@ struct TicketGroup: Identifiable, Equatable {
     let sessionCount: Int
     let totalTokens: Int
     let agents: [String]    // distinct canonical agents, first-seen order
-    let branches: [BranchBreakdown]  // sub-rows; populated for ticket groups
+    let diff: DiffStat      // pending work, summed across the group's branches
+    // All branch slices in the group (used for the outcome rollup); rendered as
+    // sub-rows only for ticket groups — a branch-only group's slice is itself.
+    let branches: [BranchBreakdown]
 }
 
 // Tickets tab — the first slice of the usage-to-outcome dashboard. Reads the
@@ -64,7 +82,10 @@ struct OutcomesView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .onAppear { ticketURLTemplate = ConfigFile.read()["STACKNUDGE_TICKET_URL"] }
+        .onAppear {
+            ticketURLTemplate = ConfigFile.read()["STACKNUDGE_TICKET_URL"]
+            nav.refreshOutcomes?()
+        }
     }
 
     // MARK: - Rows
@@ -95,7 +116,13 @@ struct OutcomesView: View {
             Text(detailLine(group))
                 .font(.caption.monospacedDigit())
                 .foregroundStyle(.secondary)
-            if !group.branches.isEmpty {
+            let rollup = outcomeRollup(group)
+            if !rollup.isEmpty {
+                HStack(spacing: 10) {
+                    ForEach(rollup, id: \.status) { statusChip($0.status, count: $0.count) }
+                }
+            }
+            if group.isTicket, !group.branches.isEmpty {
                 VStack(alignment: .leading, spacing: 2) {
                     ForEach(group.branches) { branchRow($0) }
                 }
@@ -126,24 +153,88 @@ struct OutcomesView: View {
                 .font(.caption2.monospacedDigit())
                 .foregroundStyle(.tertiary)
                 .fixedSize()
+            if let status = outcome(for: branch), status != .clean {
+                statusChip(status)
+            }
         }
         .padding(.leading, 12)
     }
 
-    // "3 sessions · 218K tokens · Claude, Codex" — the tokens segment is
-    // dropped when no session in the group carried a token count.
+    // "3 sessions · 218K tokens · 23 files · +1.8k/−400 · Claude, Codex" —
+    // each segment is dropped when it has nothing to show.
     private func detailLine(_ group: TicketGroup) -> String {
         var parts = [Self.sessionsLabel(group.sessionCount)]
         if group.totalTokens > 0 { parts.append("\(Self.shortTokens(group.totalTokens)) tokens") }
+        if !group.diff.isEmpty {
+            parts.append(Self.filesLabel(group.diff.filesChanged))
+            if group.diff.insertions > 0 || group.diff.deletions > 0 {
+                parts.append(Self.lineDelta(group.diff))
+            }
+        }
         if !group.agents.isEmpty { parts.append(group.agents.joined(separator: ", ")) }
         return parts.joined(separator: " · ")
     }
 
-    // Compact sub-row trailing: "2 sessions · 600K".
+    // Compact sub-row trailing: "2 sessions · 600K · 12 files".
     private func branchDetail(_ branch: BranchBreakdown) -> String {
         var parts = [Self.sessionsLabel(branch.sessionCount)]
         if branch.totalTokens > 0 { parts.append(Self.shortTokens(branch.totalTokens)) }
+        if branch.diff.filesChanged > 0 { parts.append(Self.filesLabel(branch.diff.filesChanged)) }
         return parts.joined(separator: " · ")
+    }
+
+    // MARK: - Outcome ("did it ship?")
+
+    private func outcome(for branch: BranchBreakdown) -> OutcomeStatus? {
+        nav.outcomeByBranch[PanelNav.outcomeKey(branch.repoRoot, branch.branch)]
+    }
+
+    // Counts of each non-clean outcome across the group's branches, ordered
+    // most-shipped first. Empty when nothing has a status yet (e.g. still
+    // computing) or everything is clean.
+    private func outcomeRollup(_ group: TicketGroup) -> [(status: OutcomeStatus, count: Int)] {
+        var counts: [OutcomeStatus: Int] = [:]
+        for branch in group.branches {
+            guard let status = outcome(for: branch), status != .clean else { continue }
+            counts[status, default: 0] += 1
+        }
+        return Self.outcomeOrder.compactMap { status in
+            counts[status].map { (status, $0) }
+        }
+    }
+
+    private func statusChip(_ status: OutcomeStatus, count: Int? = nil) -> some View {
+        HStack(spacing: 3) {
+            Circle()
+                .fill(Self.outcomeColor(status))
+                .frame(width: 6, height: 6)
+            Text(count.map { "\($0) \(Self.outcomeLabel(status))" } ?? Self.outcomeLabel(status))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .fixedSize()
+    }
+
+    private static let outcomeOrder: [OutcomeStatus] = [.merged, .pushed, .committed, .needsReview]
+
+    private static func outcomeLabel(_ status: OutcomeStatus) -> String {
+        switch status {
+        case .merged:      return "merged"
+        case .pushed:      return "pushed"
+        case .committed:   return "committed"
+        case .needsReview: return "needs review"
+        case .clean:       return "clean"
+        }
+    }
+
+    private static func outcomeColor(_ status: OutcomeStatus) -> Color {
+        switch status {
+        case .merged:      return .purple
+        case .pushed:      return .blue
+        case .committed:   return .teal
+        case .needsReview: return .orange
+        case .clean:       return .secondary
+        }
     }
 
     // MARK: - Deep link
@@ -189,10 +280,14 @@ struct OutcomesView: View {
             let agents = orderedDistinct(rows.map { displayAgent($0.agent) })
             let repos = orderedDistinct(rows.compactMap { repoName($0.repoRoot) })
             let last = rows.map(\.updatedAt).max() ?? .distantPast
-            let branches = isTicket ? branchBreakdown(rows) : []
+            let slices = branchBreakdown(rows)
+            let diff = DiffStat(
+                filesChanged: slices.reduce(0) { $0 + $1.diff.filesChanged },
+                insertions: slices.reduce(0) { $0 + $1.diff.insertions },
+                deletions: slices.reduce(0) { $0 + $1.diff.deletions })
             return (TicketGroup(id: key, isTicket: isTicket, repos: repos,
                                 sessionCount: rows.count, totalTokens: tokens,
-                                agents: agents, branches: branches), last)
+                                agents: agents, diff: diff, branches: slices), last)
         }
         return groups.sorted {
             if $0.group.isTicket != $1.group.isTicket { return $0.group.isTicket }
@@ -212,7 +307,13 @@ struct OutcomesView: View {
         return order.map { branch -> BranchBreakdown in
             let group = byBranch[branch] ?? []
             let tokens = group.compactMap(\.contextTokens).reduce(0, +)
-            return BranchBreakdown(branch: branch, sessionCount: group.count, totalTokens: tokens)
+            let latest = group.max { $0.updatedAt < $1.updatedAt }
+            let diff = DiffStat(
+                filesChanged: latest?.filesChanged ?? 0,
+                insertions: latest?.insertions ?? 0,
+                deletions: latest?.deletions ?? 0)
+            return BranchBreakdown(branch: branch, repoRoot: latest?.repoRoot,
+                                   sessionCount: group.count, totalTokens: tokens, diff: diff)
         }.sorted { $0.totalTokens > $1.totalTokens }
     }
 
@@ -245,6 +346,19 @@ struct OutcomesView: View {
         if count >= 1_000_000 { return String(format: "%.1fM", Double(count) / 1_000_000) }
         if count >= 1_000 { return "\(Int((Double(count) / 1_000).rounded()))K" }
         return "\(count)"
+    }
+
+    private static func filesLabel(_ count: Int) -> String {
+        count == 1 ? "1 file" : "\(count) files"
+    }
+
+    // "+1.8k/−400" — uses the minus sign (U+2212) to match the app's typography.
+    private static func lineDelta(_ diff: DiffStat) -> String {
+        "+\(shortCount(diff.insertions))/−\(shortCount(diff.deletions))"
+    }
+
+    private static func shortCount(_ count: Int) -> String {
+        count >= 1_000 ? String(format: "%.1fk", Double(count) / 1_000) : "\(count)"
     }
 
     // MARK: - Footer + empty state

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -663,6 +663,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         nav.setHotkey = { [weak self] spec in
             self?.registerHotkey(spec: spec) ?? false
         }
+        nav.refreshOutcomes = { [weak self] in self?.refreshOutcomes() }
 
         startConfigWatcher()
         setupNotificationCenter()
@@ -1494,23 +1495,68 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         DispatchQueue.global(qos: .utility).async {
             guard let repoRoot = Self.gitValue(cwd, ["rev-parse", "--show-toplevel"]) else { return }
             let branch = Self.gitValue(cwd, ["rev-parse", "--abbrev-ref", "HEAD"])
-            let commitSubject = Self.gitValue(cwd, ["log", "-1", "--format=%s"])
+            // Only consider the subject of a commit *unique to this branch*
+            // (base..HEAD). The absolute last commit may already be on main —
+            // e.g. an ENG-689 commit — and must not be attributed to the
+            // current, still-uncommitted ENG-688 work. No base / no branch-local
+            // commit ⇒ no commit subject ⇒ fall back to the branch alone.
+            let baseSha = OutcomeWatcher.resolveBaseSha { Self.gitValue(cwd, $0) }
+            let commitSubject = baseSha.flatMap {
+                Self.gitValue(cwd, ["log", "-1", "--format=%s", "\($0)..HEAD"])
+            }
             let ticket = TicketAttribution.ticket(branch: branch, commitSubject: commitSubject)
             let stats = transcriptPath.flatMap { TranscriptReader.read(path: $0) }
+            let snapshot = GitSnapshot.capture(cwd: cwd) { Self.gitValue($0, $1) }
             DispatchQueue.main.async { [weak self] in
                 HandoffLedger.shared.upsert(id: sessionID, agent: agent) { record in
                     record.repoRoot = repoRoot
                     record.branch = branch
-                    if record.ticket == nil { record.ticket = ticket }  // derive once, fill if empty
+                    // Re-derive every Stop (not derive-once): git state evolves
+                    // within a session, so the latest derivation is the most
+                    // accurate and lets a misattributed row self-correct. nil is
+                    // fine — the rollup re-derives from the branch at display.
+                    record.ticket = ticket
                     if let stats {
                         record.model = stats.model
                         record.contextTokens = stats.tokens
+                    }
+                    if let snapshot {
+                        record.headCommit = snapshot.headCommit
+                        record.filesChanged = snapshot.filesChanged
+                        record.insertions = snapshot.insertions
+                        record.deletions = snapshot.deletions
                     }
                 }
                 // Nudge the Tickets tab + its tab-strip count to re-read the
                 // ledger so a session shows up live while the panel is open.
                 self?.nav.handoffsRevision += 1
+                self?.refreshOutcomes()
             }
+        }
+    }
+
+    // Recompute "did it ship?" for every distinct repo+branch in the ledger,
+    // off-main (git is slow), then publish to nav for the Tickets tab. Uses the
+    // newest record per branch (ledger is newest-first) for the headCommit /
+    // uncommitted-at-Stop inputs to the derivation.
+    func refreshOutcomes() {
+        var pairs: [(repo: String, branch: String, head: String?, files: Int)] = []
+        var seen = Set<String>()
+        for record in HandoffLedger.shared.all() {
+            guard let repo = record.repoRoot, let branch = record.branch else { continue }
+            if seen.insert(PanelNav.outcomeKey(repo, branch)).inserted {
+                pairs.append((repo, branch, record.headCommit, record.filesChanged ?? 0))
+            }
+        }
+        guard !pairs.isEmpty else { return }
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            var result: [String: OutcomeStatus] = [:]
+            for pair in pairs {
+                result[PanelNav.outcomeKey(pair.repo, pair.branch)] = OutcomeWatcher.derive(
+                    branch: pair.branch, headCommit: pair.head, filesChangedAtStop: pair.files
+                ) { Self.gitValue(pair.repo, $0) }
+            }
+            DispatchQueue.main.async { self?.nav.outcomeByBranch = result }
         }
     }
 

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -171,6 +171,18 @@ final class PanelNav: ObservableObject {
     // in-memory HandoffLedger and reflect the new session live. The ledger
     // isn't itself observable; this is the single change-signal that drives it.
     @Published var handoffsRevision: Int = 0
+    // Derived "did it ship?" status per repo+branch, computed off-main by
+    // PanelController's outcome pass and read by the Tickets tab. Keyed by
+    // `outcomeKey(repoRoot, branch)`. Empty until the first pass completes.
+    @Published var outcomeByBranch: [String: OutcomeStatus] = [:]
+    // Wired by PanelController; OutcomesView calls it on appear to recompute
+    // outcomes for the branches in the ledger. Kept as a closure so the view
+    // doesn't need to know about git/process work.
+    var refreshOutcomes: (() -> Void)?
+
+    static func outcomeKey(_ repoRoot: String?, _ branch: String?) -> String {
+        "\(repoRoot ?? "")\n\(branch ?? "")"
+    }
     // Usage tab: which connected client's quota is shown (index into
     // availableUsageClients). ↑/↓ move it; read through clampedUsageClientIndex
     // so a client losing its data can't strand the selection out of range.


### PR DESCRIPTION
## Summary

Builds on the handoff ledger (#84, #86) to track *outcomes*, not just usage:
capture each session's working-tree diff at Stop and derive "did it ship?"
for its branch, surfaced in the Tickets tab. Also fixes a ticket-attribution
bug where a session inherited the ticket of an already-merged commit.

## Changes

- **GitSnapshot** — at Stop, capture the uncommitted working-tree diff vs
  HEAD (+ untracked): `headCommit`, files changed, insertions, deletions.
  Stored on `HandoffRecord` (optional fields → old rows still decode). Pure
  numstat parser + an injectable `capture(cwd:git:)`.
- **OutcomeWatcher** — derive a per-branch status from *current* git state,
  ref-based only (never checks out → safe for any historical branch):
  `merged > pushed > committed > needsReview > clean`. Base resolves local
  `main`/`master` first (a fork's `origin/main` can lag), then `origin/*`,
  then `upstream/*`. Computed off-main, published to the tab; recomputes on
  tab open + after each capture.
- **Tickets tab** — each group shows diff size (`23 files · +1.8k/−400`,
  summed across each branch's latest snapshot) and outcome chips (per branch
  sub-row + a group rollup like `2 merged · 1 needs review`).
- **Ticket attribution fix** — derive the ticket from commits *unique to the
  branch* (`base..HEAD`), so an already-merged commit (e.g. `ENG-689` on
  main) is no longer attributed to current uncommitted work; and re-derive
  every Stop so a misattributed row self-corrects.
- Tests: `GitSnapshotTests`, `OutcomeWatcherTests`, diff-aggregation in
  `OutcomesViewTests`.

## Testing

- `./build.sh` → Build complete.
- Logic validated via standalone `swiftc` harnesses (XCTest needs Xcode
  locally; the suites run in CI): GitSnapshot 8/8, OutcomeWatcher 8/8.
- Real-repo checks: `feat/token-count-repo` → merged, `feat/git-snapshot`
  → needs review, `main` → clean. Attribution: `base..HEAD` is empty when
  HEAD is on base (no stale-commit leak) and returns the in-range subject
  otherwise.

## Limitation

Squash-merged branches read as `clean`/`committed`, not `merged` — a squash
discards the branch's commits, so the ancestor check can't see them.
Squash-aware merge state needs the opt-in `gh` PR layer (§1.6), a follow-up.

## Related issues

Builds on #84, #86. Next: opt-in GitHub PR + CI linking.
