### PR TITLE
fix(install): pkill the correct app path on reinstall

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -193,7 +193,7 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
   # BEFORE we re-register the launchd agents, so the unload-then-load below
   # doesn't race with an old instance still hanging on. Matching the exact
   # binary path so we don't reap unrelated processes.
-  pkill -f "Applications/stack-nudge\.app/Contents/MacOS/stack-nudge$" 2>/dev/null || true
+  pkill -f "Applications/StackNudge\.app/Contents/MacOS/stack-nudge$" 2>/dev/null || true
   pkill -f "venv/bin/stackvox serve$"                                  2>/dev/null || true
 
   register_launchd_agent \


### PR DESCRIPTION
## Summary

The survivor-process `pkill` in `install.sh` matched the pre-v1.7 bundle name `Applications/stack-nudge.app/...`, but the app installs to — and is registered with launchd (`ProgramArguments`) as — `Applications/StackNudge.app/...`. So the running panel was never killed before the launchd unload/reload, leaving a brief two-instance window on every reinstall/upgrade.

## Changes

- `install.sh:196` — match the live `StackNudge.app` path so the old panel process is actually reaped before the launchd agents are re-registered.

## Testing

- `bash -n` + `shellcheck -S warning` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
