### PR TITLE
feat(tickets-lifecycle): enforce ticket lifecycle & gh disconnect

### DIFF
--- a/Tests/StackNudgePanelCoreTests/HandoffLedgerTests.swift
+++ b/Tests/StackNudgePanelCoreTests/HandoffLedgerTests.swift
@@ -49,6 +49,23 @@ final class HandoffLedgerTests: XCTestCase {
         XCTAssertEqual(Set(ids), ["s3", "s4"])  // oldest two pruned
     }
 
+    func test_remove_dropsByID() {
+        let ledger = HandoffLedger(path: tempURL())
+        ledger.upsert(id: "s1", agent: "codex") { $0.ticket = "ENG-1" }
+        ledger.upsert(id: "s2", agent: "claude") { $0.ticket = "ENG-2" }
+        ledger.remove(ids: ["s1"])
+        XCTAssertEqual(ledger.all().map(\.id), ["s2"])
+    }
+
+    func test_pruneOnInit_dropsStaleAtLoad() {
+        let url = tempURL()
+        // A 2020-dated record on disk should be gone after init, with no upsert.
+        let old = #"{"id":"old","agent":"codex","createdAt":"2020-01-01T00:00:00Z","updatedAt":"2020-01-01T00:00:00Z"}"# + "\n"
+        try? old.write(to: url, atomically: true, encoding: .utf8)
+        let ledger = HandoffLedger(path: url, maxAgeDays: 90)
+        XCTAssertTrue(ledger.all().isEmpty)
+    }
+
     func test_ageRetention_dropsStaleOnNextWrite() {
         let url = tempURL()
         // Pre-seed a 2020-dated record directly (the API always stamps

--- a/panel/HandoffLedger.swift
+++ b/panel/HandoffLedger.swift
@@ -22,6 +22,11 @@ final class HandoffLedger {
         self.maxAge = maxAgeDays * 86_400
         self.maxCount = maxCount
         self.byID = Self.load(url)
+        // Prune on launch too — retention otherwise only runs on the next
+        // upsert, so an idle ledger would keep stale rows indefinitely.
+        let before = byID.count
+        prune()
+        if byID.count != before { persist() }
     }
 
     // Create on first sight of a session id, or merge into the existing record.
@@ -39,6 +44,13 @@ final class HandoffLedger {
         record.updatedAt = now
         byID[id] = record
         prune()
+        persist()
+    }
+
+    // Drop records by session id (manual dismiss from the Tickets tab).
+    func remove(ids: [String]) {
+        guard !ids.isEmpty else { return }
+        for id in ids { byID.removeValue(forKey: id) }
         persist()
     }
 

--- a/panel/OutcomesView.swift
+++ b/panel/OutcomesView.swift
@@ -58,7 +58,7 @@ struct OutcomesView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            let groups = Self.groups(from: HandoffLedger.shared.all())
+            let groups = nav.visibleOutcomeGroups()
             let selectedRowID = Self.selectedRowID(groups, index: nav.outcomeSelectedIndex)
             if nav.githubLinkingEnabled, !nav.githubSignedIn {
                 connectGithubCard
@@ -96,6 +96,7 @@ struct OutcomesView: View {
                 if !groups.isEmpty {
                     FooterHint(label: "Select", keys: ["↑↓"])
                     FooterHint(label: "Open", keys: ["↵"])
+                    FooterHint(label: "Remove", keys: ["⌫"])
                 }
                 if nav.compactMode { FooterHint(label: "Compact", keys: ["M"]) }
                 FooterHint(label: "Hide", keys: ["Esc"])

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -2466,6 +2466,8 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                 nav.moveOutcomeSelection(1)
             case KeyCode.rightArrow, KeyCode.returnKey, KeyCode.numpadEnter:
                 nav.activateSelectedOutcome()
+            case KeyCode.delete, KeyCode.forwardDelete:
+                nav.dismissSelectedOutcome()
             case KeyCode.mKey:
                 enterCompactMode()
             default:

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -197,6 +197,9 @@ final class PanelNav: ObservableObject {
     // Mirror of STACKNUDGE_GITHUB; gates the PR fetch. Off by default — local
     // git tracking stays fully functional without a GitHub token.
     @Published var githubLinkingEnabled: Bool = false
+    // STACKNUDGE_HIDE_SHIPPED — drop groups whose PR reads merged so the tab
+    // focuses on in-flight work. Needs GitHub linking to know "merged".
+    @Published var hideShippedTickets: Bool = false
     // True when a GitHub token is stored (signed in). Drives whether the Tickets
     // tab shows PR chips or the "Connect GitHub" card. Set from the Keychain on
     // load and after the device flow completes.
@@ -216,10 +219,28 @@ final class PanelNav: ObservableObject {
     // each group header, then its branch sub-rows (ticket groups only).
     @Published var outcomeSelectedIndex: Int = 0
 
+    // The groups the Tickets tab renders, after the hide-shipped filter. Single
+    // source of truth so the view and the keyboard indexing never disagree.
+    func visibleOutcomeGroups() -> [TicketGroup] {
+        let groups = OutcomesView.groups(from: HandoffLedger.shared.all())
+        guard hideShippedTickets else { return groups }
+        return groups.filter { !isShipped($0) }
+    }
+
+    // "Shipped" = every branch in the group reads merged (PR state preferred,
+    // else the local outcome). Empty groups aren't shipped.
+    func isShipped(_ group: TicketGroup) -> Bool {
+        !group.branches.isEmpty && group.branches.allSatisfy {
+            let key = Self.outcomeKey($0.repoRoot, $0.branch)
+            if let pr = pullRequestByBranch[key] { return pr.state == .merged }
+            return outcomeByBranch[key] == .merged
+        }
+    }
+
     // Row count for clamping — header + (ticket) branch sub-rows, same order the
     // view renders. No config/network, so cheap to call on every keystroke.
     func outcomeRowCount() -> Int {
-        OutcomesView.groups(from: HandoffLedger.shared.all()).reduce(0) { total, group in
+        visibleOutcomeGroups().reduce(0) { total, group in
             total + 1 + (group.isTicket ? group.branches.count : 0)
         }
     }
@@ -235,7 +256,7 @@ final class PanelNav: ObservableObject {
     func activateSelectedOutcome() {
         let template = ConfigFile.read()["STACKNUDGE_TICKET_URL"]
         var urls: [String?] = []
-        for group in OutcomesView.groups(from: HandoffLedger.shared.all()) {
+        for group in visibleOutcomeGroups() {
             urls.append(headerURL(group, template: template))
             if group.isTicket {
                 for branch in group.branches {
@@ -258,6 +279,58 @@ final class PanelNav: ObservableObject {
             return pullRequestByBranch[Self.outcomeKey(branch.repoRoot, branch.branch)]?.url
         }
         return nil
+    }
+
+    // Remove the selected row's records: a ticket header drops the whole group
+    // (every branch); a branch sub-row / branch-only header drops just that
+    // branch. Matched by (repoRoot, branch), which lives on each record.
+    func dismissSelectedOutcome() {
+        let records = HandoffLedger.shared.all()
+        let rowKeys = branchKeysForRows(visibleOutcomeGroups())
+        guard !rowKeys.isEmpty else { return }
+        let index = min(max(0, outcomeSelectedIndex), rowKeys.count - 1)
+        let targets = Set(rowKeys[index])
+        guard !targets.isEmpty else { return }
+        let ids = records
+            .filter { targets.contains(Self.outcomeKey($0.repoRoot, $0.branch)) }
+            .map(\.id)
+        HandoffLedger.shared.remove(ids: ids)
+        let newCount = outcomeRowCount()
+        if outcomeSelectedIndex >= newCount { outcomeSelectedIndex = max(0, newCount - 1) }
+        handoffsRevision += 1
+    }
+
+    // Per-row branch keys in render order, matching outcomeRowCount: a header
+    // (ticket → all its branches; branch-only → its one), then a ticket group's
+    // branch sub-rows.
+    private func branchKeysForRows(_ groups: [TicketGroup]) -> [[String]] {
+        var rows: [[String]] = []
+        for group in groups {
+            rows.append(group.branches.map { Self.outcomeKey($0.repoRoot, $0.branch) })
+            if group.isTicket {
+                rows.append(contentsOf: group.branches.map { [Self.outcomeKey($0.repoRoot, $0.branch)] })
+            }
+        }
+        return rows
+    }
+
+    // Settings "Disconnect GitHub": wipe the local token + PR state, then open
+    // GitHub's authorized-apps page so the user can fully revoke there too
+    // (clearing locally stops us using it but doesn't revoke server-side).
+    func disconnectGithub() {
+        GitHubAuth.clearToken()
+        githubSignedIn = false
+        githubSignIn = .idle
+        pullRequestByBranch = [:]
+        if let url = URL(string: "https://github.com/settings/applications") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    func toggleHideShipped() {
+        hideShippedTickets.toggle()
+        ConfigFile.write(key: "STACKNUDGE_HIDE_SHIPPED",
+                         value: hideShippedTickets ? "true" : "false")
     }
     // Usage tab: which connected client's quota is shown (index into
     // availableUsageClients). ↑/↓ move it; read through clampedUsageClientIndex
@@ -431,13 +504,13 @@ final class PanelNav: ObservableObject {
     // when the offset is 1.
     var updateRowOffset: Int { updateAvailable != nil ? 1 : 0 }
 
-    // 30 rows in the body: hotkey (1) + Toggles (4) + Widget (4) + Sounds (3)
+    // 32 rows in the body: hotkey (1) + Toggles (4) + Widget (4) + Sounds (3)
     // + Voice (2 — Voice + Speed, or 1 Download row with an unused index 14)
-    // + Usage (6) + Tickets (1) + Events (1) + Actions (7) = indices 0…29. Must
+    // + Usage (6) + Tickets (3) + Events (1) + Actions (7) = indices 0…31. Must
     // be kept in sync with the row(...) calls in Settings.swift and the case
     // bodies in applyCycle/activate; off-by-one here makes the last rows wrap to
     // 0 on the down-arrow.
-    var rowCount: Int { 30 + updateRowOffset }
+    var rowCount: Int { 32 + updateRowOffset }
 
     // Row layout (kept in one place so the controller, view, and indexing
     // logic all agree on what each row index means). When updateAvailable
@@ -464,15 +537,17 @@ final class PanelNav: ObservableObject {
     //  18  Poll frequency        cycle
     //  19  Context alert at      cycle       (per-session token thresholds)
     //  20  Show remaining        toggle      (invert gauge readout: 70% left vs 30% used)
-    //  21  GitHub PR links       toggle      (opt-in gh PR/CI linking; STACKNUDGE_GITHUB)
-    //  22  History per session   cycle
-    //  23  Edit phrases…         action
-    //  24  Check permissions…    action
-    //  25  Open config file…     action
-    //  26  View release notes…   action
-    //  27  Check for updates…    action
-    //  28  Uninstall stack-nudge action
-    //  29  Quit panel            action
+    //  21  GitHub PR links       toggle      (opt-in PR/CI linking; STACKNUDGE_GITHUB)
+    //  22  Hide shipped          toggle      (drop merged groups; STACKNUDGE_HIDE_SHIPPED)
+    //  23  Disconnect GitHub…    action      (enabled when signed in)
+    //  24  History per session   cycle
+    //  25  Edit phrases…         action
+    //  26  Check permissions…    action
+    //  27  Open config file…     action
+    //  28  View release notes…   action
+    //  29  Check for updates…    action
+    //  30  Uninstall stack-nudge action
+    //  31  Quit panel            action
 
     // MARK: - Disk I/O
 
@@ -509,6 +584,7 @@ final class PanelNav: ObservableObject {
         voice           = config["STACKNUDGE_VOICE_NAME"]       ?? "af_aoede"
         voiceSpeed      = Double(config["STACKNUDGE_VOICE_SPEED"] ?? "") ?? 1.1
         githubLinkingEnabled = ConfigFile.bool(config, "STACKNUDGE_GITHUB", default: false)
+        hideShippedTickets = ConfigFile.bool(config, "STACKNUDGE_HIDE_SHIPPED", default: false)
         githubSignedIn = GitHubAuth.token() != nil
         quotaTrackingEnabled = ConfigFile.bool(config, "STACKNUDGE_QUOTA_TRACKING", default: true)
         quotaAlertsEnabled   = ConfigFile.bool(config, "STACKNUDGE_QUOTA_ALERTS",   default: true)
@@ -722,13 +798,14 @@ final class PanelNav: ObservableObject {
             } else {
                 startVoiceModelDownload()
             }
-        case 23: actions?.editPhrases()
-        case 24: actions?.checkPermissions()
-        case 25: actions?.openConfig()
-        case 26: actions?.openReleaseNotes()
-        case 27: actions?.checkForUpdates()
-        case 28: actions?.beginUninstall()
-        case 29: actions?.quit()
+        case 23: disconnectGithub()
+        case 25: actions?.editPhrases()
+        case 26: actions?.checkPermissions()
+        case 27: actions?.openConfig()
+        case 28: actions?.openReleaseNotes()
+        case 29: actions?.checkForUpdates()
+        case 30: actions?.beginUninstall()
+        case 31: actions?.quit()
         default: applyCycle(forward: true)
         }
     }
@@ -902,6 +979,8 @@ final class PanelNav: ObservableObject {
         case 21:
             toggleGithubLinking()
         case 22:
+            toggleHideShipped()
+        case 24:
             let list = Self.eventsPerSessionOptions
             let idx = list.firstIndex(of: eventsPerSession) ?? 1
             let next = forward ? (idx + 1) % list.count : (idx - 1 + list.count) % list.count

--- a/panel/Settings.swift
+++ b/panel/Settings.swift
@@ -85,21 +85,23 @@ struct SettingsView: View {
                         }
 
                         section("Tickets") {
-                            row(21 + off, label: "GitHub PR links", kind: .toggle, value: nav.githubLinkingEnabled ? "On" : "Off")
+                            row(21 + off, label: "GitHub PR links",  kind: .toggle, value: nav.githubLinkingEnabled ? "On" : "Off")
+                            row(22 + off, label: "Hide shipped",     kind: .toggle, value: nav.hideShippedTickets ? "On" : "Off", enabled: nav.githubLinkingEnabled)
+                            row(23 + off, label: "Disconnect GitHub…", kind: .action, value: nav.githubSignedIn ? "Signed in" : "", enabled: nav.githubSignedIn)
                         }
 
                         section("Events") {
-                            row(22 + off, label: "History per session", kind: .cycle, value: "\(nav.eventsPerSession)")
+                            row(24 + off, label: "History per session", kind: .cycle, value: "\(nav.eventsPerSession)")
                         }
 
                         section("Actions") {
-                            row(23 + off, label: "Edit phrases…",         kind: .action, value: "")
-                            row(24 + off, label: "Check permissions…",    kind: .action, value: "")
-                            row(25 + off, label: "Open config file…",     kind: .action, value: "")
-                            row(26 + off, label: "View release notes…",   kind: .action, value: "")
-                            row(27 + off, label: "Check for updates…",    kind: .action, value: checkForUpdatesStatus)
-                            row(28 + off, label: "Uninstall StackNudge…", kind: .action, value: "")
-                            row(29 + off, label: "Quit panel",            kind: .action, value: "")
+                            row(25 + off, label: "Edit phrases…",         kind: .action, value: "")
+                            row(26 + off, label: "Check permissions…",    kind: .action, value: "")
+                            row(27 + off, label: "Open config file…",     kind: .action, value: "")
+                            row(28 + off, label: "View release notes…",   kind: .action, value: "")
+                            row(29 + off, label: "Check for updates…",    kind: .action, value: checkForUpdatesStatus)
+                            row(30 + off, label: "Uninstall StackNudge…", kind: .action, value: "")
+                            row(31 + off, label: "Quit panel",            kind: .action, value: "")
                         }
 
                         aboutFooter


### PR DESCRIPTION
## Summary

Lifecycle controls for the Tickets tab: remove unwanted rows by hand, age out
stale ones automatically, optionally hide shipped work, and disconnect GitHub.

## Changes

- **Dismiss (⌫)** — select a row (↑/↓) in the Tickets tab and press Delete: a
  ticket header drops the whole group (every branch), a branch sub-row /
  branch-only header drops just that branch. `HandoffLedger.remove(ids:)`
  deletes the matching session records; selection re-clamps.
- **Prune on launch** — the 90-day / 1000-row retention now runs at startup
  too (previously only on a new capture), so an idle ledger still ages out.
- **Hide shipped** — Settings → Tickets toggle (`STACKNUDGE_HIDE_SHIPPED`):
  drops a group once every branch reads `merged`, keeping the tab on in-flight
  work. A single `visibleOutcomeGroups()` is the source of truth so the view
  and the keyboard indexing never disagree.
- **Disconnect GitHub** — Settings → Tickets action (enabled when signed in):
  wipes the Keychain token + PR chips, signs out, and opens
  `github.com/settings/applications` so the token can be revoked server-side
  too (clearing locally stops us using it but doesn't revoke it).
- Settings list renumbered for the two new Tickets rows (rowCount 30 → 32;
  `applyCycle` / `activate` cases shifted in lockstep).

## Testing

- `./build.sh` → Build complete.
- `HandoffLedgerTests` — remove-by-id + prune-on-init (run in CI).
- Row-index alignment validated via a standalone `swiftc` harness (12/12):
  `outcomeRowCount` / dismiss targets / row ids / the hide-shipped filter all
  stay aligned, with and without hide-shipped.

## Related issues

Builds on #88 (GitHub PR linking, merged) and the Tickets tab (#86).
