### PR TITLE
chore(): polish pass & extract dupe methods

### DIFF
--- a/Tests/StackNudgePanelCoreTests/FormattingTests.swift
+++ b/Tests/StackNudgePanelCoreTests/FormattingTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// TokenFormat is the shared abbreviated-count formatter (was duplicated across
+// CompactView / Sessions / OutcomesView).
+final class FormattingTests: XCTestCase {
+
+    func test_short_underThousand() {
+        XCTAssertEqual(TokenFormat.short(0), "0")
+        XCTAssertEqual(TokenFormat.short(42), "42")
+        XCTAssertEqual(TokenFormat.short(999), "999")
+    }
+
+    func test_short_thousands_roundedToK() {
+        XCTAssertEqual(TokenFormat.short(1_000), "1K")
+        XCTAssertEqual(TokenFormat.short(1_499), "1K")
+        XCTAssertEqual(TokenFormat.short(1_500), "2K")
+        XCTAssertEqual(TokenFormat.short(218_000), "218K")
+    }
+
+    func test_short_millions_oneDecimal() {
+        XCTAssertEqual(TokenFormat.short(1_000_000), "1.0M")
+        XCTAssertEqual(TokenFormat.short(1_900_000), "1.9M")
+    }
+}

--- a/build.sh
+++ b/build.sh
@@ -219,50 +219,12 @@ mkdir -p build
 # every run.
 touch build/.metadata_never_index
 
+# Sources are globbed (mirrors Package.swift's `sources: ["panel","shared"]`)
+# so new files are picked up automatically — no hand-maintained list to drift.
 build_app "$APP" "stack-nudge" \
   "panel/Info.plist" "notifier/Icon.icns" "13.0" \
-  panel/main.swift \
-  panel/Config.swift \
-  panel/Hotkey.swift \
-  panel/EventStore.swift \
-  panel/EventListener.swift \
-  panel/Panel.swift \
-  panel/PanelNav.swift \
-  panel/Components.swift \
-  panel/Speaker.swift \
-  panel/MenuBar.swift \
-  panel/Permissions.swift \
-  panel/Settings.swift \
-  panel/ProcessOutput.swift \
-  panel/TerminalIntegration.swift \
-  panel/ITerm2Integration.swift \
-  panel/TerminalAppIntegration.swift \
-  panel/VSCodeIntegration.swift \
-  panel/EnvVarTerminalIntegration.swift \
-  panel/SessionPersistence.swift \
-  panel/SessionStore.swift \
-  panel/SessionUsage.swift \
-  panel/CodexUsage.swift \
-  panel/AntigravityLocalServer.swift \
-  panel/AntigravityUsage.swift \
-  panel/TicketAttribution.swift \
-  panel/GitSnapshot.swift \
-  panel/OutcomeWatcher.swift \
-  panel/GitHubAPI.swift \
-  panel/GitHubAuth.swift \
-  panel/Handoff.swift \
-  panel/HandoffLedger.swift \
-  panel/OutcomesView.swift \
-  panel/Sessions.swift \
-  panel/CompactView.swift \
-  panel/TranscriptStats.swift \
-  panel/CodexTranscriptStats.swift \
-  panel/ModelLimits.swift \
-  panel/Phrases.swift \
-  panel/UpdateChecker.swift \
-  panel/Updater.swift \
-  panel/Bootstrap.swift \
-  shared/AppActivator.swift \
+  panel/*.swift \
+  shared/*.swift \
   -framework Foundation -framework AppKit -framework SwiftUI -framework Carbon \
   -framework UserNotifications
 echo "  Built $APP"

--- a/panel/CompactView.swift
+++ b/panel/CompactView.swift
@@ -136,7 +136,7 @@ struct CompactView: View {
                     Text("·")
                         .font(.system(size: 10))
                         .foregroundStyle(.tertiary)
-                    Text(Self.formatTokens(stats.tokens))
+                    Text(TokenFormat.short(stats.tokens))
                         .font(.system(size: 10, weight: .medium).monospacedDigit())
                         .foregroundStyle(.secondary)
                 }
@@ -160,7 +160,7 @@ struct CompactView: View {
                         .lineLimit(1)
                         .fixedSize()
                 } else {
-                    Text(Self.relative.localizedString(for: recent.timestamp, relativeTo: Date()))
+                    Text(RelativeTime.string(recent.timestamp, style: .short))
                         .font(.system(size: 10).monospacedDigit())
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
@@ -201,7 +201,7 @@ struct CompactView: View {
                 .font(.system(size: 10))
                 .foregroundStyle(.tertiary)
             if let stats = transcriptStats(for: session) {
-                Text(Self.formatTokens(stats.tokens))
+                Text(TokenFormat.short(stats.tokens))
                     .font(.system(size: 10, weight: .medium).monospacedDigit())
                     .foregroundStyle(.secondary)
             } else {
@@ -415,21 +415,7 @@ struct CompactView: View {
         return Color(red: 0.4, green: 0.85, blue: 1.0)
     }
 
-    private static let relative: RelativeDateTimeFormatter = {
-        let f = RelativeDateTimeFormatter()
-        f.unitsStyle = .short
-        return f
-    }()
 
-    private static func formatTokens(_ n: Int) -> String {
-        if n >= 1_000_000 {
-            return String(format: "%.1fM", Double(n) / 1_000_000)
-        }
-        if n >= 1_000 {
-            return "\(Int((Double(n) / 1_000).rounded()))K"
-        }
-        return "\(n)"
-    }
 
     private static func shortDuration(until date: Date) -> String {
         let s = max(0, Int(date.timeIntervalSinceNow))

--- a/panel/Formatting.swift
+++ b/panel/Formatting.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+// Shared number formatting so the same token rendering isn't re-implemented per
+// view. Callers append " tokens" etc. as needed.
+enum TokenFormat {
+    // Abbreviated count: "1.2M" / "218K" / "42".
+    static func short(_ count: Int) -> String {
+        if count >= 1_000_000 { return String(format: "%.1fM", Double(count) / 1_000_000) }
+        if count >= 1_000 { return "\(Int((Double(count) / 1_000).rounded()))K" }
+        return "\(count)"
+    }
+}
+
+// Shared relative-time strings ("5m ago", "in 3 days") with per-style cached
+// formatters (these were re-created in CompactView / Sessions / SessionUsage /
+// Panel). Formatters are reused on the main thread, matching prior usage.
+enum RelativeTime {
+    private static let shortStyle      = make(.short)
+    private static let abbreviated     = make(.abbreviated)
+    private static let full            = make(.full)
+
+    private static func make(_ style: RelativeDateTimeFormatter.UnitsStyle) -> RelativeDateTimeFormatter {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = style
+        return formatter
+    }
+
+    static func string(_ date: Date,
+                       style: RelativeDateTimeFormatter.UnitsStyle = .abbreviated) -> String {
+        let formatter: RelativeDateTimeFormatter
+        switch style {
+        case .short: formatter = shortStyle
+        case .full:  formatter = full
+        default:     formatter = abbreviated
+        }
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}

--- a/panel/OutcomesView.swift
+++ b/panel/OutcomesView.swift
@@ -230,7 +230,7 @@ struct OutcomesView: View {
     // each segment is dropped when it has nothing to show.
     private func detailLine(_ group: TicketGroup) -> String {
         var parts = [Self.sessionsLabel(group.sessionCount)]
-        if group.totalTokens > 0 { parts.append("\(Self.shortTokens(group.totalTokens)) tokens") }
+        if group.totalTokens > 0 { parts.append("\(TokenFormat.short(group.totalTokens)) tokens") }
         if !group.diff.isEmpty {
             parts.append(Self.filesLabel(group.diff.filesChanged))
             if group.diff.insertions > 0 || group.diff.deletions > 0 {
@@ -244,7 +244,7 @@ struct OutcomesView: View {
     // Compact sub-row trailing: "2 sessions · 600K · 12 files".
     private func branchDetail(_ branch: BranchBreakdown) -> String {
         var parts = [Self.sessionsLabel(branch.sessionCount)]
-        if branch.totalTokens > 0 { parts.append(Self.shortTokens(branch.totalTokens)) }
+        if branch.totalTokens > 0 { parts.append(TokenFormat.short(branch.totalTokens)) }
         if branch.diff.filesChanged > 0 { parts.append(Self.filesLabel(branch.diff.filesChanged)) }
         return parts.joined(separator: " · ")
     }
@@ -491,11 +491,6 @@ struct OutcomesView: View {
         count == 1 ? "1 session" : "\(count) sessions"
     }
 
-    private static func shortTokens(_ count: Int) -> String {
-        if count >= 1_000_000 { return String(format: "%.1fM", Double(count) / 1_000_000) }
-        if count >= 1_000 { return "\(Int((Double(count) / 1_000).rounded()))K" }
-        return "\(count)"
-    }
 
     private static func filesLabel(_ count: Int) -> String {
         count == 1 ? "1 file" : "\(count) files"

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -321,11 +321,6 @@ struct EventRow: View {
     // (agent, projectPath) — render-time lookup, not ingest-time snapshot.
     @EnvironmentObject private var persistence: SessionPersistence
 
-    private static let timeFormatter: RelativeDateTimeFormatter = {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter
-    }()
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
@@ -479,9 +474,9 @@ struct EventRow: View {
     // timestamp so the user can see how long is left until the re-fire.
     private var rightTimestamp: String {
         if let until = event.snoozedUntil, until > Date() {
-            return "snoozed " + Self.timeFormatter.localizedString(for: until, relativeTo: Date())
+            return "snoozed " + RelativeTime.string(until)
         }
-        return Self.timeFormatter.localizedString(for: event.timestamp, relativeTo: Date())
+        return RelativeTime.string(event.timestamp)
     }
 
     private var glyph: String {
@@ -1345,18 +1340,10 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         }
     }
 
-    // Cached — banner posts can fire frequently in test/edge cases; avoid
-    // allocating a fresh formatter every time.
-    private static let quotaBannerFormatter: RelativeDateTimeFormatter = {
-        let f = RelativeDateTimeFormatter()
-        f.unitsStyle = .full
-        return f
-    }()
-
     private func postQuotaBanner(label: String, percent: Int, resetsAt: Date?) {
         let body: String
         if let resetsAt {
-            body = "\(percent)% used. Resets \(Self.quotaBannerFormatter.localizedString(for: resetsAt, relativeTo: Date()))."
+            body = "\(percent)% used. Resets \(RelativeTime.string(resetsAt, style: .full))."
         } else {
             body = "\(percent)% used."
         }

--- a/panel/ProcessOutput.swift
+++ b/panel/ProcessOutput.swift
@@ -18,4 +18,12 @@ enum ProcessOutput {
         task.waitUntilExit()
         return String(data: data, encoding: .utf8) ?? ""
     }
+
+    // Resolve the `gh` CLI from common install locations. A launchd-spawned app
+    // has a minimal PATH, so we probe paths directly rather than relying on env.
+    // nil ⇒ not installed (callers no-op). Used for release checks/downloads.
+    static func gh() -> String? {
+        ["/opt/homebrew/bin/gh", "/usr/local/bin/gh", "/usr/bin/gh"]
+            .first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
 }

--- a/panel/SessionUsage.swift
+++ b/panel/SessionUsage.swift
@@ -439,7 +439,7 @@ struct UsageView: View {
             ProgressView(value: min(tier.utilization, 100), total: 100)
                 .tint(barColor(tier.utilization))
             if let resets = tier.resetsAt {
-                Text("Resets \(Self.relative(.full, resets))")
+                Text("Resets \(RelativeTime.string(resets, style: .full))")
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
             }
@@ -497,27 +497,7 @@ struct UsageView: View {
         if !nav.quotaTrackingEnabled { return "Tracking off" }
         if nav.quotaSyncing { return "Syncing…" }
         guard let updated = nav.quotaLastUpdated else { return "Never synced" }
-        return "Updated \(Self.relative(.abbreviated, updated))"
-    }
-
-    // Cached so SwiftUI re-renders don't allocate a fresh formatter on
-    // every call. Two styles cover all current uses (full for "Resets in
-    // 3 days", abbreviated for footer "Updated 5s ago").
-    private static let fullFormatter: RelativeDateTimeFormatter = {
-        let f = RelativeDateTimeFormatter()
-        f.unitsStyle = .full
-        return f
-    }()
-    private static let abbreviatedFormatter: RelativeDateTimeFormatter = {
-        let f = RelativeDateTimeFormatter()
-        f.unitsStyle = .abbreviated
-        return f
-    }()
-
-    private static func relative(_ style: RelativeDateTimeFormatter.UnitsStyle,
-                                 _ date: Date) -> String {
-        let formatter = (style == .abbreviated) ? abbreviatedFormatter : fullFormatter
-        return formatter.localizedString(for: date, relativeTo: Date())
+        return "Updated \(RelativeTime.string(updated, style: .abbreviated))"
     }
 
 }

--- a/panel/Sessions.swift
+++ b/panel/Sessions.swift
@@ -173,11 +173,6 @@ private struct SessionRow: View {
 
     @FocusState private var nameFieldFocused: Bool
 
-    private static let timeFormatter: RelativeDateTimeFormatter = {
-        let f = RelativeDateTimeFormatter()
-        f.unitsStyle = .abbreviated
-        return f
-    }()
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
@@ -313,7 +308,7 @@ private struct SessionRow: View {
         // varies (Opus/Sonnet on 1M context; Haiku on 200K; Sonnet 1M is
         // opt-in beta), and there's no reliable way to disambiguate from
         // the model ID. Showing the model name keeps the row honest.
-        let tokens = Self.formatTokens(stats.tokens)
+        let tokens = "\(TokenFormat.short(stats.tokens)) tokens"
         if let model = stats.model {
             return "\(tokens) · \(Self.shortModel(model))"
         }
@@ -332,12 +327,6 @@ private struct SessionRow: View {
         return s
     }
 
-    private static func formatTokens(_ n: Int) -> String {
-        if n >= 1_000 {
-            return String(format: "%.0fK tokens", Double(n) / 1_000.0)
-        }
-        return "\(n) tokens"
-    }
 
     private var nudgeRow: some View {
         HStack(spacing: 6) {
@@ -428,12 +417,12 @@ private struct SessionRow: View {
             // you how long ago the process was spawned.
             let head = session.liveStatus ?? "active"
             if let updated = session.lastActivityAt {
-                return "\(head) · \(Self.timeFormatter.localizedString(for: updated, relativeTo: Date()))"
+                return "\(head) · \(RelativeTime.string(updated))"
             }
             let elapsed = session.elapsed?.trimmingCharacters(in: .whitespaces) ?? ""
             return elapsed.isEmpty ? head : "\(head) · \(elapsed)"
         case .finished(let at):
-            return "ended " + Self.timeFormatter.localizedString(for: at, relativeTo: Date())
+            return "ended " + RelativeTime.string(at)
         }
     }
 
@@ -446,7 +435,7 @@ private struct SessionRow: View {
     private var nudgeSummary: String {
         let countLabel = activeNudgeCount == 1 ? "1 nudge" : "\(activeNudgeCount) nudges"
         guard let last = lastNudgeAt else { return countLabel }
-        let when = Self.timeFormatter.localizedString(for: last, relativeTo: Date())
+        let when = RelativeTime.string(last)
         return "\(countLabel) · last \(when)"
     }
 }

--- a/panel/UpdateChecker.swift
+++ b/panel/UpdateChecker.swift
@@ -180,10 +180,7 @@ final class UpdateChecker {
     // authenticated, network issue, repo not accessible) yields a nil result
     // and a no-op upstream.
     private func fetchViaGH(apiPath: String, completion: @escaping ([String: Any]?) -> Void) {
-        let candidates = ["/opt/homebrew/bin/gh", "/usr/local/bin/gh", "/usr/bin/gh"]
-        guard let ghPath = candidates.first(where: {
-            FileManager.default.isExecutableFile(atPath: $0)
-        }) else {
+        guard let ghPath = ProcessOutput.gh() else {
             completion(nil)
             return
         }

--- a/panel/Updater.swift
+++ b/panel/Updater.swift
@@ -286,10 +286,7 @@ final class Updater {
 
     // gh CLI fallback for private repos. Mirrors UpdateChecker.fetchViaGH.
     private func ghFetchJSON(_ apiPath: String) -> [String: Any]? {
-        let candidates = ["/opt/homebrew/bin/gh", "/usr/local/bin/gh", "/usr/bin/gh"]
-        guard let ghPath = candidates.first(where: {
-            FileManager.default.isExecutableFile(atPath: $0)
-        }) else { return nil }
+        guard let ghPath = ProcessOutput.gh() else { return nil }
         let task = Process()
         task.executableURL = URL(fileURLWithPath: ghPath)
         task.arguments = ["api", apiPath]


### PR DESCRIPTION
## Summary

Deduplication/polish pass: extracts the token-count and relative-time formatting helpers that were copy-pasted across views into a shared `Formatting.swift`, extracts the duplicated `gh` CLI path-probing into `ProcessOutput`, and replaces `build.sh`'s hand-maintained 40-file source list with globs so new files can't be silently missed.

## Changes

- **New `panel/Formatting.swift`** with two shared helpers:
  - `TokenFormat.short` — abbreviated counts ("42" / "218K" / "1.2M"), replacing three near-identical private implementations in `CompactView`, `OutcomesView`, and `Sessions`.
  - `RelativeTime.string` — relative-time strings with cached per-style `RelativeDateTimeFormatter`s, replacing five separately cached formatters in `CompactView`, `Panel` (×2), `SessionUsage`, and `Sessions`.
- **`ProcessOutput.gh()`** — the `gh` binary path probing (`/opt/homebrew/bin` → `/usr/local/bin` → `/usr/bin`) was duplicated in `UpdateChecker` and `Updater`; both now call the shared helper.
- **`build.sh`** — the app target now compiles `panel/*.swift` + `shared/*.swift` (mirroring `Package.swift`) instead of a hand-maintained list of 40 files, so adding a source file no longer requires touching the build script.
- **Tests** — new `FormattingTests` covering `TokenFormat.short` boundaries (sub-1K, K rounding, M with one decimal).

Minor user-visible side effect: session rows previously had no "M" tier (a large session showed e.g. "1500K tokens"); they now use the shared format ("1.5M tokens"), consistent with the other views.

## Testing

- CI: `swift build` (arm64 + x86_64), `swift test` (including the new `FormattingTests`), and shellcheck on `build.sh` all pass.
- All call sites preserve their previous formatter unit styles (`.short` in CompactView, `.abbreviated` in Sessions/Panel rows, `.full` for quota banner/reset lines), so rendered strings are unchanged apart from the session-row "M" tier noted above.
