### PR TITLE
feat(tickets): group unticketed sessions by repo

### DIFF
--- a/Tests/StackNudgePanelCoreTests/OutcomesViewTests.swift
+++ b/Tests/StackNudgePanelCoreTests/OutcomesViewTests.swift
@@ -3,9 +3,9 @@ import XCTest
 @testable import StackNudgePanelCore
 
 // OutcomesView.groups rolls the handoff ledger up for the Tickets tab. These
-// pin the grouping key (ticket, falling back to branch), the token/session
-// aggregation, the tickets-before-branches ordering, and the recency sort
-// within a band.
+// pin the grouping key (ticket, else the repo the unticketed work ran in), the
+// token/session aggregation, the tickets-before-repos ordering, and the recency
+// sort within a band.
 final class OutcomesViewTests: XCTestCase {
 
     private func record(id: String,
@@ -31,27 +31,29 @@ final class OutcomesViewTests: XCTestCase {
             record(id: "b", ticket: "ENG-1", tokens: 200, updated: 2),
         ])
         XCTAssertEqual(groups.count, 1)
-        XCTAssertEqual(groups.first?.id, "ENG-1")
+        XCTAssertEqual(groups.first?.label, "ENG-1")
         XCTAssertEqual(groups.first?.isTicket, true)
         XCTAssertEqual(groups.first?.sessionCount, 2)
         XCTAssertEqual(groups.first?.totalTokens, 300)
     }
 
-    func test_branchUsedAsKeyWhenNoTicket() {
+    func test_unticketedWork_groupsUnderItsRepo() {
         let groups = OutcomesView.groups(from: [
-            record(id: "a", branch: "feat/x", ticket: nil, tokens: 50),
+            record(id: "a", repoRoot: "/work/stack-nudge", branch: "feat/x", ticket: nil, tokens: 50),
         ])
-        XCTAssertEqual(groups.first?.id, "feat/x")
+        XCTAssertEqual(groups.first?.label, "stack-nudge")
+        XCTAssertEqual(groups.first?.kind, .repo)
         XCTAssertEqual(groups.first?.isTicket, false)
+        XCTAssertEqual(groups.first?.branches.map(\.branch), ["feat/x"])
         XCTAssertEqual(groups.first?.totalTokens, 50)
     }
 
-    func test_ticketsSortBeforeBranches_evenWhenBranchIsNewer() {
+    func test_ticketsSortBeforeRepos_evenWhenRepoIsNewer() {
         let groups = OutcomesView.groups(from: [
-            record(id: "a", branch: "feat/x", updated: 100),  // newest, but a branch
-            record(id: "b", ticket: "ENG-1", updated: 1),     // older, but a ticket
+            record(id: "a", repoRoot: "/work/stack-nudge", branch: "feat/x", updated: 100),  // newest, but unticketed
+            record(id: "b", ticket: "ENG-1", updated: 1),                                    // older, but a ticket
         ])
-        XCTAssertEqual(groups.map(\.id), ["ENG-1", "feat/x"])
+        XCTAssertEqual(groups.map(\.label), ["ENG-1", "stack-nudge"])
     }
 
     func test_withinTickets_sortedByMostRecentActivity() {
@@ -59,7 +61,7 @@ final class OutcomesViewTests: XCTestCase {
             record(id: "a", ticket: "ENG-1", updated: 1),
             record(id: "b", ticket: "ENG-2", updated: 5),
         ])
-        XCTAssertEqual(groups.map(\.id), ["ENG-2", "ENG-1"])
+        XCTAssertEqual(groups.map(\.label), ["ENG-2", "ENG-1"])
     }
 
     func test_distinctAgentsPreservedInFirstSeenOrder() {
@@ -71,10 +73,10 @@ final class OutcomesViewTests: XCTestCase {
         XCTAssertEqual(groups.first?.agents, ["Claude", "Codex"])
     }
 
-    func test_noTicketNoBranch_fallsBackToPlaceholder() {
-        let groups = OutcomesView.groups(from: [record(id: "a", branch: nil)])
-        XCTAssertEqual(groups.first?.id, "—")
-        XCTAssertEqual(groups.first?.isTicket, false)
+    func test_noTicketNoRepo_fallsBackToPlaceholder() {
+        let groups = OutcomesView.groups(from: [record(id: "a", repoRoot: nil, branch: nil)])
+        XCTAssertEqual(groups.first?.label, "—")
+        XCTAssertEqual(groups.first?.kind, .repo)
     }
 
     func test_lowercaseBranch_regroupsUnderTicket_evenWhenStoredTicketIsNil() {
@@ -83,7 +85,7 @@ final class OutcomesViewTests: XCTestCase {
         let groups = OutcomesView.groups(from: [
             record(id: "a", branch: "eng-75/sync", ticket: nil, tokens: 100),
         ])
-        XCTAssertEqual(groups.first?.id, "ENG-75")
+        XCTAssertEqual(groups.first?.label, "ENG-75")
         XCTAssertEqual(groups.first?.isTicket, true)
     }
 
@@ -108,12 +110,77 @@ final class OutcomesViewTests: XCTestCase {
         XCTAssertEqual(branches.last?.sessionCount, 2)
     }
 
-    func test_branchOnlyGroup_exposesItsOwnBranchSlice() {
-        // Branch-only groups carry their single slice (for the outcome rollup);
-        // the view just doesn't render it as a redundant sub-row.
-        let groups = OutcomesView.groups(from: [record(id: "a", branch: "feat/x")])
-        XCTAssertEqual(groups.first?.isTicket, false)
-        XCTAssertEqual(groups.first?.branches.map(\.branch), ["feat/x"])
+    func test_repoGroup_gathersUnticketedBranches_heaviestFirst() {
+        // Several unticketed branches in one repo collapse into a single repo
+        // group, each branch a sub-row ordered by tokens.
+        let groups = OutcomesView.groups(from: [
+            record(id: "a", repoRoot: "/work/stack-nudge", branch: "feat/light", tokens: 100),
+            record(id: "b", repoRoot: "/work/stack-nudge", branch: "feat/heavy", tokens: 900),
+            record(id: "c", repoRoot: "/work/stack-nudge", branch: "feat/light", tokens: 100),
+        ])
+        XCTAssertEqual(groups.count, 1)
+        XCTAssertEqual(groups.first?.label, "stack-nudge")
+        XCTAssertEqual(groups.first?.kind, .repo)
+        XCTAssertEqual(groups.first?.branches.map(\.branch), ["feat/heavy", "feat/light"])
+        XCTAssertEqual(groups.first?.sessionCount, 3)
+        XCTAssertEqual(groups.first?.totalTokens, 1100)
+    }
+
+    func test_unticketedWork_splitsByRepo() {
+        let groups = OutcomesView.groups(from: [
+            record(id: "a", repoRoot: "/work/stack-nudge", branch: "feat/x", updated: 1),
+            record(id: "b", repoRoot: "/work/hub",         branch: "feat/y", updated: 2),
+        ])
+        XCTAssertEqual(groups.map(\.label), ["hub", "stack-nudge"])  // distinct repo groups, recency-sorted
+        XCTAssertTrue(groups.allSatisfy { $0.kind == .repo })
+    }
+
+    func test_ticketAndRepoCoexist_ticketFirst() {
+        let groups = OutcomesView.groups(from: [
+            record(id: "a", repoRoot: "/work/stack-nudge", branch: "feat/x", updated: 5),  // unticketed → repo
+            record(id: "b", repoRoot: "/work/stack-nudge", branch: "eng-9/api", updated: 1),  // ticket
+        ])
+        XCTAssertEqual(groups.map(\.label), ["ENG-9", "stack-nudge"])
+        XCTAssertEqual(groups.map(\.kind), [.ticket, .repo])
+    }
+
+    func test_groupID_uniqueWhenTicketAndRepoShareName() {
+        // A repo literally named "ENG-9" and a ticket ENG-9 produce the same
+        // display label but must stay distinct groups with distinct ids — else
+        // SwiftUI's ForEach / row selection collides on the shared id.
+        let groups = OutcomesView.groups(from: [
+            record(id: "a", repoRoot: "/work/ENG-9", branch: "feat/x", ticket: nil),  // repo basename "ENG-9"
+            record(id: "b", repoRoot: "/work/svc",   branch: "eng-9/api", ticket: nil), // derives ticket ENG-9
+        ])
+        XCTAssertEqual(groups.count, 2)
+        XCTAssertEqual(Set(groups.map(\.label)), ["ENG-9"])               // same display text
+        XCTAssertEqual(Set(groups.map(\.id)).count, 2)                    // distinct ids
+        XCTAssertEqual(Set(groups.map(\.kind)), [.ticket, .repo])
+    }
+
+    func test_distinctReposSameBasename_notMerged() {
+        // …/acme/api and …/example/api share a basename but are different repos.
+        let groups = OutcomesView.groups(from: [
+            record(id: "a", repoRoot: "/clients/acme/api",    branch: "feat/x", tokens: 100),
+            record(id: "b", repoRoot: "/clients/example/api", branch: "feat/y", tokens: 200),
+        ])
+        XCTAssertEqual(groups.count, 2)                                   // not merged
+        XCTAssertEqual(Set(groups.map(\.label)), ["api"])                 // same display label
+        XCTAssertEqual(Set(groups.map(\.id)), ["r:/clients/acme/api", "r:/clients/example/api"])
+    }
+
+    func test_branchBreakdown_sameBranchNameAcrossRepos_staysDistinct() {
+        // One ticket worked in two repos, each with a branch named ENG-9/main.
+        // Keying by (repoRoot, branch) keeps them as two slices with their own
+        // repoRoot, rather than collapsing into one and losing a repo.
+        let groups = OutcomesView.groups(from: [
+            record(id: "a", repoRoot: "/work/api-a", branch: "ENG-9/main", ticket: "ENG-9", tokens: 100),
+            record(id: "b", repoRoot: "/work/api-b", branch: "ENG-9/main", ticket: "ENG-9", tokens: 200),
+        ])
+        let branches = groups.first?.branches ?? []
+        XCTAssertEqual(branches.count, 2)
+        XCTAssertEqual(Set(branches.map(\.repoRoot)), ["/work/api-a", "/work/api-b"])
+        XCTAssertEqual(Set(branches.map(\.id)).count, 2)
     }
 
     func test_branchDiff_usesLatestSnapshotNotSum() {

--- a/panel/OutcomesView.swift
+++ b/panel/OutcomesView.swift
@@ -18,7 +18,8 @@ struct DiffStat: Equatable {
 // `diff` is the branch's latest snapshot (pending work), not a sum across its
 // sessions — uncommitted state is point-in-time, so summing would double-count.
 struct BranchBreakdown: Identifiable, Equatable {
-    var id: String { branch }
+    // (repoRoot, branch) so two repos with a same-named branch stay distinct.
+    var id: String { PanelNav.outcomeKey(repoRoot, branch) }
     let branch: String
     let repoRoot: String?   // for the per-branch outcome lookup (repo+branch keyed)
     let sessionCount: Int
@@ -26,27 +27,39 @@ struct BranchBreakdown: Identifiable, Equatable {
     let diff: DiffStat
 }
 
+// How a group is keyed. Ticket groups carry a real Linear/Jira key and deep-link
+// to the tracker; repo groups are the bucket for unticketed work, gathering every
+// branch that ran in a repo so loose work-streams nest under the repo instead of
+// scattering one anonymous row per branch.
+enum GroupKind: Equatable { case ticket, repo }
+
 // One aggregated row in the Tickets tab: every session that shares a grouping
-// key. The key is the derived Linear/Jira ticket when one was found, else the
-// git branch (so unticketed work-streams stay separate instead of collapsing
-// into one anonymous bucket). Tokens are summed across the group's sessions.
+// key. Ticket sessions key by their derived ticket; unticketed sessions key by
+// the repo they ran in. Tokens are summed across the group's sessions.
 struct TicketGroup: Identifiable, Equatable {
-    let id: String          // grouping key = ticket ?? branch ?? placeholder
-    let isTicket: Bool      // true when id is a real ticket key (gets the deep link)
+    // Stable, unique identity = the namespaced grouping key ("t:<ticket>" /
+    // "r:<repoRoot>"). Used for SwiftUI identity, row ids, and selection — never
+    // shown. Two groups can share a `label` (a ticket and a repo both called
+    // "ENG-9", or two repos with the same basename) without colliding here.
+    let id: String
+    let label: String       // display text: ticket key, or repo basename
+    let kind: GroupKind
     let repos: [String]     // distinct repo names the sessions ran in
     let sessionCount: Int
     let totalTokens: Int
     let agents: [String]    // distinct canonical agents, first-seen order
     let diff: DiffStat      // pending work, summed across the group's branches
-    // All branch slices in the group (used for the outcome rollup); rendered as
-    // sub-rows only for ticket groups — a branch-only group's slice is itself.
+    // All branch slices in the group, rendered as indented sub-rows (both kinds).
     let branches: [BranchBreakdown]
+
+    // True when this is a real ticket key — the only kind that deep-links.
+    var isTicket: Bool { kind == .ticket }
 }
 
 // Tickets tab — the first slice of the usage-to-outcome dashboard. Reads the
-// handoff ledger, rolls token usage + session counts up per `ticket ?? branch`,
-// shows the repo each group ran in and (for tickets) the branches beneath it,
-// and deep-links each ticket row to its tracker when STACKNUDGE_TICKET_URL is
+// handoff ledger, rolls token usage + session counts up per ticket (or per repo
+// for unticketed work), shows the branches beneath each group, and deep-links
+// each ticket row to its tracker when STACKNUDGE_TICKET_URL is
 // set. Pure read over data the ledger already holds; no capture, no network.
 struct OutcomesView: View {
 
@@ -114,11 +127,16 @@ struct OutcomesView: View {
     // MARK: - Rows
 
     private func groupRow(_ group: TicketGroup, selectedRowID: String?) -> some View {
-        let linkable = group.isTicket && ticketURL(for: group.id) != nil
+        let linkable = group.isTicket && ticketURL(for: group.label) != nil
         let selected = selectedRowID == Self.headerID(group)
         return VStack(alignment: .leading, spacing: 3) {
             HStack(spacing: 6) {
-                Text(group.id)
+                if group.kind == .repo {
+                    Image(systemName: "shippingbox")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Text(group.label)
                     .font(.callout.weight(.semibold))
                     .foregroundStyle(group.isTicket ? Color.primary : Color.secondary)
                     .lineLimit(1)
@@ -129,7 +147,14 @@ struct OutcomesView: View {
                         .foregroundStyle(Color.accentColor)
                 }
                 Spacer(minLength: 8)
-                if !group.repos.isEmpty {
+                // Repo groups put the repo name in the title, so the trailing
+                // slot shows the branch count instead of the (redundant) repo.
+                if group.kind == .repo {
+                    Text(Self.branchesLabel(group.branches.count))
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .fixedSize()
+                } else if !group.repos.isEmpty {
                     Text(group.repos.joined(separator: ", "))
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
@@ -140,34 +165,20 @@ struct OutcomesView: View {
             Text(detailLine(group))
                 .font(.caption.monospacedDigit())
                 .foregroundStyle(.secondary)
-            if group.isTicket {
-                let rollup = outcomeRollup(group)
-                if !rollup.isEmpty {
-                    HStack(spacing: 10) {
-                        ForEach(rollup, id: \.status) { statusChip($0.status, count: $0.count) }
+            let rollup = outcomeRollup(group)
+            if !rollup.isEmpty {
+                HStack(spacing: 10) {
+                    ForEach(rollup, id: \.status) { statusChip($0.status, count: $0.count) }
+                }
+            }
+            if !group.branches.isEmpty {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(group.branches) { branch in
+                        branchRow(branch, selectedRowID: selectedRowID)
+                            .id(Self.branchID(branch))
                     }
                 }
-                if !group.branches.isEmpty {
-                    VStack(alignment: .leading, spacing: 2) {
-                        ForEach(group.branches) { branch in
-                            branchRow(branch, selectedRowID: selectedRowID)
-                                .id(Self.branchID(branch))
-                        }
-                    }
-                    .padding(.top, 1)
-                }
-            } else if let branch = group.branches.first {
-                // Branch-only group: one branch == the group, with no sub-row to
-                // host a chip — so render it on the header. Clickable PR chip
-                // when a PR exists, else the local-outcome chip.
-                HStack(spacing: 8) {
-                    if let pr = prInfo(for: branch) {
-                        prChip(pr)
-                    } else if let status = outcome(for: branch), status != .clean {
-                        statusChip(status)
-                    }
-                    Spacer(minLength: 0)
-                }
+                .padding(.top, 1)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -177,7 +188,7 @@ struct OutcomesView: View {
             .fill(selected ? Color.accentColor.opacity(0.14) : Color.primary.opacity(0.04)))
         .contentShape(Rectangle())
         .onTapGesture { if linkable { openTicket(group) } }
-        .help(linkable ? "Open \(group.id) in your tracker" : "")
+        .help(linkable ? "Open \(group.label) in your tracker" : "")
     }
 
     private func branchRow(_ branch: BranchBreakdown, selectedRowID: String?) -> some View {
@@ -220,7 +231,7 @@ struct OutcomesView: View {
         var ids: [String] = []
         for group in groups {
             ids.append(headerID(group))
-            if group.isTicket { ids.append(contentsOf: group.branches.map(branchID)) }
+            ids.append(contentsOf: group.branches.map(branchID))
         }
         guard !ids.isEmpty else { return nil }
         return ids[min(max(0, index), ids.count - 1)]
@@ -394,7 +405,7 @@ struct OutcomesView: View {
     }
 
     private func openTicket(_ group: TicketGroup) {
-        guard let url = ticketURL(for: group.id) else { return }
+        guard let url = ticketURL(for: group.label) else { return }
         NSWorkspace.shared.open(url)
     }
 
@@ -406,25 +417,32 @@ struct OutcomesView: View {
     // Tickets sort first (they're the unit the user tracks), then by most-recent
     // activity within each band.
     static func groups(from records: [HandoffRecord]) -> [TicketGroup] {
-        struct Resolved { let key: String; let isTicket: Bool; let record: HandoffRecord }
+        // Ticketed sessions key by their derived ticket; everything else buckets
+        // by repo. The dedupKey is namespaced (t:/r:) and, for repos, uses the
+        // full repoRoot — two checkouts with the same basename (…/acme/api,
+        // …/example/api) must stay separate. The label is the human text
+        // (ticket key, or repo basename), which may repeat across groups.
+        struct Resolved { let dedupKey: String; let label: String; let kind: GroupKind; let record: HandoffRecord }
         let resolved = records.map { record -> Resolved in
             if let ticket = record.ticket ?? TicketAttribution.ticket(branch: record.branch) {
-                return Resolved(key: ticket, isTicket: true, record: record)
+                return Resolved(dedupKey: "t:\(ticket)", label: ticket, kind: .ticket, record: record)
             }
-            return Resolved(key: record.branch ?? "—", isTicket: false, record: record)
+            let root = record.repoRoot ?? "—"
+            return Resolved(dedupKey: "r:\(root)", label: repoName(record.repoRoot) ?? "—", kind: .repo, record: record)
         }
 
         var keyOrder: [String] = []
         var byKey: [String: [Resolved]] = [:]
         for item in resolved {
-            if byKey[item.key] == nil { keyOrder.append(item.key) }
-            byKey[item.key, default: []].append(item)
+            if byKey[item.dedupKey] == nil { keyOrder.append(item.dedupKey) }
+            byKey[item.dedupKey, default: []].append(item)
         }
 
         let groups = keyOrder.map { key -> (group: TicketGroup, last: Date) in
             let items = byKey[key] ?? []
             let rows = items.map(\.record)
-            let isTicket = items.first?.isTicket ?? false
+            let kind = items.first?.kind ?? .repo
+            let label = items.first?.label ?? "—"
             let tokens = rows.compactMap(\.contextTokens).reduce(0, +)
             let agents = orderedDistinct(rows.map { displayAgent($0.agent) })
             let repos = orderedDistinct(rows.compactMap { repoName($0.repoRoot) })
@@ -434,34 +452,37 @@ struct OutcomesView: View {
                 filesChanged: slices.reduce(0) { $0 + $1.diff.filesChanged },
                 insertions: slices.reduce(0) { $0 + $1.diff.insertions },
                 deletions: slices.reduce(0) { $0 + $1.diff.deletions })
-            return (TicketGroup(id: key, isTicket: isTicket, repos: repos,
+            return (TicketGroup(id: key, label: label, kind: kind, repos: repos,
                                 sessionCount: rows.count, totalTokens: tokens,
                                 agents: agents, diff: diff, branches: slices), last)
         }
+        // Tickets first, then repo buckets; most-recent within each band.
         return groups.sorted {
             if $0.group.isTicket != $1.group.isTicket { return $0.group.isTicket }
             return $0.last > $1.last
         }.map(\.group)
     }
 
-    // Per-branch slices within a ticket, heaviest token use first.
+    // Per-branch slices within a group, heaviest token use first. Keyed by
+    // (repoRoot, branch) — matching the outcome/PR lookup — so a branch name
+    // shared across two repos doesn't collapse into one slice or lose a repoRoot.
     static func branchBreakdown(_ rows: [HandoffRecord]) -> [BranchBreakdown] {
         var order: [String] = []
-        var byBranch: [String: [HandoffRecord]] = [:]
+        var byKey: [String: [HandoffRecord]] = [:]
         for row in rows {
-            let branch = row.branch ?? "—"
-            if byBranch[branch] == nil { order.append(branch) }
-            byBranch[branch, default: []].append(row)
+            let key = PanelNav.outcomeKey(row.repoRoot, row.branch)
+            if byKey[key] == nil { order.append(key) }
+            byKey[key, default: []].append(row)
         }
-        return order.map { branch -> BranchBreakdown in
-            let group = byBranch[branch] ?? []
+        return order.map { key -> BranchBreakdown in
+            let group = byKey[key] ?? []
             let tokens = group.compactMap(\.contextTokens).reduce(0, +)
             let latest = group.max { $0.updatedAt < $1.updatedAt }
             let diff = DiffStat(
                 filesChanged: latest?.filesChanged ?? 0,
                 insertions: latest?.insertions ?? 0,
                 deletions: latest?.deletions ?? 0)
-            return BranchBreakdown(branch: branch, repoRoot: latest?.repoRoot,
+            return BranchBreakdown(branch: latest?.branch ?? "—", repoRoot: latest?.repoRoot,
                                    sessionCount: group.count, totalTokens: tokens, diff: diff)
         }.sorted { $0.totalTokens > $1.totalTokens }
     }
@@ -494,6 +515,9 @@ struct OutcomesView: View {
 
     private static func filesLabel(_ count: Int) -> String {
         count == 1 ? "1 file" : "\(count) files"
+    }
+    static func branchesLabel(_ count: Int) -> String {
+        count == 1 ? "1 branch" : "\(count) branches"
     }
 
     // "+1.8k/−400" — uses the minus sign (U+2212) to match the app's typography.

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -257,11 +257,11 @@ final class PanelNav: ObservableObject {
         }
     }
 
-    // Row count for clamping — header + (ticket) branch sub-rows, same order the
-    // view renders. No config/network, so cheap to call on every keystroke.
+    // Row count for clamping — header + branch sub-rows for every group, same
+    // order the view renders. No config/network, so cheap to call per keystroke.
     func outcomeRowCount() -> Int {
         visibleOutcomeGroups().reduce(0) { total, group in
-            total + 1 + (group.isTicket ? group.branches.count : 0)
+            total + 1 + group.branches.count
         }
     }
 
@@ -271,17 +271,16 @@ final class PanelNav: ObservableObject {
         outcomeSelectedIndex = min(max(0, outcomeSelectedIndex + delta), count - 1)
     }
 
-    // Open the selected row's link: a ticket's tracker URL (STACKNUDGE_TICKET_URL)
-    // for ticket headers, else the PR URL for a branch / branch-only header.
+    // Open the selected row's link: a ticket header → its tracker URL
+    // (STACKNUDGE_TICKET_URL); a branch sub-row → its PR. Repo headers don't
+    // link anywhere (no single PR for a repo) — their branches carry the links.
     func activateSelectedOutcome() {
         let template = ConfigFile.read()["STACKNUDGE_TICKET_URL"]
         var urls: [String?] = []
         for group in visibleOutcomeGroups() {
             urls.append(headerURL(group, template: template))
-            if group.isTicket {
-                for branch in group.branches {
-                    urls.append(pullRequestByBranch[Self.outcomeKey(branch.repoRoot, branch.branch)]?.url)
-                }
+            for branch in group.branches {
+                urls.append(pullRequestByBranch[Self.outcomeKey(branch.repoRoot, branch.branch)]?.url)
             }
         }
         guard !urls.isEmpty else { return }
@@ -292,18 +291,13 @@ final class PanelNav: ObservableObject {
     }
 
     private func headerURL(_ group: TicketGroup, template: String?) -> String? {
-        if group.isTicket, let template, template.contains("{key}") {
-            return template.replacingOccurrences(of: "{key}", with: group.id)
-        }
-        if !group.isTicket, let branch = group.branches.first {
-            return pullRequestByBranch[Self.outcomeKey(branch.repoRoot, branch.branch)]?.url
-        }
-        return nil
+        guard group.isTicket, let template, template.contains("{key}") else { return nil }
+        return template.replacingOccurrences(of: "{key}", with: group.label)
     }
 
-    // Remove the selected row's records: a ticket header drops the whole group
-    // (every branch); a branch sub-row / branch-only header drops just that
-    // branch. Matched by (repoRoot, branch), which lives on each record.
+    // Remove the selected row's records: a group header (ticket or repo) drops
+    // the whole group (every branch); a branch sub-row drops just that branch.
+    // Matched by (repoRoot, branch), which lives on each record.
     func dismissSelectedOutcome() {
         let records = HandoffLedger.shared.all()
         let rowKeys = branchKeysForRows(visibleOutcomeGroups())
@@ -321,15 +315,13 @@ final class PanelNav: ObservableObject {
     }
 
     // Per-row branch keys in render order, matching outcomeRowCount: a header
-    // (ticket → all its branches; branch-only → its one), then a ticket group's
-    // branch sub-rows.
+    // (drops all the group's branches), then one row per branch sub-row (drops
+    // just that branch). Same for ticket and repo groups.
     private func branchKeysForRows(_ groups: [TicketGroup]) -> [[String]] {
         var rows: [[String]] = []
         for group in groups {
             rows.append(group.branches.map { Self.outcomeKey($0.repoRoot, $0.branch) })
-            if group.isTicket {
-                rows.append(contentsOf: group.branches.map { [Self.outcomeKey($0.repoRoot, $0.branch)] })
-            }
+            rows.append(contentsOf: group.branches.map { [Self.outcomeKey($0.repoRoot, $0.branch)] })
         }
         return rows
     }


### PR DESCRIPTION
## Summary

Unticketed sessions in the Tickets tab no longer scatter one row per branch.
Sessions without a derivable ticket now group under the **repo** they ran in,
with their branches as indented sub-rows — the same shape ticket groups already
use. Repos outside of tickets are the obvious second grouping axis.

## Changes

- **`groups(from:)`** keys unticketed records by repo name (dedup keys
  namespaced `t:` / `r:` so a ticket and a repo sharing a name can't collide).
  Tickets still sort first, repo buckets after, most-recent within each band.
- **`TicketGroup` gains a `kind`** (`.ticket` / `.repo`); `isTicket` is now
  derived from it.
- **Repo headers** render a box glyph + branch count and don't deep-link
  (there's no single PR for a repo) — their branch sub-rows carry the PR /
  outcome chips.
- **Rollup + sub-rows render for both kinds.** Nav row-enumeration, ⌫-dismiss,
  and ↵-activate now enumerate `header + branches` uniformly, dropping the
  ticket-only special-casing; the old branch-only single-row is gone.

## Testing

- `./build.sh` → **Build complete**, zero warnings.
- `OutcomesViewTests` updated for the new keying + new cases (group-by-repo,
  split-by-repo, ticket+repo coexistence, placeholder when no repo).
- `swift test` can't run locally (needs Xcode/XCTest), so the grouping logic
  was validated with a standalone `swiftc` harness mirroring `groups(from:)` —
  **15/15**. CI runs the XCTest suite.
- **Needs a manual eyeball** (the panel can't be exercised in CI): repo header
  glyph + branch count; ↑↓ landing on both repo headers and sub-rows; ⌫ on a
  repo header removing the whole bucket vs a sub-row removing one branch;
  hide-shipped collapsing a fully-merged repo group.

## Related issues

Part of the post-1.17.0 Tickets-tab polish. No tracked issue.
