### PR TITLE
 feat(settings): keep panel open when empty + data-driven Settings rows

### DIFF
--- a/Tests/StackNudgePanelCoreTests/SettingsRowTests.swift
+++ b/Tests/StackNudgePanelCoreTests/SettingsRowTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// The Settings list is now data-driven: one ordered `settingsRows` array feeds
+// both rendering and keyboard nav. These pin the order, the conditional rows
+// (update prepend, voice collapse), and the index ⇄ row round-trip the view and
+// dispatch both rely on.
+@MainActor
+final class SettingsRowTests: XCTestCase {
+
+    func test_defaultOrder() {
+        let nav = PanelNav()
+        let rows = nav.settingsRows
+        XCTAssertEqual(rows.first, .hotkey)            // no update pending
+        XCTAssertEqual(rows.last, .quit)
+        XCTAssertEqual(nav.rowCount, rows.count)
+    }
+
+    func test_keepOpenWhenEmpty_followsPinPanel() {
+        let nav = PanelNav()
+        let rows = nav.settingsRows
+        let pin = rows.firstIndex(of: .pinPanel)
+        XCTAssertNotNil(pin)
+        XCTAssertEqual(rows[pin! + 1], .keepOpenWhenEmpty)
+    }
+
+    func test_voiceCollapsesUntilCached() {
+        let nav = PanelNav()
+        nav.voiceModelCached = false
+        XCTAssertTrue(nav.settingsRows.contains(.downloadVoiceModel))
+        XCTAssertFalse(nav.settingsRows.contains(.voice))
+
+        nav.voiceModelCached = true
+        XCTAssertTrue(nav.settingsRows.contains(.voice))
+        XCTAssertTrue(nav.settingsRows.contains(.voiceSpeed))
+        XCTAssertFalse(nav.settingsRows.contains(.downloadVoiceModel))
+    }
+
+    func test_updateRow_prependedWhenAvailable() {
+        let nav = PanelNav()
+        XCTAssertFalse(nav.settingsRows.contains(.update))
+        nav.updateAvailable = "1.2.3"
+        XCTAssertEqual(nav.settingsRows.first, .update)
+        XCTAssertEqual(nav.index(of: .update), 0)
+    }
+
+    func test_indexRowRoundTrip() {
+        let nav = PanelNav()
+        for row in nav.settingsRows {
+            nav.selectedSettingIndex = nav.index(of: row)
+            XCTAssertEqual(nav.selectedRow, row)
+        }
+    }
+}

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -2552,7 +2552,9 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     private func dismissSelected() {
         guard let id = store.selectedID else { return }
         store.remove(id: id)
-        if store.events.isEmpty { hidePanel() }
+        // Auto-close once the list empties, unless the user opted to keep the
+        // panel open (Settings → Keep open when empty).
+        if store.events.isEmpty, !nav.keepOpenWhenEmpty { hidePanel() }
     }
 
     // MARK: - Sessions actions

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -80,6 +80,23 @@ enum GithubSignIn: Equatable {
     case failed(String)
 }
 
+// Every Settings row, as a stable identity rather than a numeric index. The
+// ordered list (PanelNav.settingsRows) is the single source of truth for both
+// rendering and keyboard nav, so adding/removing/reordering a row is a one-line
+// change with no renumbering — and the applyCycle switch over this is
+// exhaustive, so the compiler flags any row left unhandled.
+enum SettingsRow: Hashable {
+    case update, hotkey
+    case banner, muteWhenFocused, pinPanel, keepOpenWhenEmpty, launchAtLogin
+    case widget, widgetCorner, widgetOpacity, mascot
+    case soundEnabled, agentDoneSound, permissionSound
+    case voiceEnabled, voice, voiceSpeed, downloadVoiceModel
+    case quotaTracking, quotaAlerts, alertThreshold, pollFrequency, contextAlert, showRemaining
+    case githubLinks, hideShipped, disconnectGithub
+    case historyPerSession
+    case editPhrases, checkPermissions, openConfig, releaseNotes, checkUpdates, uninstall, quit
+}
+
 struct SettingsActions {
     let checkPermissions: () -> Void
     let openConfig:       () -> Void
@@ -115,6 +132,9 @@ final class PanelNav: ObservableObject {
     @Published var voiceEnabled:    Bool = false
     @Published var muteWhenFocused: Bool = true
     @Published var panelPinned:     Bool = true
+    // When true, clearing the last event leaves the panel open instead of
+    // auto-hiding (STACKNUDGE_KEEP_OPEN_WHEN_EMPTY). Default off = prior behaviour.
+    @Published var keepOpenWhenEmpty: Bool = false
     @Published var launchAtLogin:   Bool = true
     @Published var soundStop:       String = "Glass"
     @Published var soundPermission: String = "Ping"
@@ -502,52 +522,40 @@ final class PanelNav: ObservableObject {
     // +1 when an update is available and the "Update to vX.Y.Z" row is
     // pinned at the top of the Settings list. All other indices shift down
     // when the offset is 1.
-    var updateRowOffset: Int { updateAvailable != nil ? 1 : 0 }
+    // Settings rows in render order — the single source of truth for both the
+    // view (Settings.swift looks up indices from this) and keyboard nav
+    // (selectedRow indexes into it). The conditionals keep render + dispatch in
+    // sync automatically: the update row appears only when an update is
+    // pending, and Voice collapses to a single Download row until the model is
+    // cached — no hand-maintained indices, no off-by-one to chase.
+    var settingsRows: [SettingsRow] {
+        var rows: [SettingsRow] = []
+        if updateAvailable != nil { rows.append(.update) }
+        rows += [.hotkey,
+                 .banner, .muteWhenFocused, .pinPanel, .keepOpenWhenEmpty, .launchAtLogin,
+                 .widget, .widgetCorner, .widgetOpacity, .mascot,
+                 .soundEnabled, .agentDoneSound, .permissionSound,
+                 .voiceEnabled]
+        rows += voiceModelCached ? [.voice, .voiceSpeed] : [.downloadVoiceModel]
+        rows += [.quotaTracking, .quotaAlerts, .alertThreshold, .pollFrequency, .contextAlert, .showRemaining,
+                 .githubLinks, .hideShipped, .disconnectGithub,
+                 .historyPerSession,
+                 .editPhrases, .checkPermissions, .openConfig, .releaseNotes, .checkUpdates, .uninstall, .quit]
+        return rows
+    }
 
-    // 32 rows in the body: hotkey (1) + Toggles (4) + Widget (4) + Sounds (3)
-    // + Voice (2 — Voice + Speed, or 1 Download row with an unused index 14)
-    // + Usage (6) + Tickets (3) + Events (1) + Actions (7) = indices 0…31. Must
-    // be kept in sync with the row(...) calls in Settings.swift and the case
-    // bodies in applyCycle/activate; off-by-one here makes the last rows wrap to
-    // 0 on the down-arrow.
-    var rowCount: Int { 32 + updateRowOffset }
+    var rowCount: Int { settingsRows.count }
 
-    // Row layout (kept in one place so the controller, view, and indexing
-    // logic all agree on what each row index means). When updateAvailable
-    // is non-nil, row 0 becomes "Update to vX.Y.Z" and every following row
-    // shifts down by one — use `index - updateRowOffset` when matching:
-    //   0  Hotkey                hotkey-record
-    //   1  Banner notifications  toggle
-    //   2  Mute when focused     toggle
-    //   3  Pin panel             toggle
-    //   4  Launch at login       toggle
-    //   5  Widget                toggle      (gates rows 6-8; off = classic show/hide-panel mode)
-    //   6  Widget corner         cycle
-    //   7  Mascot                cycle
-    //   8  Widget opacity        cycle       (40/60/80/100%; applied window-level)
-    //   9  Sound enabled         toggle      (gates rows 10 + 11)
-    //  10  Agent done sound      cycle
-    //  11  Permission sound      cycle
-    //  12  Voice notifications   toggle      (gates rows 13 + 14)
-    //  13  Voice                 cycle       (or "Download model" action)
-    //  14  Speed                 cycle
-    //  15  Quota tracking        toggle      (master; gates rows 16-18)
-    //  16  Quota alerts          toggle
-    //  17  Alert threshold       cycle
-    //  18  Poll frequency        cycle
-    //  19  Context alert at      cycle       (per-session token thresholds)
-    //  20  Show remaining        toggle      (invert gauge readout: 70% left vs 30% used)
-    //  21  GitHub PR links       toggle      (opt-in PR/CI linking; STACKNUDGE_GITHUB)
-    //  22  Hide shipped          toggle      (drop merged groups; STACKNUDGE_HIDE_SHIPPED)
-    //  23  Disconnect GitHub…    action      (enabled when signed in)
-    //  24  History per session   cycle
-    //  25  Edit phrases…         action
-    //  26  Check permissions…    action
-    //  27  Open config file…     action
-    //  28  View release notes…   action
-    //  29  Check for updates…    action
-    //  30  Uninstall stack-nudge action
-    //  31  Quit panel            action
+    // The row the keyboard selection currently points at (clamped to range).
+    var selectedRow: SettingsRow? {
+        let rows = settingsRows
+        guard !rows.isEmpty else { return nil }
+        return rows[min(max(0, selectedSettingIndex), rows.count - 1)]
+    }
+
+    // Flat index of a row in the current layout, so Settings.swift never
+    // hard-codes a number.
+    func index(of row: SettingsRow) -> Int { settingsRows.firstIndex(of: row) ?? 0 }
 
     // MARK: - Disk I/O
 
@@ -573,6 +581,7 @@ final class PanelNav: ObservableObject {
         voiceEnabled    = ConfigFile.bool(config, "STACKNUDGE_VOICE",     default: false)
         muteWhenFocused = ConfigFile.bool(config, "STACKNUDGE_MUTE_WHEN_FOCUSED", default: true)
         panelPinned     = ConfigFile.bool(config, "STACKNUDGE_PANEL_PIN", default: true)
+        keepOpenWhenEmpty = ConfigFile.bool(config, "STACKNUDGE_KEEP_OPEN_WHEN_EMPTY", default: false)
         // Source of truth for the toggle is the plist's presence on disk
         // (Bootstrap.isLaunchAtLoginEnabled) — the config key is just a
         // mirror used for parity with the other toggles. If the two ever
@@ -759,23 +768,12 @@ final class PanelNav: ObservableObject {
 
     func selectNextRow() {
         guard rowCount > 0 else { return }
-        var next = (selectedSettingIndex + 1) % rowCount
-        // When the voice model isn't cached we collapse Voice + Speed
-        // into a single "Download voice model" action at index 7. Index 8
-        // (Speed) doesn't render; skip it during keyboard nav.
-        if !voiceModelCached, next - updateRowOffset == 9 {
-            next = (next + 1) % rowCount
-        }
-        selectedSettingIndex = next
+        selectedSettingIndex = (selectedSettingIndex + 1) % rowCount
     }
 
     func selectPrevRow() {
         guard rowCount > 0 else { return }
-        var prev = (selectedSettingIndex - 1 + rowCount) % rowCount
-        if !voiceModelCached, prev - updateRowOffset == 9 {
-            prev = (prev - 1 + rowCount) % rowCount
-        }
-        selectedSettingIndex = prev
+        selectedSettingIndex = (selectedSettingIndex - 1 + rowCount) % rowCount
     }
 
     // MARK: - Cycle / activate
@@ -783,29 +781,22 @@ final class PanelNav: ObservableObject {
     // Enter: toggles flip, cycle rows step forward, actions fire, hotkey
     // row enters record mode.
     func activate() {
-        if updateRowOffset == 1, selectedSettingIndex == 0 {
-            actions?.beginUpdate()
-            return
-        }
-        switch selectedSettingIndex - updateRowOffset {
-        case 0: startRecordingHotkey()
-        case 11 where !voiceModelCached:
-            // Pre-download state: index 11 is the "Download voice model"
-            // action, not a cycle. Enter triggers (or cancels) the
-            // download.
-            if voiceModelDownloading {
-                cancelVoiceModelDownload()
-            } else {
-                startVoiceModelDownload()
-            }
-        case 23: disconnectGithub()
-        case 25: actions?.editPhrases()
-        case 26: actions?.checkPermissions()
-        case 27: actions?.openConfig()
-        case 28: actions?.openReleaseNotes()
-        case 29: actions?.checkForUpdates()
-        case 30: actions?.beginUninstall()
-        case 31: actions?.quit()
+        switch selectedRow {
+        case .update: actions?.beginUpdate()
+        case .hotkey: startRecordingHotkey()
+        case .downloadVoiceModel:
+            // The pre-download row is an action: Enter triggers (or cancels)
+            // the model download.
+            if voiceModelDownloading { cancelVoiceModelDownload() } else { startVoiceModelDownload() }
+        case .disconnectGithub: disconnectGithub()
+        case .editPhrases:      actions?.editPhrases()
+        case .checkPermissions: actions?.checkPermissions()
+        case .openConfig:       actions?.openConfig()
+        case .releaseNotes:     actions?.openReleaseNotes()
+        case .checkUpdates:     actions?.checkForUpdates()
+        case .uninstall:        actions?.beginUninstall()
+        case .quit:             actions?.quit()
+        // Toggles + cycles flip/step on Enter, same as left/right.
         default: applyCycle(forward: true)
         }
     }
@@ -828,6 +819,12 @@ final class PanelNav: ObservableObject {
         }
     }
 
+    func toggleKeepOpenWhenEmpty() {
+        keepOpenWhenEmpty.toggle()
+        ConfigFile.write(key: "STACKNUDGE_KEEP_OPEN_WHEN_EMPTY",
+                         value: keepOpenWhenEmpty ? "true" : "false")
+    }
+
     // Settings "GitHub PR links" toggle. Persists STACKNUDGE_GITHUB; on enable
     // kicks an immediate PR fetch so chips appear without waiting for the next
     // tab visit, on disable drops cached PR state so chips revert to the local
@@ -845,23 +842,20 @@ final class PanelNav: ObservableObject {
     }
 
     private func applyCycle(forward: Bool) {
-        // Update row (when present at index 0) treats left/right arrows the
-        // same as Enter — there's nothing to cycle, so just begin update.
-        if updateRowOffset == 1, selectedSettingIndex == 0 {
+        switch selectedRow {
+        case .update:
+            // Nothing to cycle — arrows behave like Enter.
             actions?.beginUpdate()
-            return
-        }
-        switch selectedSettingIndex - updateRowOffset {
-        case 0:
+        case .hotkey:
             // Cycle on the hotkey row also enters record mode.
             startRecordingHotkey()
-        case 1:
+        case .banner:
             bannerEnabled.toggle()
             ConfigFile.write(key: "STACKNUDGE_BANNER", value: bannerEnabled ? "true" : "false")
-        case 2:
+        case .muteWhenFocused:
             muteWhenFocused.toggle()
             ConfigFile.write(key: "STACKNUDGE_MUTE_WHEN_FOCUSED", value: muteWhenFocused ? "true" : "false")
-        case 3:
+        case .pinPanel:
             panelPinned.toggle()
             ConfigFile.write(key: "STACKNUDGE_PANEL_PIN", value: panelPinned ? "true" : "false")
             // Pin + Widget: Pin wins. Toggling Pin on from the widget pill
@@ -870,7 +864,9 @@ final class PanelNav: ObservableObject {
             if panelPinned, compactMode, !compactExpanded {
                 compactExpanded = true
             }
-        case 4:
+        case .keepOpenWhenEmpty:
+            toggleKeepOpenWhenEmpty()
+        case .launchAtLogin:
             // Optimistic UI flip; revert if launchctl fails so the toggle
             // never reports a state that disagrees with the plist on disk.
             let target = !launchAtLogin
@@ -882,112 +878,96 @@ final class PanelNav: ObservableObject {
                 FileHandle.standardError.write(Data(
                     "stack-nudge: setLaunchAtLogin(\(target)) failed: \(error)\n".utf8))
             }
-        case 5:
-            // Widget on/off. The user is in the full panel (that's where
-            // the Settings row lives). On toggle-on we set compactExpanded
-            // so the panel stays open at full size; the pill only appears
-            // when the user dismisses (Esc / focus-out). On toggle-off we
-            // clear compactExpanded so the next applyCompactLayout commits
+        case .widget:
+            // Widget on/off. On toggle-on we set compactExpanded so the panel
+            // stays open at full size; the pill only appears when the user
+            // dismisses. On toggle-off we clear it so the next layout commits
             // the saved full-panel frame cleanly.
             compactMode.toggle()
             ConfigFile.write(key: "STACKNUDGE_COMPACT_MODE",
                              value: compactMode ? "true" : "false")
-            if compactMode {
-                compactExpanded = true
-            } else {
-                compactExpanded = false
-            }
-        case 6:
+            compactExpanded = compactMode
+        case .widgetCorner:
             let list = CompactCorner.allCases
             let idx = list.firstIndex(of: compactCorner) ?? 0
             let next = forward ? (idx + 1) % list.count : (idx - 1 + list.count) % list.count
             compactCorner = list[next]
-            ConfigFile.write(key: "STACKNUDGE_COMPACT_CORNER",
-                             value: compactCorner.rawValue)
-        case 7:
+            ConfigFile.write(key: "STACKNUDGE_COMPACT_CORNER", value: compactCorner.rawValue)
+        case .widgetOpacity:
             let list = Self.compactAlphaOptions
             let idx = list.firstIndex(of: compactAlpha) ?? (list.count - 1)
             let next = forward ? (idx + 1) % list.count : (idx - 1 + list.count) % list.count
             compactAlpha = list[next]
-            ConfigFile.write(key: "STACKNUDGE_COMPACT_ALPHA",
-                             value: String(format: "%.2f", compactAlpha))
-        case 8:
+            ConfigFile.write(key: "STACKNUDGE_COMPACT_ALPHA", value: String(format: "%.2f", compactAlpha))
+        case .mascot:
             let list = MascotKind.allCases
             let idx = list.firstIndex(of: mascot) ?? 0
             let next = forward ? (idx + 1) % list.count : (idx - 1 + list.count) % list.count
             mascot = list[next]
             ConfigFile.write(key: "STACKNUDGE_MASCOT", value: mascot.rawValue)
-        case 9:
+        case .soundEnabled:
             soundEnabled.toggle()
             ConfigFile.write(key: "STACKNUDGE_SOUND", value: soundEnabled ? "true" : "false")
-        case 10:
+        case .agentDoneSound:
             soundStop = step(soundStop, in: Self.macSounds, forward: forward, key: "STACKNUDGE_SOUND_STOP", preview: true)
-        case 11:
+        case .permissionSound:
             soundPermission = step(soundPermission, in: Self.macSounds, forward: forward, key: "STACKNUDGE_SOUND_PERMISSION", preview: true)
-        case 12:
+        case .voiceEnabled:
             voiceEnabled.toggle()
             ConfigFile.write(key: "STACKNUDGE_VOICE", value: voiceEnabled ? "true" : "false")
-        case 13:
-            // Pre-download: the row is an action, not a cycle. Treat
-            // left/right arrow as a trigger so a user discovering the
-            // row keyboard-only can still start the download.
-            if !voiceModelCached {
-                if !voiceModelDownloading { startVoiceModelDownload() }
-                return
-            }
+        case .voice:
+            // Only reachable when the model is cached (otherwise the row is
+            // .downloadVoiceModel), so there's no download branch here.
             guard !voicesLoading, !voicesAvailable.isEmpty else { return }
             voice = step(voice, in: voicesAvailable, forward: forward, key: "STACKNUDGE_VOICE_NAME", preview: false)
             let phrase = Self.voicePreviewPhrases.randomElement() ?? "Hello."
             Speaker.speak(phrase, voice: voice, speed: String(format: "%.2f", voiceSpeed))
-        case 14:
+        case .voiceSpeed:
             let next = forward ? voiceSpeed + Self.speedStep : voiceSpeed - Self.speedStep
             voiceSpeed = max(Self.speedMin, min(Self.speedMax, (next * 100).rounded() / 100))
             ConfigFile.write(key: "STACKNUDGE_VOICE_SPEED", value: String(format: "%.2f", voiceSpeed))
-        case 15:
+        case .downloadVoiceModel:
+            // Arrow on the pre-download row triggers the download too.
+            if !voiceModelDownloading { startVoiceModelDownload() }
+        case .quotaTracking:
             toggleQuotaTracking()
-        case 16:
+        case .quotaAlerts:
             quotaAlertsEnabled.toggle()
-            ConfigFile.write(key: "STACKNUDGE_QUOTA_ALERTS",
-                             value: quotaAlertsEnabled ? "true" : "false")
-        case 17:
-            // Cycle through the static thresholds list. Index wraps in both
-            // directions so the user can dial in either way.
+            ConfigFile.write(key: "STACKNUDGE_QUOTA_ALERTS", value: quotaAlertsEnabled ? "true" : "false")
+        case .alertThreshold:
             let list = Self.quotaThresholds
             let idx = list.firstIndex(of: quotaAlertThreshold) ?? 2
             let next = forward ? (idx + 1) % list.count : (idx - 1 + list.count) % list.count
             quotaAlertThreshold = list[next]
-            ConfigFile.write(key: "STACKNUDGE_QUOTA_THRESHOLD",
-                             value: String(quotaAlertThreshold))
-        case 18:
+            ConfigFile.write(key: "STACKNUDGE_QUOTA_THRESHOLD", value: String(quotaAlertThreshold))
+        case .pollFrequency:
             let list = Self.quotaPollMinuteOptions
             let idx = list.firstIndex(of: quotaPollMinutes) ?? 2
             let next = forward ? (idx + 1) % list.count : (idx - 1 + list.count) % list.count
             quotaPollMinutes = list[next]
-            ConfigFile.write(key: "STACKNUDGE_USAGE_POLL_MIN",
-                             value: String(quotaPollMinutes))
-        case 19:
+            ConfigFile.write(key: "STACKNUDGE_USAGE_POLL_MIN", value: String(quotaPollMinutes))
+        case .contextAlert:
             let list = Self.contextAlertThresholdOptions
             let idx = list.firstIndex(of: contextAlertThresholdK) ?? 0
             let next = forward ? (idx + 1) % list.count : (idx - 1 + list.count) % list.count
             contextAlertThresholdK = list[next]
-            ConfigFile.write(key: "STACKNUDGE_CONTEXT_ALERT_THRESHOLD",
-                             value: String(contextAlertThresholdK))
-        case 20:
+            ConfigFile.write(key: "STACKNUDGE_CONTEXT_ALERT_THRESHOLD", value: String(contextAlertThresholdK))
+        case .showRemaining:
             quotaShowRemaining.toggle()
-            ConfigFile.write(key: "STACKNUDGE_QUOTA_SHOW_REMAINING",
-                             value: quotaShowRemaining ? "true" : "false")
-        case 21:
+            ConfigFile.write(key: "STACKNUDGE_QUOTA_SHOW_REMAINING", value: quotaShowRemaining ? "true" : "false")
+        case .githubLinks:
             toggleGithubLinking()
-        case 22:
+        case .hideShipped:
             toggleHideShipped()
-        case 24:
+        case .historyPerSession:
             let list = Self.eventsPerSessionOptions
             let idx = list.firstIndex(of: eventsPerSession) ?? 1
             let next = forward ? (idx + 1) % list.count : (idx - 1 + list.count) % list.count
             eventsPerSession = list[next]
-            ConfigFile.write(key: "STACKNUDGE_EVENTS_PER_SESSION",
-                             value: String(eventsPerSession))
-        default:
+            ConfigFile.write(key: "STACKNUDGE_EVENTS_PER_SESSION", value: String(eventsPerSession))
+        // Action rows have nothing to cycle.
+        case .disconnectGithub, .editPhrases, .checkPermissions, .openConfig,
+             .releaseNotes, .checkUpdates, .uninstall, .quit, .none:
             break
         }
     }

--- a/panel/Settings.swift
+++ b/panel/Settings.swift
@@ -25,15 +25,14 @@ struct SettingsView: View {
                         } else if !nav.recentlyWiredAgents.isEmpty {
                             wiredConfirmationRow(nav.recentlyWiredAgents)
                         }
-                        // Index 0 when present, shifting everything else by
-                        // +1. The offset is held on nav (updateRowOffset).
+                        // Shown only when an update is pending; nav.settingsRows
+                        // puts it first (index 0) so selection lines up.
                         if let version = nav.updateAvailable {
                             updateRow(version: version)
                         }
-                        let off = nav.updateRowOffset
 
                         section("Hotkey") {
-                            row(0 + off, label: "Panel shortcut",
+                            row(.hotkey, label: "Panel shortcut",
                                 kind: .cycle,
                                 value: nav.recordingHotkey ? "Press combo…" : nav.hotkeyDisplay)
                             if let error = nav.hotkeyError {
@@ -46,62 +45,63 @@ struct SettingsView: View {
                         }
 
                         section("Toggles") {
-                            row(1 + off, label: "Banner notifications", kind: .toggle, value: nav.bannerEnabled   ? "On" : "Off")
-                            row(2 + off, label: "Mute when focused",    kind: .toggle, value: nav.muteWhenFocused ? "On" : "Off")
-                            row(3 + off, label: "Pin panel",            kind: .toggle, value: nav.panelPinned     ? "On" : "Off")
-                            row(4 + off, label: "Launch at login",      kind: .toggle, value: nav.launchAtLogin   ? "On" : "Off")
+                            row(.banner,           label: "Banner notifications", kind: .toggle, value: nav.bannerEnabled    ? "On" : "Off")
+                            row(.muteWhenFocused,  label: "Mute when focused",    kind: .toggle, value: nav.muteWhenFocused  ? "On" : "Off")
+                            row(.pinPanel,         label: "Pin panel",            kind: .toggle, value: nav.panelPinned      ? "On" : "Off")
+                            row(.keepOpenWhenEmpty, label: "Keep open when empty", kind: .toggle, value: nav.keepOpenWhenEmpty ? "On" : "Off")
+                            row(.launchAtLogin,    label: "Launch at login",      kind: .toggle, value: nav.launchAtLogin    ? "On" : "Off")
                         }
 
                         section("Widget") {
-                            row(5 + off, label: "Widget",        kind: .toggle, value: nav.compactMode ? "On" : "Off")
-                            row(6 + off, label: "Widget corner", kind: .cycle,  value: nav.compactCorner.label,             enabled: nav.compactMode)
-                            row(7 + off, label: "Widget opacity", kind: .cycle, value: "\(Int(nav.compactAlpha * 100))%",   enabled: nav.compactMode)
-                            row(8 + off, label: "Mascot",        kind: .cycle,  value: nav.mascot.label,                    enabled: nav.compactMode)
+                            row(.widget,        label: "Widget",        kind: .toggle, value: nav.compactMode ? "On" : "Off")
+                            row(.widgetCorner,  label: "Widget corner", kind: .cycle,  value: nav.compactCorner.label,            enabled: nav.compactMode)
+                            row(.widgetOpacity, label: "Widget opacity", kind: .cycle, value: "\(Int(nav.compactAlpha * 100))%",  enabled: nav.compactMode)
+                            row(.mascot,        label: "Mascot",        kind: .cycle,  value: nav.mascot.label,                   enabled: nav.compactMode)
                         }
 
                         section("Sounds") {
-                            row(9 + off, label: "Sound enabled", kind: .toggle, value: nav.soundEnabled ? "On" : "Off")
-                            row(10 + off, label: "Agent done",   kind: .cycle,  value: nav.soundStop,       enabled: nav.soundEnabled)
-                            row(11 + off, label: "Permission",   kind: .cycle,  value: nav.soundPermission, enabled: nav.soundEnabled)
+                            row(.soundEnabled,    label: "Sound enabled", kind: .toggle, value: nav.soundEnabled ? "On" : "Off")
+                            row(.agentDoneSound,  label: "Agent done",    kind: .cycle,  value: nav.soundStop,       enabled: nav.soundEnabled)
+                            row(.permissionSound, label: "Permission",    kind: .cycle,  value: nav.soundPermission, enabled: nav.soundEnabled)
                         }
 
                         section("Voice") {
-                            row(12 + off, label: "Voice notifications", kind: .toggle, value: nav.voiceEnabled ? "On" : "Off")
+                            row(.voiceEnabled, label: "Voice notifications", kind: .toggle, value: nav.voiceEnabled ? "On" : "Off")
                             if nav.voiceModelCached {
-                                row(13 + off, label: "Voice", kind: .cycle, value: voiceLabel,                                  enabled: nav.voiceEnabled)
-                                row(14 + off, label: "Speed", kind: .cycle, value: String(format: "%.2f×", nav.voiceSpeed),     enabled: nav.voiceEnabled)
+                                row(.voice,      label: "Voice", kind: .cycle, value: voiceLabel,                              enabled: nav.voiceEnabled)
+                                row(.voiceSpeed, label: "Speed", kind: .cycle, value: String(format: "%.2f×", nav.voiceSpeed), enabled: nav.voiceEnabled)
                             } else {
-                                voiceModelDownloadRow(index: 13 + off)
+                                voiceModelDownloadRow(index: nav.index(of: .downloadVoiceModel))
                             }
                         }
 
                         section("Usage") {
-                            row(15 + off, label: "Quota tracking",  kind: .toggle, value: nav.quotaTrackingEnabled ? "On" : "Off")
-                            row(16 + off, label: "Quota alerts",    kind: .toggle, value: nav.quotaAlertsEnabled    ? "On" : "Off", enabled: nav.quotaTrackingEnabled)
-                            row(17 + off, label: "Alert threshold", kind: .cycle,  value: "\(nav.quotaAlertThreshold)%",            enabled: nav.quotaTrackingEnabled && nav.quotaAlertsEnabled)
-                            row(18 + off, label: "Poll frequency",  kind: .cycle,  value: "\(nav.quotaPollMinutes) min",            enabled: nav.quotaTrackingEnabled)
-                            row(19 + off, label: "Context alert at", kind: .cycle, value: contextAlertLabel)
-                            row(20 + off, label: "Show remaining",   kind: .toggle, value: nav.quotaShowRemaining ? "On" : "Off", enabled: nav.quotaTrackingEnabled)
+                            row(.quotaTracking, label: "Quota tracking",  kind: .toggle, value: nav.quotaTrackingEnabled ? "On" : "Off")
+                            row(.quotaAlerts,   label: "Quota alerts",    kind: .toggle, value: nav.quotaAlertsEnabled    ? "On" : "Off", enabled: nav.quotaTrackingEnabled)
+                            row(.alertThreshold, label: "Alert threshold", kind: .cycle,  value: "\(nav.quotaAlertThreshold)%",            enabled: nav.quotaTrackingEnabled && nav.quotaAlertsEnabled)
+                            row(.pollFrequency, label: "Poll frequency",  kind: .cycle,  value: "\(nav.quotaPollMinutes) min",            enabled: nav.quotaTrackingEnabled)
+                            row(.contextAlert,  label: "Context alert at", kind: .cycle, value: contextAlertLabel)
+                            row(.showRemaining, label: "Show remaining",   kind: .toggle, value: nav.quotaShowRemaining ? "On" : "Off", enabled: nav.quotaTrackingEnabled)
                         }
 
                         section("Tickets") {
-                            row(21 + off, label: "GitHub PR links",  kind: .toggle, value: nav.githubLinkingEnabled ? "On" : "Off")
-                            row(22 + off, label: "Hide shipped",     kind: .toggle, value: nav.hideShippedTickets ? "On" : "Off", enabled: nav.githubLinkingEnabled)
-                            row(23 + off, label: "Disconnect GitHub…", kind: .action, value: nav.githubSignedIn ? "Signed in" : "", enabled: nav.githubSignedIn)
+                            row(.githubLinks,     label: "GitHub PR links",  kind: .toggle, value: nav.githubLinkingEnabled ? "On" : "Off")
+                            row(.hideShipped,     label: "Hide shipped",     kind: .toggle, value: nav.hideShippedTickets ? "On" : "Off", enabled: nav.githubLinkingEnabled)
+                            row(.disconnectGithub, label: "Disconnect GitHub…", kind: .action, value: nav.githubSignedIn ? "Signed in" : "", enabled: nav.githubSignedIn)
                         }
 
                         section("Events") {
-                            row(24 + off, label: "History per session", kind: .cycle, value: "\(nav.eventsPerSession)")
+                            row(.historyPerSession, label: "History per session", kind: .cycle, value: "\(nav.eventsPerSession)")
                         }
 
                         section("Actions") {
-                            row(25 + off, label: "Edit phrases…",         kind: .action, value: "")
-                            row(26 + off, label: "Check permissions…",    kind: .action, value: "")
-                            row(27 + off, label: "Open config file…",     kind: .action, value: "")
-                            row(28 + off, label: "View release notes…",   kind: .action, value: "")
-                            row(29 + off, label: "Check for updates…",    kind: .action, value: checkForUpdatesStatus)
-                            row(30 + off, label: "Uninstall StackNudge…", kind: .action, value: "")
-                            row(31 + off, label: "Quit panel",            kind: .action, value: "")
+                            row(.editPhrases,      label: "Edit phrases…",         kind: .action, value: "")
+                            row(.checkPermissions, label: "Check permissions…",    kind: .action, value: "")
+                            row(.openConfig,       label: "Open config file…",     kind: .action, value: "")
+                            row(.releaseNotes,     label: "View release notes…",   kind: .action, value: "")
+                            row(.checkUpdates,     label: "Check for updates…",    kind: .action, value: checkForUpdatesStatus)
+                            row(.uninstall,        label: "Uninstall StackNudge…", kind: .action, value: "")
+                            row(.quit,             label: "Quit panel",            kind: .action, value: "")
                         }
 
                         aboutFooter
@@ -323,7 +323,7 @@ struct SettingsView: View {
     // releases page via the openReleasePage action.
     @ViewBuilder
     private func updateRow(version: String) -> some View {
-        let selected = nav.selectedSettingIndex == 0
+        let selected = nav.selectedSettingIndex == nav.index(of: .update)
         HStack(spacing: 10) {
             Image(systemName: "arrow.down.circle.fill")
                 .font(.body)
@@ -393,12 +393,12 @@ struct SettingsView: View {
     }
 
     @ViewBuilder
-    private func row(_ index: Int, label: String, kind: SettingsKind, value: String, enabled: Bool = true) -> some View {
+    private func row(_ id: SettingsRow, label: String, kind: SettingsKind, value: String, enabled: Bool = true) -> some View {
         SettingsRowView(
             label: label,
             value: value,
             kind: kind,
-            selected: nav.selectedSettingIndex == index
+            selected: nav.selectedSettingIndex == nav.index(of: id)
         )
         // Visual-only dimming when a row is gated by another setting
         // (Sound section's deps when Sound is off; Usage deps when
@@ -406,9 +406,9 @@ struct SettingsView: View {
         // these rows so muscle memory isn't disrupted — the user just
         // sees that the row is currently inert.
         .opacity(enabled ? 1.0 : 0.4)
-        .id(index)
+        .id(nav.index(of: id))
         .onTapGesture {
-            nav.selectedSettingIndex = index
+            nav.selectedSettingIndex = nav.index(of: id)
             // For actions, single-click is enough. For toggles/cycles a click
             // on the row also acts so mouse users don't have to keyboard.
             if kind == .action || kind == .toggle {


### PR DESCRIPTION
## Summary

Make the Settings list data-driven: one ordered `SettingsRow` array
(`PanelNav.settingsRows`) is the single source of truth for both rendering and
keyboard dispatch, replacing the hand-maintained numeric-index system that had
quietly drifted into bugs. Adds a "Keep open when empty" toggle on top of the
new model.

## Changes

- **Data-driven rows.** A `SettingsRow` enum + ordered `settingsRows` drives
  everything: the view looks up each row's index from it, and `applyCycle` is
  now an **exhaustive switch** over it (the compiler flags any unhandled row).
  Gone: `updateRowOffset`, the `rowCount` literal, the `+ off` arithmetic, and
  the hand-maintained index comment. Adding/reordering a row no longer means
  renumbering ~30 dispatch cases.
- **Fixed latent index bugs** the old system was hiding: `activate` fired the
  voice-model download on the *Permission sound* row, and `selectNextRow`'s
  voice-collapse skip pointed at the wrong index.
- **"Keep open when empty" toggle** (Settings → Toggles, after Pin panel;
  `STACKNUDGE_KEEP_OPEN_WHEN_EMPTY`, default off) — stops the panel
  auto-closing when you clear the last event. Gates the dismiss-to-empty
  `hidePanel()`. The *approve* path still hides, deliberately, so the Enter
  keystroke lands in your editor.

## Testing

- `./build.sh` → Build complete (zero warnings; exhaustive switch compiles).
- `SettingsRowTests`: row order, voice collapse, update-row prepend, and the
  index ⇄ row round-trip the view and dispatch both rely on.
- Standalone `swiftc` harness — 8/8. Render order and dispatch order are now
  the *same* array, so they can't drift; worth a live eyeball of Settings
  arrow-nav since the panel can't be exercised in CI.

## Related issues

Part of the post-1.17.0 polish pass.
