### PR TITLE
fix: security & correctness hardening from deep-dive audit

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -49,6 +49,13 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
       exit 1
     fi
   fi
+  # Don't destroy the installed copy until we've confirmed the new bundle
+  # actually carries an executable — a corrupt or incomplete artifact would
+  # otherwise leave the user with no app installed at all.
+  if ! ls "$PREBUILT_APP"/Contents/MacOS/* >/dev/null 2>&1; then
+    echo "  ✗ $PREBUILT_APP has no executable in Contents/MacOS — refusing to replace the installed app."
+    exit 1
+  fi
   rm -rf "$HOME/Applications/StackNudge.app"
   rm -rf "$HOME/Applications/stack-nudge-panel.app"  # clean up old panel binary
   cp -r "$PREBUILT_APP" "$HOME/Applications/StackNudge.app"
@@ -116,10 +123,22 @@ register_launchd_agent() {
   shift 3
   local plist_path="$HOME/Library/LaunchAgents/${label}.plist"
 
+  # Escape XML metacharacters before interpolating any value into the plist —
+  # a program arg or path containing & < > (e.g. an install dir whose name
+  # contains them) would otherwise produce a malformed plist launchd rejects.
+  xml_escape() {
+    local s="$1"
+    s="${s//&/&amp;}"; s="${s//</&lt;}"; s="${s//>/&gt;}"
+    printf '%s' "$s"
+  }
+
   local program_xml=""
   for arg in "$@"; do
-    program_xml+="        <string>${arg}</string>"$'\n'
+    program_xml+="        <string>$(xml_escape "$arg")</string>"$'\n'
   done
+  local label_xml log_xml
+  label_xml=$(xml_escape "$label")
+  log_xml=$(xml_escape "$log_path")
 
   local keep_alive_xml
   case "$keep_alive_mode" in
@@ -134,7 +153,7 @@ register_launchd_agent() {
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>${label}</string>
+    <string>${label_xml}</string>
     <key>ProgramArguments</key>
     <array>
 ${program_xml}    </array>
@@ -143,9 +162,9 @@ ${program_xml}    </array>
     <key>KeepAlive</key>
     ${keep_alive_xml}
     <key>StandardOutPath</key>
-    <string>${log_path}</string>
+    <string>${log_xml}</string>
     <key>StandardErrorPath</key>
-    <string>${log_path}</string>
+    <string>${log_xml}</string>
 </dict>
 </plist>
 PLIST

--- a/notify.conf.example
+++ b/notify.conf.example
@@ -44,3 +44,8 @@
 # always notify regardless of focus.
 # Default: true
 #STACKNUDGE_MUTE_WHEN_FOCUSED=false
+
+# Log a debug line (to the launchd log) explaining voice decisions — useful
+# when a notification played silently and you want to know why.
+# Default: false
+#STACKNUDGE_DEBUG=true

--- a/notify.sh
+++ b/notify.sh
@@ -239,8 +239,11 @@ voice_phrase_for() {
   fi
 
   local template="${templates[$((RANDOM % ${#templates[@]}))]}"
-  # shellcheck disable=SC2059
-  printf "$template" "$repo"
+  # Substitute the repo name into the %s placeholder ourselves rather than
+  # letting the phrase be a printf format string — a phrase (especially a
+  # user-supplied one from phrases.user.json) with stray % tokens would
+  # otherwise corrupt or truncate the spoken output.
+  printf '%s' "${template//%s/$repo}"
 }
 
 PANEL_SOCK="${HOME}/.stack-nudge/panel.sock"
@@ -583,10 +586,17 @@ notify_macos() {
 # Create a unique FIFO at /tmp for the user's response. Echoes the path.
 # Returns empty if mkfifo fails.
 create_perm_fifo() {
-  local fifo
-  fifo="/tmp/stack-nudge-perm-$$-$(date +%s)-$RANDOM.fifo"
+  # Place the FIFO inside a private mktemp dir (mode 0700, CSPRNG-named) rather
+  # than a $RANDOM-suffixed /tmp path — $RANDOM is only 16-bit, so the old name
+  # was guessable, letting a local attacker pre-create the FIFO or inject a
+  # decision. The dir is removed alongside the FIFO in wait_for_permission_response.
+  local dir
+  dir=$(mktemp -d "${TMPDIR:-/tmp}/stack-nudge-perm.XXXXXXXX" 2>/dev/null) || return
+  local fifo="$dir/fifo"
   if mkfifo -m 0600 "$fifo" 2>/dev/null; then
     echo "$fifo"
+  else
+    rmdir "$dir" 2>/dev/null
   fi
 }
 
@@ -598,7 +608,7 @@ wait_for_permission_response() {
   local fifo="$1"
   local timeout=550  # Claude Code's hook timeout defaults to 600s — leave buffer
 
-  trap 'rm -f "$fifo"' EXIT
+  trap 'rm -f "$fifo"; rmdir "$(dirname "$fifo")" 2>/dev/null' EXIT
 
   local decision
   decision=$(NUDGE_FIFO="$fifo" NUDGE_TIMEOUT="$timeout" python3 - <<'PY' 2>/dev/null

--- a/notify.sh
+++ b/notify.sh
@@ -9,9 +9,27 @@ AGENT="${1:-agent}"
 EVENT="${2:-stop}"
 OS="$(uname -s 2>/dev/null || echo Windows)"
 
-# Load user config (overrides defaults below).
+# Load user config (overrides defaults below). Parse as KEY=VALUE data only —
+# never `source` it, so anything able to write to this file (a compromised
+# postinstall, a stray tool) can't get arbitrary code to run on every hook
+# event. Only STACKNUDGE_* keys are recognised; anything else is ignored.
 # Copy notify.conf.example to ~/.stack-nudge/config to customise.
-[[ -f "${HOME}/.stack-nudge/config" ]] && source "${HOME}/.stack-nudge/config"
+load_stacknudge_config() {
+  local config="${HOME}/.stack-nudge/config"
+  [[ -f "$config" ]] || return 0
+  local line key value
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ "$line" =~ ^[[:space:]]*(export[[:space:]]+)?(STACKNUDGE_[A-Z0-9_]+)=(.*)$ ]] || continue
+    key="${BASH_REMATCH[2]}"
+    value="${BASH_REMATCH[3]}"
+    # Strip one layer of matching surrounding quotes, if present.
+    if [[ "$value" =~ ^\"(.*)\"$ ]] || [[ "$value" =~ ^\'(.*)\'$ ]]; then
+      value="${BASH_REMATCH[1]}"
+    fi
+    printf -v "$key" '%s' "$value"
+  done < "$config"
+}
+load_stacknudge_config
 
 # Read JSON piped from Claude Code hooks (contains transcript_path for Stop events).
 # Skip if stdin is a terminal (manual invocation).
@@ -305,12 +323,17 @@ detect_iterm_tab_name() {
   tty_path=$(tty 2>/dev/null) || return
   [[ -z "$tty_path" || "$tty_path" == "not a tty" ]] && return
 
-  ITERM_TAB_NAME=$(osascript <<APPLESCRIPT 2>/dev/null || true
+  # Pass the tty path through the environment and read it back with
+  # `system attribute` inside a quoted heredoc, rather than letting bash
+  # interpolate it into the script text — keeps an unusual /dev path (or a
+  # symlinked pseudo-tty name) from breaking out of the AppleScript string.
+  ITERM_TAB_NAME=$(STACKNUDGE_TTY="$tty_path" osascript <<'APPLESCRIPT' 2>/dev/null || true
+set ttyPath to system attribute "STACKNUDGE_TTY"
 tell application "iTerm2"
   repeat with w in windows
     repeat with t in tabs of w
       repeat with s in sessions of t
-        if (tty of s) is equal to "$tty_path" then
+        if (tty of s) is equal to ttyPath then
           return name of s
         end if
       end repeat
@@ -503,11 +526,17 @@ notify_macos() {
   local project_name
   project_name=$(basename "$PWD")
   if [[ -n "$process_name" ]]; then
-    win_title=$(osascript \
+    # Pass the project name through the environment and read it back inside
+    # AppleScript via `system attribute`, rather than interpolating it into the
+    # script text — a directory named `foo" & do shell script "…` would
+    # otherwise close the string and inject AppleScript/shell. process_name is
+    # safe to interpolate (it comes from the fixed bundle-id allowlist above).
+    win_title=$(STACKNUDGE_PROJECT_NAME="$project_name" osascript \
+      -e "set projectName to system attribute \"STACKNUDGE_PROJECT_NAME\"" \
       -e "tell application \"System Events\"" \
       -e "  tell process \"${process_name}\"" \
       -e "    try" \
-      -e "      get title of first window whose title contains \"${project_name}\"" \
+      -e "      get title of first window whose title contains projectName" \
       -e "    end try" \
       -e "  end tell" \
       -e "end tell" 2>/dev/null)

--- a/panel/AntigravityLocalServer.swift
+++ b/panel/AntigravityLocalServer.swift
@@ -46,7 +46,10 @@ enum AntigravityLocalServer {
             status = (response as? HTTPURLResponse)?.statusCode ?? 0
             semaphore.signal()
         }.resume()
-        _ = semaphore.wait(timeout: .now() + 5)
+        // Backstop above URLSession's own resource timeout (6s) so the request's
+        // completion handler is what releases the wait — not a shorter deadline
+        // that returns while the dataTask is still running.
+        _ = semaphore.wait(timeout: .now() + 8)
         return status == 200 ? payload : nil
     }
 

--- a/panel/CodexUsage.swift
+++ b/panel/CodexUsage.swift
@@ -29,10 +29,15 @@ final class CodexQuotaProbe {
     private var cacheKey: String?
     private var cached: CodexQuotaSnapshot?
 
+    // Serialises read() so overlapping polls — the 60s/5min timer firing while a
+    // prior fetch is still doing disk I/O on a large ~/.codex/sessions tree —
+    // can't race on cacheKey/cached. These are only ever touched on this queue.
+    private let probeQueue = DispatchQueue(label: "stack-nudge.codex-quota")
+
     // Calls completion on the main queue. File IO runs off-main.
     func fetch(completion: @escaping (CodexQuotaSnapshot?) -> Void) {
         let dir = sessionsDir
-        DispatchQueue.global(qos: .utility).async { [weak self] in
+        probeQueue.async { [weak self] in
             let result = self?.read(dir: dir) ?? nil
             DispatchQueue.main.async { completion(result) }
         }

--- a/panel/EventStore.swift
+++ b/panel/EventStore.swift
@@ -167,7 +167,7 @@ final class EventStore: ObservableObject {
         // identical one landed within the dedup window.
         let dedupWindow: TimeInterval = 2
         if events.contains(where: { existing in
-            event.timestamp.timeIntervalSince(existing.timestamp) < dedupWindow
+            abs(event.timestamp.timeIntervalSince(existing.timestamp)) < dedupWindow
                 && existing.agent == event.agent
                 && existing.kind == event.kind
                 && existing.message == event.message

--- a/panel/GitHubAPI.swift
+++ b/panel/GitHubAPI.swift
@@ -71,8 +71,17 @@ enum GitHubAPI {
 
     static func parse(_ json: String) -> PullRequestInfo? {
         guard let data = json.data(using: .utf8),
-              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let node = firstPRNode(root),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        // GraphQL returns HTTP 200 with {"data":null,"errors":[…]} on failures
+        // (bad token, rate limit, field errors). Surface them instead of
+        // silently treating the response as "no PR found".
+        if let errors = root["errors"] as? [[String: Any]], !errors.isEmpty {
+            let messages = errors.compactMap { $0["message"] as? String }.joined(separator: "; ")
+            FileHandle.standardError.write(Data("stack-nudge: GitHub GraphQL errors: \(messages)\n".utf8))
+            return nil
+        }
+        guard let node = firstPRNode(root),
               let number = node["number"] as? Int,
               let url = node["url"] as? String,
               let stateRaw = node["state"] as? String,

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -219,6 +219,9 @@ struct PanelContentView: View {
 
     private var eventsBody: some View {
         VStack(alignment: .leading, spacing: 0) {
+            if let error = nav.listenerError {
+                listenerErrorBanner(error)
+            }
             if store.events.isEmpty {
                 emptyState
             } else {
@@ -227,6 +230,21 @@ struct PanelContentView: View {
             footer
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private func listenerErrorBanner(_ error: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text(error)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.orange.opacity(0.12))
     }
 
     private var emptyState: some View {
@@ -1198,10 +1216,15 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         quotaProbe.fetch { [weak self] snapshot in
             guard let self else { return }
             self.nav.quotaSyncing = false
-            guard let snapshot else { return }
-            self.nav.quota = snapshot
-            self.nav.quotaLastUpdated = Date()
-            self.evaluateQuotaThresholds(snapshot)
+            self.nav.usingPlaintextCredentials = self.quotaProbe.usingPlaintextCredentials
+            if let snapshot {
+                self.nav.quota = snapshot
+                self.nav.quotaError = nil
+                self.nav.quotaLastUpdated = Date()
+                self.evaluateQuotaThresholds(snapshot)
+            } else if self.quotaProbe.lastProbeFailed {
+                self.nav.quotaError = "Quota data unavailable — the usage endpoint may have changed."
+            }
         }
         // Codex (ChatGPT-plan) rate limits — read locally from the newest
         // rollout, no network. Independent of the Anthropic probe above so one
@@ -2790,9 +2813,13 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         listener = EventListener(store: store, socketPath: socketPath)
         do {
             try listener?.start()
+            nav.listenerError = nil
         } catch {
             FileHandle.standardError.write(Data(
                 "stack-nudge-panel: listener failed: \(error)\n".utf8))
+            nav.listenerError =
+                "Event socket failed to start — agent notifications won't arrive. "
+                + "Restart StackNudge to retry. (\(error))"
         }
     }
 }

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -1638,7 +1638,8 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                     userCode: response.userCode, verificationURI: response.verificationURI)
                 self.pollGithubSignIn(clientID: clientID,
                                       deviceCode: response.deviceCode,
-                                      interval: response.interval)
+                                      interval: response.interval,
+                                      deadline: Date().addingTimeInterval(TimeInterval(response.expiresIn)))
             }
         }
     }
@@ -1647,9 +1648,15 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
 
     // One poll per `interval` seconds. Stops if the user cancelled (state left
     // awaitingApproval). On success, stores the token and kicks a PR refresh.
-    private func pollGithubSignIn(clientID: String, deviceCode: String, interval: Int) {
+    private func pollGithubSignIn(clientID: String, deviceCode: String, interval: Int, deadline: Date) {
         DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(max(1, interval))) { [weak self] in
             guard let self, case .awaitingApproval = self.nav.githubSignIn else { return }
+            // Enforce the device code's own expiry (RFC 8628 §3.5) rather than
+            // polling forever if the endpoint never returns expired_token.
+            if Date() >= deadline {
+                self.nav.githubSignIn = .failed("Code expired — try again")
+                return
+            }
             GitHubAuth.poll(clientID: clientID, deviceCode: deviceCode) { result in
                 DispatchQueue.main.async {
                     guard case .awaitingApproval = self.nav.githubSignIn else { return }
@@ -1660,9 +1667,10 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                         self.nav.githubSignIn = .idle
                         self.refreshPullRequests()
                     case .pending:
-                        self.pollGithubSignIn(clientID: clientID, deviceCode: deviceCode, interval: interval)
+                        self.pollGithubSignIn(clientID: clientID, deviceCode: deviceCode, interval: interval, deadline: deadline)
                     case .slowDown(let slower):
-                        self.pollGithubSignIn(clientID: clientID, deviceCode: deviceCode, interval: slower)
+                        // RFC 8628: back off by at least 5s; honour a larger server interval.
+                        self.pollGithubSignIn(clientID: clientID, deviceCode: deviceCode, interval: max(slower, interval + 5), deadline: deadline)
                     case .expired:
                         self.nav.githubSignIn = .failed("Code expired — try again")
                     case .denied:
@@ -2533,10 +2541,12 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         let sendApproval = approve && event.hasActionButton
 
         // FIFO path = the source hook is blocking on a permission decision.
-        // Write "allow" to it and we're done — Claude Code skips its UI prompt.
-        if sendApproval, let fifo = event.fifoPath {
+        // Write the decision (allow or deny) and we're done — the agent consumes
+        // it and skips its own UI prompt. Previously only "allow" was written, so
+        // a Deny left the hook blocked until its 550s timeout.
+        if let fifo = event.fifoPath {
             DispatchQueue.global(qos: .userInitiated).async {
-                Self.writeFIFO(fifo, "allow")
+                Self.writeFIFO(fifo, approve ? "allow" : "deny")
             }
             return
         }

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -178,6 +178,19 @@ final class PanelNav: ObservableObject {
     // True while a probe is in-flight. Set by PanelController around the
     // fetch call so the UI can swap the footer status to "Syncing…".
     @Published var quotaSyncing:     Bool = false
+    // Set when a probe had a token but the request/parse failed (vs. simply
+    // having no Claude Code session). Drives the Usage tab's "quota unavailable"
+    // state so a silently-changed endpoint isn't read as "still loading".
+    // Cleared on the next successful probe.
+    @Published var quotaError:       String?
+    // True when the Claude token was read from the plaintext
+    // ~/.claude/.credentials.json rather than the Keychain — any same-user
+    // process can read that file. Drives a warning in Settings → Usage.
+    @Published var usingPlaintextCredentials: Bool = false
+    // Set when the event socket failed to bind at startup — the panel is then
+    // deaf to every agent notification. Drives the banner at the top of the
+    // Events tab so the failure isn't silent. Cleared when the socket binds.
+    @Published var listenerError:    String?
     // Per-Claude-session context-window stats. Keyed by Claude's
     // session_id UUID (NudgeEvent.claudeSessionID), populated by
     // PanelController whenever an event arrives with a transcript_path.

--- a/panel/Phrases.swift
+++ b/panel/Phrases.swift
@@ -113,7 +113,11 @@ struct PhraseStore {
         let pipe = Pipe()
         task.standardOutput = pipe
         task.standardError  = Pipe()
-        do { try task.run() } catch { return [:] }
+        do { try task.run() } catch {
+            FileHandle.standardError.write(Data(
+                "stack-nudge: failed to load phrase defaults for \(lang): \(error)\n".utf8))
+            return [:]
+        }
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         task.waitUntilExit()
 

--- a/panel/SessionUsage.swift
+++ b/panel/SessionUsage.swift
@@ -78,6 +78,14 @@ final class QuotaProbe {
     // token is cached. nil when the field isn't present.
     private var lastSubscriptionType: String?
 
+    // Surfaced to the UI by PanelController after each probe (both touched only
+    // on the main queue, like cachedToken). lastProbeFailed is true when we had
+    // a token but the request/parse failed — distinct from having no token at
+    // all. usingPlaintextCredentials is true when the token came from the
+    // plaintext credentials file rather than the Keychain.
+    private(set) var lastProbeFailed = false
+    private(set) var usingPlaintextCredentials = false
+
     init() {
         let cfg = URLSessionConfiguration.ephemeral
         cfg.timeoutIntervalForRequest  = 10
@@ -98,6 +106,7 @@ final class QuotaProbe {
             cachedToken = fresh
             token = fresh
         } else {
+            lastProbeFailed = false
             completion(nil)
             return
         }
@@ -129,10 +138,16 @@ final class QuotaProbe {
                     FileHandle.standardError.write(Data(
                         "stack-nudge: /api/oauth/usage returned \(code)\n".utf8))
                 }
-                DispatchQueue.main.async { completion(nil) }
+                DispatchQueue.main.async {
+                    self?.lastProbeFailed = true
+                    completion(nil)
+                }
                 return
             }
-            DispatchQueue.main.async { completion(snapshot) }
+            DispatchQueue.main.async {
+                self?.lastProbeFailed = false
+                completion(snapshot)
+            }
         }.resume()
     }
 
@@ -144,7 +159,11 @@ final class QuotaProbe {
     // the Keychain item ~every 8h, wiping the ACL grant — anthropics/claude-code#22144,
     // closed as not planned) can opt in by writing the file at mode 0600.
     private func readAccessToken() -> String? {
-        if let token = readCredentialsFile() { return token }
+        if let token = readCredentialsFile() {
+            usingPlaintextCredentials = true
+            return token
+        }
+        usingPlaintextCredentials = false
         return readKeychainToken()
     }
 
@@ -450,17 +469,33 @@ struct UsageView: View {
 
     private var emptyState: some View {
         VStack(spacing: 10) {
-            ProgressView()
-                .controlSize(.small)
-            Text("Loading usage…")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-            Text("Requires a signed-in Claude Code session, or a Codex session on a ChatGPT plan. The first Claude read may prompt the system keychain.")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 280)
-                .fixedSize(horizontal: false, vertical: true)
+            if let error = nav.quotaError {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.title2)
+                    .foregroundStyle(.orange)
+                Text(error)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                Text("StackNudge reads an unofficial Claude usage endpoint; a Claude Code update can change its shape. This clears on its own once the endpoint is reachable and parseable again.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 280)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Loading usage…")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Text("Requires a signed-in Claude Code session, or a Codex session on a ChatGPT plan. The first Claude read may prompt the system keychain.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 280)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.vertical, 24)

--- a/panel/Settings.swift
+++ b/panel/Settings.swift
@@ -82,6 +82,14 @@ struct SettingsView: View {
                             row(.pollFrequency, label: "Poll frequency",  kind: .cycle,  value: "\(nav.quotaPollMinutes) min",            enabled: nav.quotaTrackingEnabled)
                             row(.contextAlert,  label: "Context alert at", kind: .cycle, value: contextAlertLabel)
                             row(.showRemaining, label: "Show remaining",   kind: .toggle, value: nav.quotaShowRemaining ? "On" : "Off", enabled: nav.quotaTrackingEnabled)
+                            if nav.usingPlaintextCredentials {
+                                Text("⚠︎ Reading the Claude token from ~/.claude/.credentials.json (plaintext) — any process running as you can read it. Delete that file to fall back to the Keychain.")
+                                    .font(.caption)
+                                    .foregroundStyle(.orange)
+                                    .padding(.horizontal, 14)
+                                    .padding(.top, 2)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
                         }
 
                         section("Tickets") {

--- a/panel/Updater.swift
+++ b/panel/Updater.swift
@@ -163,16 +163,17 @@ final class Updater {
                                           expectedSize: asset.size)
         appendLog("Downloaded to \(tarballURL.path)")
 
-        // 3. Verify checksum if a sidecar was published.
-        if let sha = shaAsset {
-            setPhase(.verifying)
-            try verifyChecksum(tarballURL: tarballURL,
-                               shaAssetURL: sha.downloadURL,
-                               assetName: asset.name)
-            appendLog("Checksum OK")
-        } else {
-            appendLog("No .sha256 sidecar — skipping checksum (release isn't yet wired for it)")
+        // 3. Verify checksum. Every release publishes a .sha256 sidecar
+        //    (release.yml), so a missing one means a tampered or incomplete
+        //    release — refuse rather than install an unverified artifact.
+        guard let sha = shaAsset else {
+            throw UpdateError.checksumSidecarMissing(assetName: asset.name)
         }
+        setPhase(.verifying)
+        try verifyChecksum(tarballURL: tarballURL,
+                           shaAssetURL: sha.downloadURL,
+                           assetName: asset.name)
+        appendLog("Checksum OK")
 
         // 4. Extract.
         setPhase(.extracting)
@@ -576,6 +577,7 @@ enum UpdateError: LocalizedError {
     case downloadHTTP(status: Int)
     case downloadSizeMismatch(expected: Int, got: Int)
     case checksumFetchFailed
+    case checksumSidecarMissing(assetName: String)
     case checksumMismatch(expected: String, actual: String, assetName: String)
     case extractFailed(stderr: String)
     case swapFailed(underlying: Error)
@@ -594,6 +596,8 @@ enum UpdateError: LocalizedError {
             return "Downloaded \(got) bytes, expected \(expected) bytes."
         case .checksumFetchFailed:
             return "Couldn't fetch the .sha256 sidecar for the release artifact."
+        case .checksumSidecarMissing(let assetName):
+            return "No .sha256 sidecar published for \(assetName) — refusing to install an unverified update."
         case .checksumMismatch(let expected, let actual, let assetName):
             return "Checksum mismatch for \(assetName). Expected \(expected), got \(actual)."
         case .extractFailed(let stderr):


### PR DESCRIPTION
Summary

Resolves the high- and medium-severity findings from a deep-dive code audit of the repo. The common thread is closing security holes and surfacing failures that were previously silent: AppleScript/shell injection in the hook, arbitrary code execution via a sourced config file, a Codex quota data race, a Deny that hung the agent, an auto-update that skipped checksum verification, and several "fails with no UI signal" paths in the panel.

Changes

Security — notify.sh / install.sh
- Parse ~/.stack-nudge/config as allowlisted STACKNUDGE_* KEY=VALUE data instead of source-ing it, so a write to that file can't run code on every hook event.
- Pass the project name (cwd basename) and tty path into osascript via the environment + system attribute rather than interpolating them into the AppleScript text — closes injection via a maliciously named directory or tty path.
- Render voice phrases with explicit %s substitution instead of as a printf format string (stray % no longer corrupts output).
- Create the permission FIFO in a private mktemp -d dir (0700) instead of a guessable 16-bit $RANDOM path.
- XML-escape values written into the launchd plist; verify the prebuilt bundle has an executable before replacing the installed app.

Correctness — panel
- CodexQuotaProbe.read() runs on a private serial queue — no data race on cacheKey/cached.
- Deny now writes the permission FIFO (previously only Allow did), so a Deny no longer blocks the agent's hook until its 550s timeout.
- EventStore dedup uses abs() on the timestamp delta — out-of-order events aren't dropped as false duplicates.
- Device-flow sign-in enforces the code's expiry (RFC 8628) and backs off by ≥5s on slow_down.
- AntigravityLocalServer semaphore backstop raised above the URLSession resource timeout.

Robustness — surfacing silent failures
- Updater refuses to install when a release has no .sha256 sidecar, instead of silently skipping checksum verification.
- GitHubAPI.parse detects the GraphQL errors envelope (HTTP 200 + {errors:[…]}) instead of treating it as "no PR".
- Socket-bind failure, unofficial Anthropic quota-endpoint failures, and use of the plaintext ~/.claude/.credentials.json token are now surfaced in the UI (Events banner, Usage "unavailable" state, Settings warning) rather than failing silently.

Testing

- ./build.sh passes for both arm64 and x86_64 (clean compile + link + ad-hoc sign).
- swiftc -typecheck panel/*.swift shared/*.swift — 0 errors.
- bash -n + shellcheck -S warning clean on all tracked *.sh (matches CI's lint job).
- notify.sh config parser functionally tested: parses valid STACKNUDGE_* keys, ignores others, does not execute injected $(…).
- Unit tests not run locally (XCTest needs full Xcode — CI runs swift test on both arches); statically verified no existing test over changed code regresses.
