### PR TITLE
fix: harden phrase pipeline, validate IPC fifo_path, fix 'O'-key orphan

### DIFF
--- a/notify.sh
+++ b/notify.sh
@@ -189,42 +189,75 @@ voice_phrase_for() {
     return
   fi
 
-  # shellcheck disable=SC1090
-  source "$lang_file"
+  # Parse the phrase arrays out of the file as DATA — never `source` it. The
+  # file lives in a user-writable install dir, so sourcing ran arbitrary shell
+  # on every hook event. extract_phrase_array does a pure text scan of the
+  # `NAME=( "…" "…" )` literal (handles \" and \\; a `)` inside a quote is safe).
+  extract_phrase_array() {
+    awk -v name="$2" '
+      BEGIN { active=0; instr=0; esc=0; cur=""; opener=name "=(" }
+      {
+        line=$0; i=1; n=length(line)
+        if (!active) {
+          if (substr(line,1,length(opener))==opener) { active=1; i=length(opener)+1 }
+          else next
+        }
+        for (; i<=n; i++) {
+          c=substr(line,i,1)
+          if (instr) {
+            if (esc) { cur=cur c; esc=0 }
+            else if (c=="\\") { esc=1 }
+            else if (c=="\"") { printf "%s%c", cur, 0; cur=""; instr=0 }
+            else { cur=cur c }
+          } else if (c=="\"") { instr=1 }
+          else if (c==")") { active=0; exit }
+        }
+      }
+    ' "$1"
+  }
+  local item
+  TEMPLATES_RESPONSE=()
+  TEMPLATES_NOTIFICATION=()
+  while IFS= read -r -d '' item; do TEMPLATES_RESPONSE+=("$item"); done \
+    < <(extract_phrase_array "$lang_file" TEMPLATES_RESPONSE)
+  while IFS= read -r -d '' item; do TEMPLATES_NOTIFICATION+=("$item"); done \
+    < <(extract_phrase_array "$lang_file" TEMPLATES_NOTIFICATION)
 
   # Layer user-managed phrases from phrases.user.json on top of the shipped
-  # arrays. Each pool can declare disabled defaults (skipped) and custom
-  # additions (appended). Quiet failure if jq isn't installed or the file's
-  # missing — the user just gets the unmodified defaults.
+  # arrays (disabled removals + custom additions). No `eval`: each pool's
+  # current items go in as positional args and the filtered result comes back
+  # NUL-delimited, so a custom phrase containing $(...) or a quote stays inert.
   local user_json="${HOME}/.stack-nudge/phrases.user.json"
   if [[ -f "$user_json" ]] && command -v jq >/dev/null 2>&1; then
-    # filter_pool <jq-path-prefix> <bash-array-name>
-    filter_pool() {
-      local pool="$1" arr="$2"
-      local disabled
+    apply_user_phrases() {
+      local pool="$1"; shift
+      local disabled d skip elem
+      local result=()
       disabled=$(jq -r --arg lang "$lang" --arg pool "$pool" \
                  '.[$lang][$pool].disabled[]?' "$user_json" 2>/dev/null)
-      if [[ -n "$disabled" ]]; then
-        local kept=()
-        local existing
-        eval "existing=(\"\${${arr}[@]}\")"
-        for existing_item in "${existing[@]}"; do
-          local skip=0
+      for elem in "$@"; do
+        skip=0
+        if [[ -n "$disabled" ]]; then
           while IFS= read -r d; do
-            [[ "$existing_item" == "$d" ]] && { skip=1; break; }
+            [[ "$elem" == "$d" ]] && { skip=1; break; }
           done <<< "$disabled"
-          [[ $skip -eq 0 ]] && kept+=("$existing_item")
-        done
-        eval "${arr}=(\"\${kept[@]}\")"
-      fi
-      local extra
-      while IFS= read -r extra; do
-        [[ -n "$extra" ]] && eval "${arr}+=(\"\$extra\")"
+        fi
+        [[ $skip -eq 0 ]] && result+=("$elem")
+      done
+      while IFS= read -r elem; do
+        [[ -n "$elem" ]] && result+=("$elem")
       done < <(jq -r --arg lang "$lang" --arg pool "$pool" \
                '.[$lang][$pool].custom[]?' "$user_json" 2>/dev/null)
+      [[ ${#result[@]} -gt 0 ]] && printf '%s\0' "${result[@]}"
     }
-    filter_pool "response"     TEMPLATES_RESPONSE
-    filter_pool "notification" TEMPLATES_NOTIFICATION
+    local tmp=()
+    while IFS= read -r -d '' item; do tmp+=("$item"); done \
+      < <(apply_user_phrases response "${TEMPLATES_RESPONSE[@]}")
+    TEMPLATES_RESPONSE=("${tmp[@]}")
+    tmp=()
+    while IFS= read -r -d '' item; do tmp+=("$item"); done \
+      < <(apply_user_phrases notification "${TEMPLATES_NOTIFICATION[@]}")
+    TEMPLATES_NOTIFICATION=("${tmp[@]}")
   fi
 
   local templates=()

--- a/panel/EventListener.swift
+++ b/panel/EventListener.swift
@@ -176,6 +176,22 @@ private struct NudgeEventDTO: Decodable {
     let claude_session_id: String?
     let transcript_path: String?
 
+    // Only accept a fifo_path that looks like one of our permission FIFOs AND
+    // is actually a FIFO on disk. The socket is a trust boundary: any same-uid
+    // process that can write it could otherwise supply an arbitrary path, and
+    // the panel's writeFIFO would then clobber a regular file or deliver a
+    // fabricated allow/deny to the agent. We drop just the path (not the whole
+    // event) on failure, so the nudge still shows but can't auto-resolve.
+    private static func validatedFifoPath(_ path: String?) -> String? {
+        guard let path,
+              path.contains("/stack-nudge-perm."),
+              (path as NSString).lastPathComponent == "fifo"
+        else { return nil }
+        var st = stat()
+        guard stat(path, &st) == 0, (st.st_mode & S_IFMT) == S_IFIFO else { return nil }
+        return path
+    }
+
     func toNudgeEvent() -> NudgeEvent {
         NudgeEvent(
             agent: agent,
@@ -195,7 +211,7 @@ private struct NudgeEventDTO: Decodable {
             termProgram: term_program,
             sessionID: session_id,
             itermTabName: iterm_tab_name,
-            fifoPath: fifo_path,
+            fifoPath: Self.validatedFifoPath(fifo_path),
             voiceMessage: voice_message,
             soundName: sound_name,
             bypassMute: bypass_mute ?? false,

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -2616,14 +2616,19 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     // target's key window.
     private func actOnSelected(approve: Bool) {
         guard let event = store.selectedEvent else { return }
-        store.remove(id: event.id)
-        // Stay on the panel if there are more events to act on; otherwise
-        // close so the system frontmost reverts naturally and the approval
-        // keystroke lands in the target app's key window (see comment above
-        // about why hiding must precede the keystroke dispatch).
-        if store.events.isEmpty { hidePanel() }
-
         let sendApproval = approve && event.hasActionButton
+
+        // A blocking permission opened via 'O' (approve:false, "Open editor")
+        // must stay in the panel so the user can still resolve it (Dismiss →
+        // deny); removing it would orphan the hook for ~550s with no recovery
+        // path. Approvals — and any event without a pending FIFO — are removed
+        // as before. Stay on the panel if other events remain; otherwise close
+        // so the system frontmost reverts naturally and the approval keystroke
+        // lands in the target app's key window (see comment above re: hiding).
+        if sendApproval || event.fifoPath == nil {
+            store.remove(id: event.id)
+            if store.events.isEmpty { hidePanel() }
+        }
 
         // Approve a blocking permission by writing "allow" to its FIFO; the agent
         // then skips its own prompt. Deny is the Dismiss gesture (see

--- a/panel/Phrases.swift
+++ b/panel/Phrases.swift
@@ -95,48 +95,43 @@ struct PhraseStore {
         try? data.write(to: jsonURL, options: .atomic)
     }
 
-    // Read shipped defaults for a given language by sourcing the bash file
-    // and printing the arrays as JSON. We don't want to maintain two sources
-    // of truth for the defaults — they live in phrases/<lang>.sh.
+    // Read shipped defaults for a given language by parsing the phrase arrays
+    // out of phrases/<lang>.sh as DATA — never sourcing the file. The file lives
+    // under user-writable ~/.stack-nudge/phrases/, so the old `bash -c source`
+    // ran arbitrary shell in this long-lived, entitlement-holding process.
     static func defaults(lang: String) -> [PhrasePool: [String]] {
         let phrasesDir = (NSHomeDirectory() as NSString)
             .appendingPathComponent(".stack-nudge/phrases")
         let path = "\(phrasesDir)/\(lang).sh"
-        guard FileManager.default.fileExists(atPath: path) else { return [:] }
-
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/bin/bash")
-        task.arguments = [
-            "-c",
-            "source \"\(path)\"; printf '%s\\0' \"${TEMPLATES_RESPONSE[@]}\"; printf '\\0'; printf '%s\\0' \"${TEMPLATES_NOTIFICATION[@]}\"",
+        guard let text = try? String(contentsOfFile: path, encoding: .utf8) else { return [:] }
+        return [
+            .response:     parseBashArray(named: "TEMPLATES_RESPONSE", in: text),
+            .notification: parseBashArray(named: "TEMPLATES_NOTIFICATION", in: text),
         ]
-        let pipe = Pipe()
-        task.standardOutput = pipe
-        task.standardError  = Pipe()
-        do { try task.run() } catch {
-            FileHandle.standardError.write(Data(
-                "stack-nudge: failed to load phrase defaults for \(lang): \(error)\n".utf8))
-            return [:]
-        }
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        task.waitUntilExit()
+    }
 
-        let parts = data.split(separator: 0x00, maxSplits: .max,
-                                omittingEmptySubsequences: false)
-        var responseItems: [String] = []
-        var notificationItems: [String] = []
-        var crossedBoundary = false
-        for part in parts {
-            if part.isEmpty {
-                if !crossedBoundary { crossedBoundary = true }
-                continue
+    // Extract the double-quoted string elements of a `NAME=( "…" "…" )` bash
+    // array literal. Pure text scan — no shell execution. Handles \" and \\
+    // escapes; a literal `)` inside a quoted phrase doesn't end the array.
+    static func parseBashArray(named name: String, in text: String) -> [String] {
+        guard let open = text.range(of: "\(name)=(") else { return [] }
+        var items: [String] = []
+        var current = ""
+        var inString = false
+        var escaped = false
+        for ch in text[open.upperBound...] {
+            if inString {
+                if escaped { current.append(ch); escaped = false }
+                else if ch == "\\" { escaped = true }
+                else if ch == "\"" { items.append(current); current = ""; inString = false }
+                else { current.append(ch) }
+            } else if ch == "\"" {
+                inString = true
+            } else if ch == ")" {
+                break
             }
-            let s = String(data: Data(part), encoding: .utf8) ?? ""
-            guard !s.isEmpty else { continue }
-            if !crossedBoundary { responseItems.append(s) }
-            else                 { notificationItems.append(s) }
         }
-        return [.response: responseItems, .notification: notificationItems]
+        return items
     }
 }
 


### PR DESCRIPTION
## Summary

Resolves all five HIGH findings from the third `/deep-dive` on v1.19.1. Three are an arbitrary-code-execution class — the phrase pipeline read user-writable files under `~/.stack-nudge/` by *executing* them (the same class PR #98 closed for the config file); the other two harden the permission IPC path and the open-editor gesture.

## Changes

**Phrase pipeline — stop executing user-writable files (RCE)**
- `notify.sh`: parse the `TEMPLATES_*` array literals out of `phrases/<lang>.sh` as **data** via a pure awk text scan, instead of `source`-ing the file.
- `notify.sh`: apply `phrases.user.json` (disabled removals + custom additions) without `eval` — each pool's items go through a function as positional args and come back NUL-delimited, so a custom phrase containing `$(…)` or a quote stays literal.
- `Phrases.swift`: parse the array literals in Swift instead of `bash -c "source <path>"` in the resident, entitlement-holding panel process.

**Permission IPC / gesture**
- `EventListener.swift`: validate the socket-supplied `fifo_path` (`/stack-nudge-perm.` prefix + basename `fifo` + `S_ISFIFO`) before accepting it — a same-uid process could otherwise have the panel write `allow`/`deny` into an arbitrary file or a fabricated pipe. Drop just the path on failure (the nudge still shows).
- `Panel.swift`: `actOnSelected` no longer removes the event before the FIFO check, so `'O'` ("Open editor") on a blocking permission keeps it in the panel (resolvable via Dismiss → deny) instead of orphaning the hook for ~550s.

## Testing

- `swiftc -typecheck panel/*.swift shared/*.swift` — 0 errors.
- Full `./build.sh` (arm64) — clean compile + link + ad-hoc sign.
- `bash -n` + `shellcheck -S warning` clean on `notify.sh`.
- Functional tests of **both** new phrase parsers against a hostile phrase file + `phrases.user.json`: correct extraction, disable/custom behaviour preserved, and `$(…)`/quote payloads proven inert (no code executed). The Swift parser is also verified on a `")"`-inside-a-phrase case. Bash side deliberately avoids 3.2-incompatible constructs (no namerefs / `mapfile -d`).
- Unit tests not run locally (XCTest needs full Xcode); CI runs `swift test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
