### PR TITLE
feat(tickets): accumulate context tokens across compactions

### DIFF
--- a/Tests/StackNudgePanelCoreTests/ContextTokensTests.swift
+++ b/Tests/StackNudgePanelCoreTests/ContextTokensTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// ContextTokens.fold turns the per-Stop context-occupancy reading into a running
+// cumulative total. These pin the four cases that matter: monotonic growth,
+// compaction reset, sub-threshold noise, and seeding (new + pre-upgrade records).
+final class ContextTokensTests: XCTestCase {
+
+    func test_newRecord_seedsToReading() {
+        let folded = ContextTokens.fold(total: nil, lastReading: nil, newReading: 100)
+        XCTAssertEqual(folded.total, 100)
+        XCTAssertEqual(folded.lastReading, 100)
+    }
+
+    func test_monotonicGrowth_sumsToFinalReading() {
+        // No compaction: cumulative tracks the latest reading exactly.
+        var state = ContextTokens.fold(total: nil, lastReading: nil, newReading: 10_000)
+        state = ContextTokens.fold(total: state.total, lastReading: state.lastReading, newReading: 50_000)
+        state = ContextTokens.fold(total: state.total, lastReading: state.lastReading, newReading: 120_000)
+        XCTAssertEqual(state.total, 120_000)
+    }
+
+    func test_compaction_banksPeakThenAccumulatesNewCycle() {
+        // Grow to a 180K peak, compact down to 40K, climb to 160K. Effort =
+        // peak (180K) + new-cycle growth (160K − 40K) = 300K — not the 160K a
+        // last-reading-wins capture would show.
+        var state = ContextTokens.fold(total: nil, lastReading: nil, newReading: 180_000)
+        state = ContextTokens.fold(total: state.total, lastReading: state.lastReading, newReading: 40_000)
+        XCTAssertEqual(state.total, 180_000)        // drop banks nothing
+        XCTAssertEqual(state.lastReading, 40_000)   // new cycle baseline
+        state = ContextTokens.fold(total: state.total, lastReading: state.lastReading, newReading: 160_000)
+        XCTAssertEqual(state.total, 300_000)
+    }
+
+    func test_subThresholdDip_keepsBaseline_soOnlyRealGrowthBanks() {
+        // A 5K dip is noise, not a compaction: the baseline stays at the peak,
+        // so a recovery only banks growth above it (185K − 180K = 5K).
+        var state = ContextTokens.fold(total: 180_000, lastReading: 180_000, newReading: 175_000)
+        XCTAssertEqual(state.total, 180_000)
+        XCTAssertEqual(state.lastReading, 180_000)
+        state = ContextTokens.fold(total: state.total, lastReading: state.lastReading, newReading: 185_000)
+        XCTAssertEqual(state.total, 185_000)
+    }
+
+    func test_dropExactlyAtThreshold_countsAsCompaction() {
+        let folded = ContextTokens.fold(total: 180_000, lastReading: 180_000, newReading: 160_000)
+        XCTAssertEqual(folded.total, 180_000)       // 20K drop == threshold → reset, no subtract
+        XCTAssertEqual(folded.lastReading, 160_000)
+    }
+
+    func test_preUpgradeRecord_seedsWithoutDoubleCounting() {
+        // Legacy record: a single stored figure, no lastReading. Seeding must not
+        // add the new reading on top of the stored total.
+        var state = ContextTokens.fold(total: 80_000, lastReading: nil, newReading: 90_000)
+        XCTAssertEqual(state.total, 90_000)
+        XCTAssertEqual(state.lastReading, 90_000)
+        state = ContextTokens.fold(total: state.total, lastReading: state.lastReading, newReading: 110_000)
+        XCTAssertEqual(state.total, 110_000)
+    }
+
+    func test_preUpgradeRecord_lowerReadingKeepsHigherTotal() {
+        // Legacy total above the current reading (upgraded mid-compaction) is kept.
+        let folded = ContextTokens.fold(total: 180_000, lastReading: nil, newReading: 40_000)
+        XCTAssertEqual(folded.total, 180_000)
+        XCTAssertEqual(folded.lastReading, 40_000)
+    }
+}

--- a/Tests/StackNudgePanelCoreTests/TranscriptReaderTests.swift
+++ b/Tests/StackNudgePanelCoreTests/TranscriptReaderTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// Real-shape coverage for the Claude transcript reader and, more importantly,
+// the parse → ContextTokens.fold pipeline the handoff capture runs on every
+// Stop. The Codex reader has its own fixtures (CodexTranscriptReaderTests);
+// here we pin the Claude usage-block shape and prove that a transcript whose
+// occupancy rises, compacts, then rises again accumulates its real effort
+// rather than collapsing to the post-compaction reading.
+final class TranscriptReaderTests: XCTestCase {
+
+    private func writeTranscript(_ lines: [String], name: String = "session.jsonl") -> String {
+        let dir = NSTemporaryDirectory() + "claude-transcript-\(UUID().uuidString)/"
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let path = dir + name
+        try? (lines.joined(separator: "\n") + "\n")
+            .write(toFile: path, atomically: true, encoding: .utf8)
+        return path
+    }
+
+    // A real Claude Code assistant entry whose usage block sums to `occupancy`
+    // (input + cache_creation + cache_read), matching what readClaude reads.
+    private func claudeLine(_ occupancy: Int, model: String = "claude-opus-4-8") -> String {
+        #"{"type":"assistant","message":{"model":"\#(model)","usage":{"input_tokens":\#(occupancy - 5000),"cache_creation_input_tokens":2000,"cache_read_input_tokens":3000}}}"#
+    }
+
+    func test_read_claudeUsage_sumsInputAndCacheTokens() {
+        let path = writeTranscript([
+            #"{"type":"user","message":{"role":"user"}}"#,
+            claudeLine(60_000),
+        ])
+        let actual = TranscriptReader.read(path: path)
+        XCTAssertEqual(actual?.tokens, 60_000)  // 55000 + 2000 + 3000
+        XCTAssertEqual(actual?.model, "claude-opus-4-8")
+    }
+
+    func test_read_usesLatestAssistantUsage() {
+        // Occupancy climbs across turns; the reader reports the newest.
+        let path = writeTranscript([
+            claudeLine(40_000),
+            claudeLine(90_000),
+            claudeLine(150_000),
+        ])
+        XCTAssertEqual(TranscriptReader.read(path: path)?.tokens, 150_000)
+    }
+
+    func test_read_returnsNilWhenNoAssistantUsage() {
+        let path = writeTranscript([
+            #"{"type":"user","message":{"role":"user"}}"#,
+            #"{"type":"system","subtype":"init"}"#,
+        ])
+        XCTAssertNil(TranscriptReader.read(path: path))
+    }
+
+    func test_foldOverRealReadings_accumulatesAcrossCompaction() {
+        // Drive the real capture pipeline: at each Stop the transcript has grown
+        // (or been compacted), readClaude returns the latest occupancy, and fold
+        // banks it. Occupancy goes 50K → 150K → [compaction] 40K → 120K.
+        // Effort = 150K peak + (120K − 40K) new-cycle growth = 230K, not the
+        // 120K a latest-reading-wins capture would record.
+        let occupancyAtEachStop = [50_000, 150_000, 40_000, 120_000]
+        var lines: [String] = []
+        var state: (total: Int, lastReading: Int)?
+
+        for occupancy in occupancyAtEachStop {
+            lines.append(claudeLine(occupancy))
+            let path = writeTranscript(lines)
+            guard let stats = TranscriptReader.read(path: path) else {
+                return XCTFail("reader returned nil for a transcript with usage")
+            }
+            XCTAssertEqual(stats.tokens, occupancy)  // parsed real shape == expected occupancy
+            state = ContextTokens.fold(total: state?.total, lastReading: state?.lastReading,
+                                       newReading: stats.tokens)
+        }
+
+        XCTAssertEqual(state?.total, 230_000)
+        XCTAssertNotEqual(state?.total, 120_000)  // would be the naive latest-reading result
+    }
+}

--- a/panel/ContextTokens.swift
+++ b/panel/ContextTokens.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+// Folds successive context-window readings into a running cumulative total for
+// the handoff ledger. Each Stop captures the *current* context occupancy
+// (input + cache tokens at the latest turn), which climbs within a session and
+// then drops sharply when the conversation is compacted or /cleared. Overwriting
+// the stored figure with the latest reading makes a compacted session
+// under-report its real effort (the Tickets tab would show only the
+// post-compaction remainder). Instead we sum the growth across compaction
+// cycles, so the tab reflects total work done in the session.
+enum ContextTokens {
+
+    // A single-reading drop of at least this many tokens reads as a compaction
+    // or /clear rather than in-session noise. Shared with the context-fill
+    // banner's re-arm logic (Panel.evaluateContextThreshold) so both agree on
+    // what "a compaction" looks like.
+    static let compactDropThreshold = 20_000
+
+    // Fold `newReading` into the running (total, lastReading):
+    //   - growth within a cycle banks the delta;
+    //   - a ≥threshold drop is a compaction — the prior peak is already banked,
+    //     so a fresh cycle starts from the new occupancy without subtracting;
+    //   - a sub-threshold dip keeps the higher baseline, so a recovery only
+    //     banks genuine new growth above the prior peak;
+    //   - a nil lastReading (a new record, or one written before this model
+    //     existed) seeds the baseline without double-counting the prior total.
+    static func fold(total: Int?, lastReading: Int?, newReading: Int) -> (total: Int, lastReading: Int) {
+        guard let lastReading else {
+            return (max(total ?? 0, newReading), newReading)
+        }
+        let running = total ?? 0
+        if newReading > lastReading {
+            return (running + (newReading - lastReading), newReading)
+        }
+        if lastReading - newReading >= compactDropThreshold {
+            return (running, newReading)
+        }
+        return (running, lastReading)
+    }
+}

--- a/panel/Handoff.swift
+++ b/panel/Handoff.swift
@@ -12,7 +12,14 @@ struct HandoffRecord: Codable, Identifiable, Equatable {
     var branch: String?
     var ticket: String?         // Linear/Jira key (e.g. "ENG-12142"); nil if none
     var model: String?
-    var contextTokens: Int?     // latest context-window tokens for the session
+    // Cumulative context-window tokens for the session — summed growth across
+    // compaction cycles (see ContextTokens.fold), not just the latest reading,
+    // so a compacted session still reflects its real effort.
+    var contextTokens: Int?
+    // Last raw context-occupancy reading, kept only to fold the next one. Defaults
+    // nil so records written before cumulative tracking decode cleanly (→ re-seeded)
+    // and existing constructions don't need to supply this bookkeeping field.
+    var lastContextReading: Int? = nil
     // Uncommitted working-tree diff at the latest Stop (vs HEAD, + untracked).
     // Optional so records written before this field decode cleanly.
     var headCommit: String?

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -1508,7 +1508,14 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                     record.ticket = ticket
                     if let stats {
                         record.model = stats.model
-                        record.contextTokens = stats.tokens
+                        // Fold the reading into a running total so a compacted
+                        // session reflects its real effort, not just the
+                        // post-compaction remainder (see ContextTokens.fold).
+                        let folded = ContextTokens.fold(total: record.contextTokens,
+                                                        lastReading: record.lastContextReading,
+                                                        newReading: stats.tokens)
+                        record.contextTokens = folded.total
+                        record.lastContextReading = folded.lastReading
                     }
                     if let snapshot {
                         record.headCommit = snapshot.headCommit
@@ -1682,7 +1689,6 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     // alert pipeline, not anything the UI observes.
     private var contextAlertLastTokens: [String: Int] = [:]
     private var contextAlertFired: Set<String> = []
-    private static let contextCompactDropThreshold = 20_000
 
     // Decide whether to fire a context-fill banner for this session.
     // Rules:
@@ -1702,7 +1708,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         let current = stats.tokens
 
         if let last = contextAlertLastTokens[sessionID],
-           last - current >= Self.contextCompactDropThreshold {
+           last - current >= ContextTokens.compactDropThreshold {
             contextAlertFired.remove(sessionID)
         }
         contextAlertLastTokens[sessionID] = current


### PR DESCRIPTION
## Summary

The Tickets-tab token figure under-reported any session that compacted. We
captured `contextTokens` as the *latest* reading each Stop, but that reading is
the **current context-window occupancy**, which collapses when a conversation
is compacted or `/cleared` — so a 600K-token session that compacted twice might
show ~80K. This makes the figure cumulative across compaction cycles, so the
tab reflects real effort.

## Changes

- **`ContextTokens.fold`** (new, pure) folds each occupancy reading into a
  running total:
  - growth within a cycle banks the delta;
  - a **≥20K single-reading drop** is a compaction — the prior peak is already
    banked, so a fresh cycle starts from the new occupancy without subtracting;
  - a sub-threshold dip keeps the higher baseline (noise, not a reset);
  - a `nil` baseline (new record, or one written before this) seeds without
    double-counting, so legacy ledger rows upgrade cleanly.
- **Capture site** (`Panel.swift`) folds instead of overwriting. Non-compacted
  sessions are unchanged (sum of monotonic deltas == final reading).
- **Applies to every agent the capture reads** — both the Claude reader
  (`input + cache`) and the Codex reader (`last_token_usage.total − reasoning`)
  report current occupancy, so both compact and both are fixed.
- **`HandoffRecord` gains `lastContextReading`** (`Int?`, defaulted nil → old
  JSONL decodes cleanly) to carry the per-fold baseline.
- The 20K compaction threshold is now **one shared constant**, reused by the
  context-fill banner's re-arm logic so both agree on what a compaction is. The
  banner itself is untouched — it reads raw occupancy, not the ledger.

## Testing

- `./build.sh` → **Build complete**, zero warnings.
- `ContextTokensTests` pins the fold arithmetic (growth, compaction reset,
  sub-threshold noise, new + pre-upgrade seeding).
- `TranscriptReaderTests` adds previously-missing real-shape Claude usage-block
  coverage **and** an integration test that drives a real transcript through
  `TranscriptReader.read → fold` across a compaction, asserting it accumulates
  (230K) rather than collapsing to the latest reading (120K).
- `swift test` can't run locally (needs Xcode/XCTest), so both were validated
  with standalone `swiftc` harnesses against the **real source** — fold
  **10/10**, real parse→fold pipeline **9/9**. CI runs the XCTest suite.

## Related issues

Part of the post-1.17.0 Tickets-tab polish. No tracked issue.
