### PR TITLE
fix(): include multiple branches per session

### DIFF
--- a/Tests/StackNudgePanelCoreTests/HandoffLedgerTests.swift
+++ b/Tests/StackNudgePanelCoreTests/HandoffLedgerTests.swift
@@ -49,6 +49,24 @@ final class HandoffLedgerTests: XCTestCase {
         XCTAssertEqual(Set(ids), ["s3", "s4"])  // oldest two pruned
     }
 
+    func test_sessionBranchKey_oneRowPerBranch() {
+        let ledger = HandoffLedger(path: tempURL())
+        // Same session, two branches → two rows (effort kept per branch).
+        ledger.upsert(sessionID: "s1", branch: "eng-75/a", agent: "claude") { $0.branch = "eng-75/a" }
+        ledger.upsert(sessionID: "s1", branch: "eng-75/b", agent: "claude") { $0.branch = "eng-75/b" }
+        XCTAssertEqual(Set(ledger.all().compactMap(\.branch)), ["eng-75/a", "eng-75/b"])
+        XCTAssertEqual(ledger.all().count, 2)
+    }
+
+    func test_sessionBranchKey_sameBranchMerges() {
+        let ledger = HandoffLedger(path: tempURL())
+        // Same session + same branch (e.g. a resume) → one row, last write wins.
+        ledger.upsert(sessionID: "s1", branch: "eng-75/a", agent: "claude") { $0.contextTokens = 100 }
+        ledger.upsert(sessionID: "s1", branch: "eng-75/a", agent: "claude") { $0.contextTokens = 250 }
+        XCTAssertEqual(ledger.all().count, 1)
+        XCTAssertEqual(ledger.all().first?.contextTokens, 250)
+    }
+
     func test_remove_dropsByID() {
         let ledger = HandoffLedger(path: tempURL())
         ledger.upsert(id: "s1", agent: "codex") { $0.ticket = "ENG-1" }

--- a/panel/Handoff.swift
+++ b/panel/Handoff.swift
@@ -6,7 +6,7 @@ import Foundation
 // fields are the basis for the per-ticket usage rollup; risk/outcome/PR fields
 // are added by later iterations (RiskClassifier, OutcomeWatcher).
 struct HandoffRecord: Codable, Identifiable, Equatable {
-    let id: String              // agent session id — the upsert key
+    let id: String              // upsert key "<session id>\n<branch>" (per session+branch)
     let agent: String           // canonical agent: "claude" | "codex" | "agy"
     var repoRoot: String?
     var branch: String?

--- a/panel/HandoffLedger.swift
+++ b/panel/HandoffLedger.swift
@@ -47,6 +47,18 @@ final class HandoffLedger {
         persist()
     }
 
+    // Key by session *and* branch so a session that moves across branches keeps
+    // a row per branch — capturing all the effort spent on each — instead of
+    // overwriting as it switches. A resume on the same branch still merges.
+    func upsert(sessionID: String, branch: String?, agent: String,
+                _ merge: (inout HandoffRecord) -> Void) {
+        upsert(id: Self.key(sessionID: sessionID, branch: branch), agent: agent, merge)
+    }
+
+    static func key(sessionID: String, branch: String?) -> String {
+        "\(sessionID)\n\(branch ?? "")"
+    }
+
     // Drop records by session id (manual dismiss from the Tickets tab).
     func remove(ids: [String]) {
         guard !ids.isEmpty else { return }

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -1511,7 +1511,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
             let stats = transcriptPath.flatMap { TranscriptReader.read(path: $0) }
             let snapshot = GitSnapshot.capture(cwd: cwd) { Self.gitValue($0, $1) }
             DispatchQueue.main.async { [weak self] in
-                HandoffLedger.shared.upsert(id: sessionID, agent: agent) { record in
+                HandoffLedger.shared.upsert(sessionID: sessionID, branch: branch, agent: agent) { record in
                     record.repoRoot = repoRoot
                     record.branch = branch
                     // Re-derive every Stop (not derive-once): git state evolves


### PR DESCRIPTION
## Summary

The handoff ledger keyed rows by **session id alone**, so a session that moved
across branches *overwrote* its earlier branch — only the latest survived, and
a ticket lost the rest of its branches in the Tickets tab. Key by **session +
branch** instead, so every branch a session works on is captured and rolls up
under its ticket.

## Changes

- `HandoffLedger.upsert(sessionID:branch:agent:)` keys rows by
  `"<session id>\n<branch>"` (`key(sessionID:branch:)`):
  - a session switching branches now keeps **a row per branch** (the effort on
    each is preserved, not overwritten),
  - a **resume on the same branch** still merges (same key),
  - branches from different sessions still aggregate under the branch/ticket.
- `captureHandoff` calls the new method; `HandoffRecord.id`'s comment updated
  to reflect the composite key.

## Testing

- `./build.sh` → Build complete.
- `HandoffLedgerTests`: `test_sessionBranchKey_oneRowPerBranch` (distinct
  branches → 2 rows) and `test_sessionBranchKey_sameBranchMerges` (same branch
  → one row, last write wins). Run in CI.

## Notes

Records captured before this change (session-id-only key) coexist and age out
(90d retention). A session that straddled the upgrade may briefly show one
extra "session" for a branch until the old row ages out; `rm
~/.stack-nudge/handoffs.jsonl` resets cleanly if preferred.

## Related issues

Builds on the Tickets tab + handoff ledger (#84, #86); independent of the
polish-pass PR.
