### PR TITLE
chore(ci): pin actions & check pr titles for rp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pr-title:
+    name: PR title (Conventional Commits)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      # release-please only bumps/releases on a parseable Conventional Commit.
+      # A malformed title (e.g. an empty scope `fix():`) silently skips the
+      # release with no error, so gate it here at PR time. Title is read via
+      # env, never interpolated into the script (avoids title injection).
+      - name: Validate PR title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "Title: $TITLE"
+          pattern='^(feat|fix|docs|chore|refactor|test|build|ci|perf|style|revert)(\([a-z0-9._-]+\))?!?: .+'
+          if ! printf '%s' "$TITLE" | grep -qE "$pattern"; then
+            echo "::error::PR title must be a Conventional Commit — 'type: subject' or 'type(scope): subject'. An empty scope like 'fix():' is invalid and silently skips the release."
+            exit 1
+          fi
+
   shell:
     name: shell syntax + shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: bash -n on tracked shell scripts
         run: |
@@ -29,7 +49,7 @@ jobs:
           done
 
       - name: shellcheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
         with:
           severity: warning
 
@@ -41,7 +61,7 @@ jobs:
       matrix:
         arch: [arm64, x86_64]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: build StackNudge.app
         run: ./build.sh ${{ matrix.arch }}
@@ -60,7 +80,7 @@ jobs:
     name: swift test
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: print toolchain
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,7 +35,7 @@ jobs:
       # The fallback `workflow_dispatch` trigger on release.yml stays —
       # if `RELEASE_PAT` is unset, the action uses GITHUB_TOKEN and you
       # can still dispatch the build manually.
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
           token: ${{ secrets.RELEASE_PAT }}
           config-file: .release-please-config.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       TARGET_TAG: ${{ inputs.tag || github.ref_name }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Check out the actual tag's commit rather than the workflow's
           # ref, so workflow_dispatch builds the same source the original
@@ -154,7 +154,7 @@ jobs:
       # tag_name explicit so workflow_dispatch attaches to the right release
       # — without it action-gh-release uses github.ref which is "main"-ish
       # for manual dispatches and fails to find a matching release.
-      - uses: softprops/action-gh-release@v3
+      - uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           tag_name: ${{ env.TARGET_TAG }}
           files: |

--- a/README.md
+++ b/README.md
@@ -217,6 +217,19 @@ The hotkey row records live: press `⏎` on it, press the new combo, and stack-n
 
 All Settings choices persist to `~/.stack-nudge/config` (a `KEY=value` text file). You don't need to edit it directly — Settings is the source of truth — but it's there for backup/sync or scripted setup.
 
+### Tickets (usage → outcomes)
+
+The **Tickets** tab (`⌘4`) rolls every captured agent session up **by ticket** — derived from your branch naming (`eng-123/…` → `ENG-123`), falling back to the branch when there's no ticket — and shows the tokens spent, files changed, and the live git outcome: *needs-review → committed → pushed → merged*. Select rows with `↑ ↓`, open the ticket or PR with `⏎`, dismiss one with `⌫`.
+
+Opt-in GitHub linking adds real **PR + CI status** (so even squash-merged work reads as *merged*). Turn it on in Settings → Tickets → **GitHub PR links**, then sign in via the in-panel device flow (no `gh` needed). Config keys (all optional; the toggles in Settings write the same file):
+
+| Key | What it does |
+|-----|--------------|
+| `STACKNUDGE_GITHUB` | `true` to enable GitHub PR/CI linking (off by default) |
+| `STACKNUDGE_GITHUB_CLIENT_ID` | Override the embedded OAuth app Client ID (rarely needed) |
+| `STACKNUDGE_TICKET_URL` | Deep-link template for ticket rows, e.g. `https://linear.app/acme/issue/{key}` — `{key}` is replaced with the ticket |
+| `STACKNUDGE_HIDE_SHIPPED` | `true` to drop groups once their PR reads merged, keeping the tab on in-flight work |
+
 ### Menu bar (macOS)
 
 When the panel daemon is running, a bell icon appears in your menu bar. The same items you can reach from the in-panel Settings tab are mirrored here for one-click access without summoning the panel:


### PR DESCRIPTION
## Summary

CI hardening plus a docs gap. Pin all GitHub Actions to commit SHAs (org
policy), add a PR-title Conventional-Commit gate so a malformed title can't
silently skip a release (as `fix():` did, blocking 1.17.1), and document the
new `STACKNUDGE_*` config keys.

## Changes

- **SHA-pin every Action** — per the org rule "Actions must be pinned to full
  commit SHAs (not version tags)": `actions/checkout`,
  `ludeeus/action-shellcheck` (was `@master` — a moving branch, the worst
  supply-chain case), `softprops/action-gh-release`, and
  `googleapis/release-please-action`. Each carries a `# vX` comment.
- **PR-title gate** (`ci.yml`, on `pull_request`) — a dependency-free shell
  step that rejects non-Conventional-Commit titles, including the empty-scope
  `fix():` form that release-please logged as `commit could not be parsed`,
  counted as 0 commits, and skipped the release for. The title is read via an
  env var (never interpolated into the script) to avoid injection.
- **README config keys** — document `STACKNUDGE_GITHUB`,
  `STACKNUDGE_GITHUB_CLIENT_ID`, `STACKNUDGE_TICKET_URL`, and
  `STACKNUDGE_HIDE_SHIPPED` (Tickets-tab / GitHub-linking settings) that were
  shipped undocumented.

## Testing

- All three workflow YAMLs parse; every `uses:` is now a 40-char SHA.
- Title regex verified: rejects `fix():` / `chore():`, accepts `fix:` /
  `fix(scope):` / `feat!:`.
- No app code touched — build unaffected; CI exercises the workflows.

## Related issues

Follow-up to the release that didn't fire (the `fix():` title on #91); part of
the post-1.17.0 polish.
