### PR TITLE
feat(gh-pr-linking): link prs to gh via device mode login oauth app

### DIFF
--- a/Tests/StackNudgePanelCoreTests/GitHubAPITests.swift
+++ b/Tests/StackNudgePanelCoreTests/GitHubAPITests.swift
@@ -1,0 +1,81 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// GitHubAPI builds the GraphQL PR query and parses the response (PR state +
+// CI rollup), plus owner/repo extraction from a remote URL. Pure; no network.
+final class GitHubAPITests: XCTestCase {
+
+    func test_repoSlug_https() {
+        let actual = GitHubAPI.repoSlug(fromRemoteURL: "https://github.com/StackOneHQ/stack-nudge.git")
+        XCTAssertEqual(actual?.owner, "StackOneHQ")
+        XCTAssertEqual(actual?.repo, "stack-nudge")
+    }
+
+    func test_repoSlug_ssh() {
+        let actual = GitHubAPI.repoSlug(fromRemoteURL: "git@github.com:StackOneHQ/stack-nudge.git")
+        XCTAssertEqual(actual?.owner, "StackOneHQ")
+        XCTAssertEqual(actual?.repo, "stack-nudge")
+    }
+
+    func test_repoSlug_noGitSuffix() {
+        let actual = GitHubAPI.repoSlug(fromRemoteURL: "https://github.com/o/r")
+        XCTAssertEqual(actual?.owner, "o")
+        XCTAssertEqual(actual?.repo, "r")
+    }
+
+    func test_repoSlug_nonGitHub_isNil() {
+        XCTAssertNil(GitHubAPI.repoSlug(fromRemoteURL: "https://gitlab.com/o/r.git"))
+    }
+
+    func test_query_carriesVariables() {
+        let actual = GitHubAPI.query(owner: "o", repo: "r", branch: "ENG-1/x")
+        XCTAssertTrue(actual.contains("headRefName"))
+        XCTAssertTrue(actual.contains("\"branch\":\"ENG-1\\/x\"") || actual.contains("\"branch\":\"ENG-1/x\""))
+        XCTAssertTrue(actual.contains("statusCheckRollup"))
+    }
+
+    private func response(state: String, isDraft: Bool = false, ci: String?) -> String {
+        let rollup = ci.map { "{\"state\":\"\($0)\"}" } ?? "null"
+        return """
+        {"data":{"repository":{"pullRequests":{"nodes":[{
+          "number":86,"url":"https://github.com/o/r/pull/86","state":"\(state)","isDraft":\(isDraft),
+          "commits":{"nodes":[{"commit":{"statusCheckRollup":\(rollup)}}]}}]}}}}
+        """
+    }
+
+    func test_parse_openWithPassingCI() {
+        let actual = GitHubAPI.parse(response(state: "OPEN", ci: "SUCCESS"))
+        XCTAssertEqual(actual, PullRequestInfo(number: 86, url: "https://github.com/o/r/pull/86",
+                                               state: .open, isDraft: false, ci: .passing))
+    }
+
+    func test_parse_mergedNoCI() {
+        let actual = GitHubAPI.parse(response(state: "MERGED", ci: nil))
+        XCTAssertEqual(actual?.state, .merged)
+        XCTAssertNil(actual?.ci)
+    }
+
+    func test_parse_draftPendingCI() {
+        let actual = GitHubAPI.parse(response(state: "OPEN", isDraft: true, ci: "PENDING"))
+        XCTAssertEqual(actual?.isDraft, true)
+        XCTAssertEqual(actual?.ci, .pending)
+    }
+
+    func test_parse_failingCI() {
+        XCTAssertEqual(GitHubAPI.parse(response(state: "OPEN", ci: "FAILURE"))?.ci, .failing)
+    }
+
+    func test_parse_noPRNodes_isNil() {
+        XCTAssertNil(GitHubAPI.parse(#"{"data":{"repository":{"pullRequests":{"nodes":[]}}}}"#))
+    }
+
+    func test_parse_malformed_isNil() {
+        XCTAssertNil(GitHubAPI.parse("not json"))
+        XCTAssertNil(GitHubAPI.parse(#"{"data":{"repository":null}}"#))
+    }
+
+    func test_pullRequest_nilRunYieldsNil() {
+        XCTAssertNil(GitHubAPI.pullRequest(owner: "o", repo: "r", branch: "b") { _ in nil })
+    }
+}

--- a/Tests/StackNudgePanelCoreTests/GitHubAuthTests.swift
+++ b/Tests/StackNudgePanelCoreTests/GitHubAuthTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// GitHubAuth parses the OAuth device-flow responses. These pin the device-code
+// fields (and interval/expiry defaults) and the poll error → result mapping.
+final class GitHubAuthTests: XCTestCase {
+
+    func test_parseDeviceCode_full() {
+        let json = """
+        {"device_code":"dc","user_code":"4F2A-9C7B",
+         "verification_uri":"https://github.com/login/device","interval":5,"expires_in":900}
+        """
+        let actual = GitHubAuth.parseDeviceCode(Data(json.utf8))
+        XCTAssertEqual(actual, DeviceCodeResponse(deviceCode: "dc", userCode: "4F2A-9C7B",
+                                                  verificationURI: "https://github.com/login/device",
+                                                  interval: 5, expiresIn: 900))
+    }
+
+    func test_parseDeviceCode_defaultsWhenIntervalMissing() {
+        let json = #"{"device_code":"dc","user_code":"u","verification_uri":"v"}"#
+        let actual = GitHubAuth.parseDeviceCode(Data(json.utf8))
+        XCTAssertEqual(actual?.interval, 5)
+        XCTAssertEqual(actual?.expiresIn, 900)
+    }
+
+    func test_parseDeviceCode_malformed_isNil() {
+        XCTAssertNil(GitHubAuth.parseDeviceCode(Data("nope".utf8)))
+        XCTAssertNil(GitHubAuth.parseDeviceCode(Data(#"{"user_code":"u"}"#.utf8)))
+    }
+
+    func test_parsePoll_token() {
+        let json = #"{"access_token":"gho_abc","token_type":"bearer","scope":"repo"}"#
+        XCTAssertEqual(GitHubAuth.parsePoll(Data(json.utf8)), .token("gho_abc"))
+    }
+
+    func test_parsePoll_pending() {
+        XCTAssertEqual(GitHubAuth.parsePoll(Data(#"{"error":"authorization_pending"}"#.utf8)), .pending)
+    }
+
+    func test_parsePoll_slowDown_carriesInterval() {
+        XCTAssertEqual(GitHubAuth.parsePoll(Data(#"{"error":"slow_down","interval":10}"#.utf8)), .slowDown(10))
+    }
+
+    func test_parsePoll_expired() {
+        XCTAssertEqual(GitHubAuth.parsePoll(Data(#"{"error":"expired_token"}"#.utf8)), .expired)
+    }
+
+    func test_parsePoll_denied() {
+        XCTAssertEqual(GitHubAuth.parsePoll(Data(#"{"error":"access_denied"}"#.utf8)), .denied)
+    }
+
+    func test_parsePoll_unknownError_isFailed() {
+        XCTAssertEqual(GitHubAuth.parsePoll(Data(#"{"error":"teapot"}"#.utf8)), .failed("teapot"))
+    }
+
+    func test_parsePoll_garbage_isFailed() {
+        XCTAssertEqual(GitHubAuth.parsePoll(Data("???".utf8)), .failed("bad json"))
+    }
+}

--- a/build.sh
+++ b/build.sh
@@ -248,6 +248,8 @@ build_app "$APP" "stack-nudge" \
   panel/TicketAttribution.swift \
   panel/GitSnapshot.swift \
   panel/OutcomeWatcher.swift \
+  panel/GitHubAPI.swift \
+  panel/GitHubAuth.swift \
   panel/Handoff.swift \
   panel/HandoffLedger.swift \
   panel/OutcomesView.swift \

--- a/panel/GitHubAPI.swift
+++ b/panel/GitHubAPI.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+// PR lifecycle as GitHub reports it. `merged` is authoritative for "did it
+// ship?" — it closes the squash-merge gap the local OutcomeWatcher can't see.
+enum PRState: String, Equatable {
+    case open = "OPEN"
+    case closed = "CLOSED"
+    case merged = "MERGED"
+}
+
+// Collapsed CI signal for a PR (from the GraphQL statusCheckRollup).
+enum CIStatus: String, Equatable {
+    case pending
+    case passing
+    case failing
+}
+
+struct PullRequestInfo: Equatable {
+    let number: Int
+    let url: String
+    let state: PRState
+    let isDraft: Bool
+    let ci: CIStatus?   // nil when the PR has no checks
+}
+
+// gh-free GitHub reads: query a branch's newest PR (+ CI rollup) via the GraphQL
+// API using our own token (see GitHubAuth). GraphQL `headRefName` matches by
+// branch name regardless of which fork the head lives on, and statusCheckRollup
+// gives the CI state in the same round-trip — both awkward over REST. The HTTP
+// runner is injected so the query building + response parsing stay unit-testable.
+enum GitHubAPI {
+
+    static let graphQLEndpoint = URL(string: "https://api.github.com/graphql")!
+
+    // owner/repo from a remote URL — https (`https://github.com/o/r.git`) or
+    // ssh (`git@github.com:o/r.git`). nil when it isn't a github.com remote.
+    static func repoSlug(fromRemoteURL url: String) -> (owner: String, repo: String)? {
+        let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let marker = trimmed.range(of: "github.com") else { return nil }
+        var path = String(trimmed[marker.upperBound...])
+        path = String(path.drop(while: { $0 == ":" || $0 == "/" }))   // strip ssh ':' / https '/'
+        if path.hasSuffix(".git") { path = String(path.dropLast(4)) }
+        let parts = path.split(separator: "/")
+        guard parts.count >= 2 else { return nil }
+        return (String(parts[0]), String(parts[1]))
+    }
+
+    // GraphQL request body (JSON string) for the newest PR on `branch`.
+    static func query(owner: String, repo: String, branch: String) -> String {
+        let graphql = """
+        query($owner:String!,$repo:String!,$branch:String!){\
+        repository(owner:$owner,name:$repo){\
+        pullRequests(headRefName:$branch,first:1,orderBy:{field:CREATED_AT,direction:DESC}){\
+        nodes{number url state isDraft \
+        commits(last:1){nodes{commit{statusCheckRollup{state}}}}}}}}
+        """
+        let body: [String: Any] = [
+            "query": graphql,
+            "variables": ["owner": owner, "repo": repo, "branch": branch],
+        ]
+        let data = (try? JSONSerialization.data(withJSONObject: body)) ?? Data()
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    // Fetch a branch's PR via the injected runner (`run(graphQLBody) -> json?`).
+    static func pullRequest(owner: String, repo: String, branch: String,
+                            run: (String) -> String?) -> PullRequestInfo? {
+        guard let response = run(query(owner: owner, repo: repo, branch: branch)) else { return nil }
+        return parse(response)
+    }
+
+    static func parse(_ json: String) -> PullRequestInfo? {
+        guard let data = json.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let node = firstPRNode(root),
+              let number = node["number"] as? Int,
+              let url = node["url"] as? String,
+              let stateRaw = node["state"] as? String,
+              let state = PRState(rawValue: stateRaw)
+        else { return nil }
+        return PullRequestInfo(
+            number: number,
+            url: url,
+            state: state,
+            isDraft: node["isDraft"] as? Bool ?? false,
+            ci: ciStatus(fromNode: node))
+    }
+
+    private static func firstPRNode(_ root: [String: Any]) -> [String: Any]? {
+        let data = root["data"] as? [String: Any]
+        let repository = data?["repository"] as? [String: Any]
+        let pullRequests = repository?["pullRequests"] as? [String: Any]
+        let nodes = pullRequests?["nodes"] as? [[String: Any]]
+        return nodes?.first
+    }
+
+    // statusCheckRollup.state on the PR's latest commit → one CI signal.
+    static func ciStatus(fromNode node: [String: Any]) -> CIStatus? {
+        guard let commitNodes = (node["commits"] as? [String: Any])?["nodes"] as? [[String: Any]],
+              let commit = commitNodes.first?["commit"] as? [String: Any],
+              let rollup = commit["statusCheckRollup"] as? [String: Any],
+              let state = (rollup["state"] as? String)?.uppercased()
+        else { return nil }
+        switch state {
+        case "SUCCESS":            return .passing
+        case "FAILURE", "ERROR":   return .failing
+        case "PENDING", "EXPECTED": return .pending
+        default:                   return nil
+        }
+    }
+}

--- a/panel/GitHubAuth.swift
+++ b/panel/GitHubAuth.swift
@@ -1,0 +1,166 @@
+import Foundation
+import Security
+
+// GitHub OAuth device-flow response: the user enters `userCode` at
+// `verificationURI`, we poll every `interval` seconds until `expiresIn` lapses.
+struct DeviceCodeResponse: Equatable {
+    let deviceCode: String
+    let userCode: String
+    let verificationURI: String
+    let interval: Int
+    let expiresIn: Int
+}
+
+// One poll outcome. `slowDown` carries GitHub's requested new interval.
+enum DevicePollResult: Equatable {
+    case token(String)
+    case pending
+    case slowDown(Int)
+    case expired
+    case denied
+    case failed(String)
+}
+
+// In-panel GitHub sign-in via the OAuth device flow, plus Keychain token
+// storage. No client secret (device flow needs none); the public client_id
+// comes from STACKNUDGE_GITHUB_CLIENT_ID so it can be set without a rebuild.
+// Networking is thin; the response parsers are pure for unit testing.
+enum GitHubAuth {
+
+    static let keychainService = "stack-nudge-github"
+    static let keychainAccount = "oauth-token"
+    static let deviceCodeURL = URL(string: "https://github.com/login/device/code")!
+    static let tokenURL = URL(string: "https://github.com/login/oauth/access_token")!
+    static let scope = "repo"
+
+    // The app's public OAuth client_id — identical for every user (device flow
+    // needs no secret), so it ships embedded like `gh` does and end users
+    // configure nothing. Paste the StackNudge OAuth app's Client ID here.
+    static let defaultClientID = "Ov23li9cyzCK1T0evP0a"
+
+    // Embedded id, overridable by STACKNUDGE_GITHUB_CLIENT_ID (testing / a
+    // different app, no rebuild). nil ⇒ not configured yet.
+    static func clientID() -> String? {
+        if let override = ConfigFile.read()["STACKNUDGE_GITHUB_CLIENT_ID"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !override.isEmpty
+        {
+            return override
+        }
+        return defaultClientID.isEmpty ? nil : defaultClientID
+    }
+
+    // MARK: - Keychain
+
+    static func token() -> String? {
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(baseQuery(returningData: true) as CFDictionary, &item)
+        guard status == errSecSuccess, let data = item as? Data,
+            let token = String(data: data, encoding: .utf8), !token.isEmpty
+        else { return nil }
+        return token
+    }
+
+    static func store(token: String) {
+        SecItemDelete(baseQuery(returningData: false) as CFDictionary)  // replace any existing
+        var add = baseQuery(returningData: false)
+        add[kSecValueData as String] = Data(token.utf8)
+        SecItemAdd(add as CFDictionary, nil)
+    }
+
+    static func clearToken() {
+        SecItemDelete(baseQuery(returningData: false) as CFDictionary)
+    }
+
+    private static func baseQuery(returningData: Bool) -> [String: Any] {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: keychainAccount,
+        ]
+        if returningData {
+            query[kSecReturnData as String] = true
+            query[kSecMatchLimit as String] = kSecMatchLimitOne
+        }
+        return query
+    }
+
+    // MARK: - Device flow networking
+
+    static func requestDeviceCode(
+        clientID: String,
+        session: URLSession = .shared,
+        completion: @escaping (DeviceCodeResponse?) -> Void
+    ) {
+        let request = formPOST(deviceCodeURL, ["client_id": clientID, "scope": scope])
+        session.dataTask(with: request) { data, _, _ in
+            completion(data.flatMap(parseDeviceCode))
+        }.resume()
+    }
+
+    static func poll(
+        clientID: String,
+        deviceCode: String,
+        session: URLSession = .shared,
+        completion: @escaping (DevicePollResult) -> Void
+    ) {
+        let request = formPOST(
+            tokenURL,
+            [
+                "client_id": clientID,
+                "device_code": deviceCode,
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            ])
+        session.dataTask(with: request) { data, _, _ in
+            completion(data.map(parsePoll) ?? .failed("no response"))
+        }.resume()
+    }
+
+    // MARK: - Pure parsers (testable)
+
+    static func parseDeviceCode(_ data: Data) -> DeviceCodeResponse? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let deviceCode = json["device_code"] as? String,
+            let userCode = json["user_code"] as? String,
+            let verificationURI = json["verification_uri"] as? String
+        else { return nil }
+        return DeviceCodeResponse(
+            deviceCode: deviceCode,
+            userCode: userCode,
+            verificationURI: verificationURI,
+            interval: json["interval"] as? Int ?? 5,
+            expiresIn: json["expires_in"] as? Int ?? 900)
+    }
+
+    static func parsePoll(_ data: Data) -> DevicePollResult {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return .failed("bad json")
+        }
+        if let token = json["access_token"] as? String, !token.isEmpty { return .token(token) }
+        switch json["error"] as? String {
+        case "authorization_pending": return .pending
+        case "slow_down": return .slowDown(json["interval"] as? Int ?? 5)
+        case "expired_token": return .expired
+        case "access_denied": return .denied
+        case let other?: return .failed(other)
+        case nil: return .failed("unknown")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func formPOST(_ url: URL, _ params: [String: String]) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-._~"))
+        request.httpBody =
+            params
+            .map {
+                "\($0.key)=\($0.value.addingPercentEncoding(withAllowedCharacters: allowed) ?? $0.value)"
+            }
+            .joined(separator: "&")
+            .data(using: .utf8)
+        return request
+    }
+}

--- a/panel/OutcomesView.swift
+++ b/panel/OutcomesView.swift
@@ -59,24 +59,44 @@ struct OutcomesView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             let groups = Self.groups(from: HandoffLedger.shared.all())
+            let selectedRowID = Self.selectedRowID(groups, index: nav.outcomeSelectedIndex)
+            if nav.githubLinkingEnabled, !nav.githubSignedIn {
+                connectGithubCard
+                Divider().opacity(0.4)
+            }
             if groups.isEmpty {
                 emptyState
             } else {
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 8) {
-                        ForEach(groups) { groupRow($0) }
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 8) {
+                            ForEach(groups) { group in
+                                groupRow(group, selectedRowID: selectedRowID)
+                                    .id(Self.headerID(group))
+                            }
+                        }
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 14)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(ThinScrollers())
                     }
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 14)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(ThinScrollers())
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .scrollIndicators(.visible)
+                    .onChange(of: nav.outcomeSelectedIndex) { _ in
+                        guard let selectedRowID else { return }
+                        withAnimation(.easeOut(duration: 0.15)) {
+                            proxy.scrollTo(selectedRowID, anchor: .center)
+                        }
+                    }
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .scrollIndicators(.visible)
             }
 
             PageFooter {
                 FooterHint(label: footerStatus(groups), keys: [])
+                if !groups.isEmpty {
+                    FooterHint(label: "Select", keys: ["↑↓"])
+                    FooterHint(label: "Open", keys: ["↵"])
+                }
                 if nav.compactMode { FooterHint(label: "Compact", keys: ["M"]) }
                 FooterHint(label: "Hide", keys: ["Esc"])
             }
@@ -84,14 +104,17 @@ struct OutcomesView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .onAppear {
             ticketURLTemplate = ConfigFile.read()["STACKNUDGE_TICKET_URL"]
+            nav.outcomeSelectedIndex = 0
             nav.refreshOutcomes?()
+            nav.refreshPullRequests?()
         }
     }
 
     // MARK: - Rows
 
-    private func groupRow(_ group: TicketGroup) -> some View {
+    private func groupRow(_ group: TicketGroup, selectedRowID: String?) -> some View {
         let linkable = group.isTicket && ticketURL(for: group.id) != nil
+        let selected = selectedRowID == Self.headerID(group)
         return VStack(alignment: .leading, spacing: 3) {
             HStack(spacing: 6) {
                 Text(group.id)
@@ -116,30 +139,49 @@ struct OutcomesView: View {
             Text(detailLine(group))
                 .font(.caption.monospacedDigit())
                 .foregroundStyle(.secondary)
-            let rollup = outcomeRollup(group)
-            if !rollup.isEmpty {
-                HStack(spacing: 10) {
-                    ForEach(rollup, id: \.status) { statusChip($0.status, count: $0.count) }
+            if group.isTicket {
+                let rollup = outcomeRollup(group)
+                if !rollup.isEmpty {
+                    HStack(spacing: 10) {
+                        ForEach(rollup, id: \.status) { statusChip($0.status, count: $0.count) }
+                    }
                 }
-            }
-            if group.isTicket, !group.branches.isEmpty {
-                VStack(alignment: .leading, spacing: 2) {
-                    ForEach(group.branches) { branchRow($0) }
+                if !group.branches.isEmpty {
+                    VStack(alignment: .leading, spacing: 2) {
+                        ForEach(group.branches) { branch in
+                            branchRow(branch, selectedRowID: selectedRowID)
+                                .id(Self.branchID(branch))
+                        }
+                    }
+                    .padding(.top, 1)
                 }
-                .padding(.top, 1)
+            } else if let branch = group.branches.first {
+                // Branch-only group: one branch == the group, with no sub-row to
+                // host a chip — so render it on the header. Clickable PR chip
+                // when a PR exists, else the local-outcome chip.
+                HStack(spacing: 8) {
+                    if let pr = prInfo(for: branch) {
+                        prChip(pr)
+                    } else if let status = outcome(for: branch), status != .clean {
+                        statusChip(status)
+                    }
+                    Spacer(minLength: 0)
+                }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 8)
         .padding(.vertical, 6)
-        .background(RoundedRectangle(cornerRadius: 6).fill(Color.primary.opacity(0.04)))
+        .background(RoundedRectangle(cornerRadius: 6)
+            .fill(selected ? Color.accentColor.opacity(0.14) : Color.primary.opacity(0.04)))
         .contentShape(Rectangle())
         .onTapGesture { if linkable { openTicket(group) } }
         .help(linkable ? "Open \(group.id) in your tracker" : "")
     }
 
-    private func branchRow(_ branch: BranchBreakdown) -> some View {
-        HStack(spacing: 6) {
+    private func branchRow(_ branch: BranchBreakdown, selectedRowID: String?) -> some View {
+        let selected = selectedRowID == Self.branchID(branch)
+        return HStack(spacing: 6) {
             Image(systemName: "arrow.turn.down.right")
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
@@ -153,11 +195,34 @@ struct OutcomesView: View {
                 .font(.caption2.monospacedDigit())
                 .foregroundStyle(.tertiary)
                 .fixedSize()
-            if let status = outcome(for: branch), status != .clean {
+            if let pr = prInfo(for: branch) {
+                prChip(pr)
+            } else if let status = outcome(for: branch), status != .clean {
                 statusChip(status)
             }
         }
         .padding(.leading, 12)
+        .padding(.vertical, 1)
+        .background(RoundedRectangle(cornerRadius: 4)
+            .fill(selected ? Color.accentColor.opacity(0.14) : Color.clear))
+    }
+
+    // Stable per-row ids — order must match PanelNav's selection indexing
+    // (header, then a ticket group's branch sub-rows).
+    private static func headerID(_ group: TicketGroup) -> String { "g:\(group.id)" }
+
+    private static func branchID(_ branch: BranchBreakdown) -> String {
+        "b:\(PanelNav.outcomeKey(branch.repoRoot, branch.branch))"
+    }
+
+    private static func selectedRowID(_ groups: [TicketGroup], index: Int) -> String? {
+        var ids: [String] = []
+        for group in groups {
+            ids.append(headerID(group))
+            if group.isTicket { ids.append(contentsOf: group.branches.map(branchID)) }
+        }
+        guard !ids.isEmpty else { return nil }
+        return ids[min(max(0, index), ids.count - 1)]
     }
 
     // "3 sessions · 218K tokens · 23 files · +1.8k/−400 · Claude, Codex" —
@@ -189,13 +254,31 @@ struct OutcomesView: View {
         nav.outcomeByBranch[PanelNav.outcomeKey(branch.repoRoot, branch.branch)]
     }
 
-    // Counts of each non-clean outcome across the group's branches, ordered
-    // most-shipped first. Empty when nothing has a status yet (e.g. still
-    // computing) or everything is clean.
+    private func prInfo(for branch: BranchBreakdown) -> PullRequestInfo? {
+        nav.pullRequestByBranch[PanelNav.outcomeKey(branch.repoRoot, branch.branch)]
+    }
+
+    // A PR's state, when known, supersedes the local heuristic — a MERGED PR is
+    // how a squash-merged branch finally reads as "merged". Open → at least
+    // pushed; closed-not-merged falls back to the local truth.
+    private func effectiveStatus(for branch: BranchBreakdown) -> OutcomeStatus? {
+        if let pr = prInfo(for: branch) {
+            switch pr.state {
+            case .merged: return .merged
+            case .open:   return .pushed
+            case .closed: return outcome(for: branch)
+            }
+        }
+        return outcome(for: branch)
+    }
+
+    // Counts of each non-clean status across the group's branches (PR state
+    // preferred), ordered most-shipped first. Empty when nothing has resolved
+    // yet or everything is clean.
     private func outcomeRollup(_ group: TicketGroup) -> [(status: OutcomeStatus, count: Int)] {
         var counts: [OutcomeStatus: Int] = [:]
         for branch in group.branches {
-            guard let status = outcome(for: branch), status != .clean else { continue }
+            guard let status = effectiveStatus(for: branch), status != .clean else { continue }
             counts[status, default: 0] += 1
         }
         return Self.outcomeOrder.compactMap { status in
@@ -234,6 +317,71 @@ struct OutcomesView: View {
         case .committed:   return .teal
         case .needsReview: return .orange
         case .clean:       return .secondary
+        }
+    }
+
+    // Clickable PR chip: state dot + label + a CI glyph. Opens the PR in the
+    // browser. Used in place of the local-outcome chip when a PR is known.
+    private func prChip(_ pr: PullRequestInfo) -> some View {
+        Button {
+            if let url = URL(string: pr.url) { NSWorkspace.shared.open(url) }
+        } label: {
+            HStack(spacing: 3) {
+                Circle()
+                    .fill(Self.prColor(pr))
+                    .frame(width: 6, height: 6)
+                Text(Self.prLabel(pr))
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(Color.accentColor)
+                if let ci = pr.ci {
+                    Image(systemName: Self.ciSymbol(ci))
+                        .font(.system(size: 8, weight: .bold))
+                        .foregroundStyle(Self.ciColor(ci))
+                }
+                // Link affordance so the chip reads as clickable (vs the static
+                // local-outcome chip) regardless of PR state — merged included.
+                Image(systemName: "arrow.up.right")
+                    .font(.system(size: 7, weight: .bold))
+                    .foregroundStyle(Color.accentColor.opacity(0.7))
+            }
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(Color.accentColor.opacity(0.12)))
+            .fixedSize()
+        }
+        .buttonStyle(.plain)
+        .help("Open PR #\(pr.number)")
+    }
+
+    private static func prLabel(_ pr: PullRequestInfo) -> String {
+        switch pr.state {
+        case .merged: return "merged"
+        case .closed: return "closed"
+        case .open:   return pr.isDraft ? "draft #\(pr.number)" : "PR #\(pr.number)"
+        }
+    }
+
+    private static func prColor(_ pr: PullRequestInfo) -> Color {
+        switch pr.state {
+        case .merged: return .purple
+        case .closed: return .secondary
+        case .open:   return pr.isDraft ? .secondary : .blue
+        }
+    }
+
+    private static func ciSymbol(_ ci: CIStatus) -> String {
+        switch ci {
+        case .passing: return "checkmark"
+        case .failing: return "xmark"
+        case .pending: return "clock"
+        }
+    }
+
+    private static func ciColor(_ ci: CIStatus) -> Color {
+        switch ci {
+        case .passing: return .green
+        case .failing: return .red
+        case .pending: return .yellow
         }
     }
 
@@ -369,6 +517,75 @@ struct OutcomesView: View {
         let groupWord = groups.count == 1 ? "group" : "groups"
         let sessionWord = sessions == 1 ? "session" : "sessions"
         return "\(groups.count) \(groupWord) · \(sessions) \(sessionWord)"
+    }
+
+    // MARK: - Connect GitHub (device-flow sign-in)
+
+    @ViewBuilder private var connectGithubCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("GitHub PR links")
+                .font(.callout.weight(.semibold))
+            switch nav.githubSignIn {
+            case .idle:
+                Text("Connect GitHub to show PR + CI status on these branches.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                cardButton("Connect GitHub", prominent: true) { nav.startGithubSignIn?() }
+            case .requesting:
+                HStack(spacing: 6) {
+                    ProgressView().controlSize(.small)
+                    Text("Contacting GitHub…").font(.caption).foregroundStyle(.secondary)
+                }
+            case let .awaitingApproval(userCode, verificationURI):
+                Text("Enter this code at \(displayURL(verificationURI)):")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(userCode)
+                    .font(.title3.monospaced().weight(.bold))
+                    .textSelection(.enabled)
+                HStack(spacing: 8) {
+                    cardButton("Copy & open GitHub", prominent: true) {
+                        copyAndOpen(code: userCode, url: verificationURI)
+                    }
+                    cardButton("Cancel") { nav.cancelGithubSignIn?() }
+                }
+                HStack(spacing: 6) {
+                    ProgressView().controlSize(.small)
+                    Text("Waiting for approval…").font(.caption2).foregroundStyle(.tertiary)
+                }
+            case let .failed(message):
+                Text(message).font(.caption).foregroundStyle(.orange)
+                cardButton("Try again", prominent: true) { nav.startGithubSignIn?() }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+    }
+
+    private func cardButton(_ title: String, prominent: Bool = false,
+                            action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.caption.weight(.medium))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(prominent ? Color.accentColor.opacity(0.9) : Color.primary.opacity(0.08)))
+                .foregroundStyle(prominent ? Color.white : Color.primary)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func copyAndOpen(code: String, url: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(code, forType: .string)
+        if let target = URL(string: url) { NSWorkspace.shared.open(target) }
+    }
+
+    private func displayURL(_ url: String) -> String {
+        url.replacingOccurrences(of: "https://", with: "")
     }
 
     private var emptyState: some View {

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -664,6 +664,9 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
             self?.registerHotkey(spec: spec) ?? false
         }
         nav.refreshOutcomes = { [weak self] in self?.refreshOutcomes() }
+        nav.refreshPullRequests = { [weak self] in self?.refreshPullRequests() }
+        nav.startGithubSignIn = { [weak self] in self?.startGithubSignIn() }
+        nav.cancelGithubSignIn = { [weak self] in self?.cancelGithubSignIn() }
 
         startConfigWatcher()
         setupNotificationCenter()
@@ -1560,6 +1563,124 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         }
     }
 
+    // Opt-in (STACKNUDGE_GITHUB): fetch the PR + CI state for each distinct
+    // repo+branch via the GitHub GraphQL API with our stored token, off-main,
+    // publishing incrementally so chips appear as each branch resolves. A PR's
+    // MERGED state is what closes the squash gap the local OutcomeWatcher can't
+    // see. No-op when disabled or not signed in.
+    func refreshPullRequests() {
+        guard nav.githubLinkingEnabled, let token = GitHubAuth.token() else { return }
+        var pairs: [(repo: String, branch: String)] = []
+        var seen = Set<String>()
+        for record in HandoffLedger.shared.all() {
+            guard let repo = record.repoRoot, let branch = record.branch else { continue }
+            if seen.insert(PanelNav.outcomeKey(repo, branch)).inserted {
+                pairs.append((repo, branch))
+            }
+        }
+        guard !pairs.isEmpty else { return }
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            for pair in pairs {
+                guard let slug = Self.repoSlug(forRepo: pair.repo) else { continue }
+                let info = GitHubAPI.pullRequest(owner: slug.owner, repo: slug.repo,
+                                                 branch: pair.branch) { body in
+                    Self.graphQLPOST(body, token: token)
+                }
+                guard let info else { continue }
+                let key = PanelNav.outcomeKey(pair.repo, pair.branch)
+                DispatchQueue.main.async { self?.nav.pullRequestByBranch[key] = info }
+            }
+        }
+    }
+
+    // owner/repo for a working copy — prefer `upstream` (the real mainline in a
+    // fork workflow, where PRs live) then `origin`.
+    private static func repoSlug(forRepo repoRoot: String) -> (owner: String, repo: String)? {
+        for remote in ["upstream", "origin"] {
+            if let url = gitValue(repoRoot, ["remote", "get-url", remote]),
+               let slug = GitHubAPI.repoSlug(fromRemoteURL: url) {
+                return slug
+            }
+        }
+        return nil
+    }
+
+    // Synchronous GraphQL POST (called from the off-main fetch loop) — blocks on
+    // a semaphore so the caller's loop stays simple; 10s ceiling.
+    private static func graphQLPOST(_ body: String, token: String) -> String? {
+        var request = URLRequest(url: GitHubAPI.graphQLEndpoint)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body.data(using: .utf8)
+        var result: String?
+        let done = DispatchSemaphore(value: 0)
+        URLSession.shared.dataTask(with: request) { data, _, _ in
+            if let data { result = String(data: data, encoding: .utf8) }
+            done.signal()
+        }.resume()
+        _ = done.wait(timeout: .now() + 10)
+        return result
+    }
+
+    // MARK: - GitHub device-flow sign-in
+
+    // Kick off the in-panel device flow: request a code, surface it to the
+    // Tickets-tab card, then poll until the user approves (or it expires).
+    func startGithubSignIn() {
+        guard let clientID = GitHubAuth.clientID() else {
+            nav.githubSignIn = .failed("GitHub client ID not configured")
+            return
+        }
+        nav.githubSignIn = .requesting
+        GitHubAuth.requestDeviceCode(clientID: clientID) { [weak self] response in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                guard let response else {
+                    self.nav.githubSignIn = .failed("Couldn't reach GitHub — try again")
+                    return
+                }
+                self.nav.githubSignIn = .awaitingApproval(
+                    userCode: response.userCode, verificationURI: response.verificationURI)
+                self.pollGithubSignIn(clientID: clientID,
+                                      deviceCode: response.deviceCode,
+                                      interval: response.interval)
+            }
+        }
+    }
+
+    func cancelGithubSignIn() { nav.githubSignIn = .idle }
+
+    // One poll per `interval` seconds. Stops if the user cancelled (state left
+    // awaitingApproval). On success, stores the token and kicks a PR refresh.
+    private func pollGithubSignIn(clientID: String, deviceCode: String, interval: Int) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(max(1, interval))) { [weak self] in
+            guard let self, case .awaitingApproval = self.nav.githubSignIn else { return }
+            GitHubAuth.poll(clientID: clientID, deviceCode: deviceCode) { result in
+                DispatchQueue.main.async {
+                    guard case .awaitingApproval = self.nav.githubSignIn else { return }
+                    switch result {
+                    case .token(let token):
+                        GitHubAuth.store(token: token)
+                        self.nav.githubSignedIn = true
+                        self.nav.githubSignIn = .idle
+                        self.refreshPullRequests()
+                    case .pending:
+                        self.pollGithubSignIn(clientID: clientID, deviceCode: deviceCode, interval: interval)
+                    case .slowDown(let slower):
+                        self.pollGithubSignIn(clientID: clientID, deviceCode: deviceCode, interval: slower)
+                    case .expired:
+                        self.nav.githubSignIn = .failed("Code expired — try again")
+                    case .denied:
+                        self.nav.githubSignIn = .failed("Access denied")
+                    case .failed(let message):
+                        self.nav.githubSignIn = .failed(message)
+                    }
+                }
+            }
+        }
+    }
+
     // Run `git -C <cwd> <args>`; trim, and treat non-repo / empty output as nil.
     private static func gitValue(_ cwd: String, _ args: [String]) -> String? {
         let output = ProcessOutput.read("/usr/bin/git", ["-C", cwd] + args)
@@ -2330,9 +2451,9 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
             return true
         }
 
-        // Tickets tab: a single scrollable rollup, no sub-selection. ↑/↓ scroll
-        // it, M enters the widget, Esc hides. Other keys are swallowed so they
-        // don't leak through to the events store.
+        // Tickets tab: ↑/↓ move the row selection, →/Enter open the selected
+        // row's ticket/PR link, M enters the widget, Esc hides. Other keys are
+        // swallowed so they don't leak through to the events store.
         if nav.mode == .outcomes {
             let plain = mods.intersection([.command, .control, .option, .shift]).isEmpty
             guard plain else { return false }
@@ -2340,9 +2461,11 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
             case KeyCode.escape:
                 hidePanel()
             case KeyCode.upArrow:
-                scrollDetailBy(-40)
+                nav.moveOutcomeSelection(-1)
             case KeyCode.downArrow:
-                scrollDetailBy(40)
+                nav.moveOutcomeSelection(1)
+            case KeyCode.rightArrow, KeyCode.returnKey, KeyCode.numpadEnter:
+                nav.activateSelectedOutcome()
             case KeyCode.mKey:
                 enterCompactMode()
             default:

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -71,6 +71,15 @@ enum MascotKind: String, CaseIterable {
     }
 }
 
+// In-panel GitHub device-flow sign-in state. `awaitingApproval` carries the
+// one-time code + verification URL to show while we poll in the background.
+enum GithubSignIn: Equatable {
+    case idle
+    case requesting
+    case awaitingApproval(userCode: String, verificationURI: String)
+    case failed(String)
+}
+
 struct SettingsActions {
     let checkPermissions: () -> Void
     let openConfig:       () -> Void
@@ -179,9 +188,76 @@ final class PanelNav: ObservableObject {
     // outcomes for the branches in the ledger. Kept as a closure so the view
     // doesn't need to know about git/process work.
     var refreshOutcomes: (() -> Void)?
+    // Opt-in GitHub PR/CI state per repo+branch (STACKNUDGE_GITHUB), fetched via
+    // `gh` by PanelController and read by the Tickets tab. Supersedes the local
+    // outcome when present — a PR reporting MERGED closes the squash gap. Keyed
+    // by `outcomeKey`. Empty when the feature is off or `gh` is absent.
+    @Published var pullRequestByBranch: [String: PullRequestInfo] = [:]
+    var refreshPullRequests: (() -> Void)?
+    // Mirror of STACKNUDGE_GITHUB; gates the PR fetch. Off by default — local
+    // git tracking stays fully functional without a GitHub token.
+    @Published var githubLinkingEnabled: Bool = false
+    // True when a GitHub token is stored (signed in). Drives whether the Tickets
+    // tab shows PR chips or the "Connect GitHub" card. Set from the Keychain on
+    // load and after the device flow completes.
+    @Published var githubSignedIn: Bool = false
+    // Live device-flow state for the in-panel "Connect GitHub" card.
+    @Published var githubSignIn: GithubSignIn = .idle
+    // Wired by PanelController — start/cancel the device-flow sign-in.
+    var startGithubSignIn:  (() -> Void)?
+    var cancelGithubSignIn: (() -> Void)?
 
     static func outcomeKey(_ repoRoot: String?, _ branch: String?) -> String {
         "\(repoRoot ?? "")\n\(branch ?? "")"
+    }
+
+    // Tickets-tab keyboard selection (↑/↓ move, Enter/→ opens the row's link),
+    // mirroring the Usage tab. Indexes a flat list of rows in render order:
+    // each group header, then its branch sub-rows (ticket groups only).
+    @Published var outcomeSelectedIndex: Int = 0
+
+    // Row count for clamping — header + (ticket) branch sub-rows, same order the
+    // view renders. No config/network, so cheap to call on every keystroke.
+    func outcomeRowCount() -> Int {
+        OutcomesView.groups(from: HandoffLedger.shared.all()).reduce(0) { total, group in
+            total + 1 + (group.isTicket ? group.branches.count : 0)
+        }
+    }
+
+    func moveOutcomeSelection(_ delta: Int) {
+        let count = outcomeRowCount()
+        guard count > 0 else { return }
+        outcomeSelectedIndex = min(max(0, outcomeSelectedIndex + delta), count - 1)
+    }
+
+    // Open the selected row's link: a ticket's tracker URL (STACKNUDGE_TICKET_URL)
+    // for ticket headers, else the PR URL for a branch / branch-only header.
+    func activateSelectedOutcome() {
+        let template = ConfigFile.read()["STACKNUDGE_TICKET_URL"]
+        var urls: [String?] = []
+        for group in OutcomesView.groups(from: HandoffLedger.shared.all()) {
+            urls.append(headerURL(group, template: template))
+            if group.isTicket {
+                for branch in group.branches {
+                    urls.append(pullRequestByBranch[Self.outcomeKey(branch.repoRoot, branch.branch)]?.url)
+                }
+            }
+        }
+        guard !urls.isEmpty else { return }
+        let index = min(max(0, outcomeSelectedIndex), urls.count - 1)
+        if let url = urls[index], let target = URL(string: url) {
+            NSWorkspace.shared.open(target)
+        }
+    }
+
+    private func headerURL(_ group: TicketGroup, template: String?) -> String? {
+        if group.isTicket, let template, template.contains("{key}") {
+            return template.replacingOccurrences(of: "{key}", with: group.id)
+        }
+        if !group.isTicket, let branch = group.branches.first {
+            return pullRequestByBranch[Self.outcomeKey(branch.repoRoot, branch.branch)]?.url
+        }
+        return nil
     }
     // Usage tab: which connected client's quota is shown (index into
     // availableUsageClients). ↑/↓ move it; read through clampedUsageClientIndex
@@ -355,13 +431,13 @@ final class PanelNav: ObservableObject {
     // when the offset is 1.
     var updateRowOffset: Int { updateAvailable != nil ? 1 : 0 }
 
-    // 29 rows in the body: hotkey (1) + Toggles (4) + Widget (4) + Sounds (3)
+    // 30 rows in the body: hotkey (1) + Toggles (4) + Widget (4) + Sounds (3)
     // + Voice (2 — Voice + Speed, or 1 Download row with an unused index 14)
-    // + Usage (6) + Events (1) + Actions (7) = indices 0…28. Must be kept
-    // in sync with the row(...) calls in Settings.swift and the case bodies
-    // in applyCycle/activate; off-by-one here makes the last rows wrap to 0
-    // on the down-arrow.
-    var rowCount: Int { 29 + updateRowOffset }
+    // + Usage (6) + Tickets (1) + Events (1) + Actions (7) = indices 0…29. Must
+    // be kept in sync with the row(...) calls in Settings.swift and the case
+    // bodies in applyCycle/activate; off-by-one here makes the last rows wrap to
+    // 0 on the down-arrow.
+    var rowCount: Int { 30 + updateRowOffset }
 
     // Row layout (kept in one place so the controller, view, and indexing
     // logic all agree on what each row index means). When updateAvailable
@@ -388,13 +464,15 @@ final class PanelNav: ObservableObject {
     //  18  Poll frequency        cycle
     //  19  Context alert at      cycle       (per-session token thresholds)
     //  20  Show remaining        toggle      (invert gauge readout: 70% left vs 30% used)
-    //  21  Edit phrases…         action
-    //  22  Check permissions…    action
-    //  23  Open config file…     action
-    //  24  View release notes…   action
-    //  25  Check for updates…    action
-    //  26  Uninstall stack-nudge action
-    //  27  Quit panel            action
+    //  21  GitHub PR links       toggle      (opt-in gh PR/CI linking; STACKNUDGE_GITHUB)
+    //  22  History per session   cycle
+    //  23  Edit phrases…         action
+    //  24  Check permissions…    action
+    //  25  Open config file…     action
+    //  26  View release notes…   action
+    //  27  Check for updates…    action
+    //  28  Uninstall stack-nudge action
+    //  29  Quit panel            action
 
     // MARK: - Disk I/O
 
@@ -430,6 +508,8 @@ final class PanelNav: ObservableObject {
         soundPermission = config["STACKNUDGE_SOUND_PERMISSION"] ?? "Ping"
         voice           = config["STACKNUDGE_VOICE_NAME"]       ?? "af_aoede"
         voiceSpeed      = Double(config["STACKNUDGE_VOICE_SPEED"] ?? "") ?? 1.1
+        githubLinkingEnabled = ConfigFile.bool(config, "STACKNUDGE_GITHUB", default: false)
+        githubSignedIn = GitHubAuth.token() != nil
         quotaTrackingEnabled = ConfigFile.bool(config, "STACKNUDGE_QUOTA_TRACKING", default: true)
         quotaAlertsEnabled   = ConfigFile.bool(config, "STACKNUDGE_QUOTA_ALERTS",   default: true)
         quotaShowRemaining   = ConfigFile.bool(config, "STACKNUDGE_QUOTA_SHOW_REMAINING", default: false)
@@ -642,13 +722,13 @@ final class PanelNav: ObservableObject {
             } else {
                 startVoiceModelDownload()
             }
-        case 22: actions?.editPhrases()
-        case 23: actions?.checkPermissions()
-        case 24: actions?.openConfig()
-        case 25: actions?.openReleaseNotes()
-        case 26: actions?.checkForUpdates()
-        case 27: actions?.beginUninstall()
-        case 28: actions?.quit()
+        case 23: actions?.editPhrases()
+        case 24: actions?.checkPermissions()
+        case 25: actions?.openConfig()
+        case 26: actions?.openReleaseNotes()
+        case 27: actions?.checkForUpdates()
+        case 28: actions?.beginUninstall()
+        case 29: actions?.quit()
         default: applyCycle(forward: true)
         }
     }
@@ -668,6 +748,22 @@ final class PanelNav: ObservableObject {
         if !quotaTrackingEnabled {
             quota = nil
             quotaLastUpdated = nil
+        }
+    }
+
+    // Settings "GitHub PR links" toggle. Persists STACKNUDGE_GITHUB; on enable
+    // kicks an immediate PR fetch so chips appear without waiting for the next
+    // tab visit, on disable drops cached PR state so chips revert to the local
+    // outcome.
+    func toggleGithubLinking() {
+        githubLinkingEnabled.toggle()
+        ConfigFile.write(key: "STACKNUDGE_GITHUB",
+                         value: githubLinkingEnabled ? "true" : "false")
+        if githubLinkingEnabled {
+            if githubSignedIn { refreshPullRequests?() } else { startGithubSignIn?() }
+        } else {
+            pullRequestByBranch = [:]
+            githubSignIn = .idle
         }
     }
 
@@ -804,6 +900,8 @@ final class PanelNav: ObservableObject {
             ConfigFile.write(key: "STACKNUDGE_QUOTA_SHOW_REMAINING",
                              value: quotaShowRemaining ? "true" : "false")
         case 21:
+            toggleGithubLinking()
+        case 22:
             let list = Self.eventsPerSessionOptions
             let idx = list.firstIndex(of: eventsPerSession) ?? 1
             let next = forward ? (idx + 1) % list.count : (idx - 1 + list.count) % list.count

--- a/panel/Settings.swift
+++ b/panel/Settings.swift
@@ -84,18 +84,22 @@ struct SettingsView: View {
                             row(20 + off, label: "Show remaining",   kind: .toggle, value: nav.quotaShowRemaining ? "On" : "Off", enabled: nav.quotaTrackingEnabled)
                         }
 
+                        section("Tickets") {
+                            row(21 + off, label: "GitHub PR links", kind: .toggle, value: nav.githubLinkingEnabled ? "On" : "Off")
+                        }
+
                         section("Events") {
-                            row(21 + off, label: "History per session", kind: .cycle, value: "\(nav.eventsPerSession)")
+                            row(22 + off, label: "History per session", kind: .cycle, value: "\(nav.eventsPerSession)")
                         }
 
                         section("Actions") {
-                            row(22 + off, label: "Edit phrases…",         kind: .action, value: "")
-                            row(23 + off, label: "Check permissions…",    kind: .action, value: "")
-                            row(24 + off, label: "Open config file…",     kind: .action, value: "")
-                            row(25 + off, label: "View release notes…",   kind: .action, value: "")
-                            row(26 + off, label: "Check for updates…",    kind: .action, value: checkForUpdatesStatus)
-                            row(27 + off, label: "Uninstall StackNudge…", kind: .action, value: "")
-                            row(28 + off, label: "Quit panel",            kind: .action, value: "")
+                            row(23 + off, label: "Edit phrases…",         kind: .action, value: "")
+                            row(24 + off, label: "Check permissions…",    kind: .action, value: "")
+                            row(25 + off, label: "Open config file…",     kind: .action, value: "")
+                            row(26 + off, label: "View release notes…",   kind: .action, value: "")
+                            row(27 + off, label: "Check for updates…",    kind: .action, value: checkForUpdatesStatus)
+                            row(28 + off, label: "Uninstall StackNudge…", kind: .action, value: "")
+                            row(29 + off, label: "Quit panel",            kind: .action, value: "")
                         }
 
                         aboutFooter


### PR DESCRIPTION
## Summary

Opt-in GitHub PR/CI linking for the Tickets tab's "did it ship?" — with an
in-panel **device-flow sign-in** and **gh-free reads** (our own token →
GitHub GraphQL). A PR's MERGED state closes the squash-merge gap the local
OutcomeWatcher can't see (squash discards a branch's commits).

## Changes

- **In-panel sign-in** (`GitHubAuth`) — OAuth device flow (request code →
  poll) + Keychain token storage. A "Connect GitHub" card in the Tickets tab
  shows the one-time code + "Copy & open GitHub" and polls to completion. No
  `gh`, no client secret, no callback. Public `client_id` ships embedded
  (`GitHubAuth.defaultClientID`), overridable via `STACKNUDGE_GITHUB_CLIENT_ID`.
- **gh-free reads** (`GitHubAPI`) — GraphQL PR-by-`headRefName` + CI rollup
  using the stored token; owner/repo resolved from the git remote
  (`upstream` → `origin`). The `gh` binary dependency is gone entirely.
- **PR chips** — each branch shows a clickable chip opening the PR: state
  (merged / open / draft / closed) + CI (✓ / ✗ / ◷), superseding the local
  outcome. Rendered on ticket sub-rows and branch-only group headers.
- **Arrow-key navigation** — ↑/↓ select rows, → / Enter open the selected
  ticket/PR link, auto-scroll to selection (mirrors the Usage tab).
- **Settings → Tickets → "GitHub PR links"** toggle (`STACKNUDGE_GITHUB`, off
  by default); turning it on while signed-out kicks off the sign-in.

## Testing

- `./build.sh` → Build complete.
- `GitHubAPITests` + `GitHubAuthTests` — repo-slug / GraphQL / CI-rollup
  parsing and device-code + poll-error mapping (run in CI).
- Real end-to-end: live GraphQL resolved `feat/tickets-tab → PR #86 MERGED,
  CI passing` (squash gap closes); device-flow login verified manually.

## Prerequisite

A registered GitHub OAuth app with **Device Flow** enabled; its public
Client ID lives in `GitHubAuth.defaultClientID`.

## Related issues

Builds on the handoff ledger + outcome tracking (#84, #86, #87).
