### PR TITLE
fix(sessions): recognise iTermServer daemon so focus works

### DIFF
--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -2748,12 +2748,25 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
               let session = sessions.sessions.first(where: { $0.pid == pid }),
               let bundleID = bundleID(for: session.terminalApp) else { return }
         hidePanel()
+        // session.tabId is the per-tab identity our terminal integrations
+        // captured, but the underlying value differs per terminal — so it
+        // has to reach AppActivator via the parameter that terminal's
+        // activation path reads. VSCode/Cursor/Antigravity store
+        // VSCODE_IPC_HOOK_CLI (→ ipcHook, disambiguates windows for
+        // --reuse-window); iTerm2 stores its session GUID (→ sessionID,
+        // selects the exact pane). Ghostty/Warp/Terminal fall back to
+        // projectPath / AX tab-title and need neither. Without this the
+        // captured tabId was dropped and focus landed on whatever window
+        // the app last had frontmost.
+        let ipcHook = VSCodeIntegration.isVSCodeHosted(session.terminalApp) ? session.tabId : nil
+        let sessionID = session.terminalApp?.contains("iTerm") == true ? session.tabId : nil
         DispatchQueue.global(qos: .userInitiated).async {
             AppActivator.activate(
                 bundleID: bundleID,
                 windowTitle: session.projectName,
-                ipcHook: nil,
+                ipcHook: ipcHook,
                 projectPath: session.projectPath,
+                sessionID: sessionID,
                 sendApproval: false,
                 agent: session.agent
             )

--- a/panel/SessionStore.swift
+++ b/panel/SessionStore.swift
@@ -446,6 +446,24 @@ final class SessionStore: ObservableObject {
         "iTerm2", "iTerm", "Terminal", "Warp", "WarpTerminal", "ghostty", "Ghostty",
     ]
 
+    // Resolve a raw `ps` process name to the canonical terminal-app name the
+    // rest of the app keys off (bundleID lookup, iTerm enrichment, focus).
+    // Most terminals present with a stable name already in `terminalApps`.
+    // iTerm2 3.5+ is the exception: each session runs under a detached
+    // `iTermServer-<version>` daemon (session restoration) parented to
+    // launchd, not under the iTerm2 app — so the process name is
+    // version-suffixed (e.g. "iTermServer-3.6.11") and never equals "iTerm2",
+    // and the app itself isn't in the parent chain to walk up to. Left
+    // unmapped, those sessions get no terminalApp — which drops their tab
+    // enrichment and makes Enter-to-focus a silent no-op. Map the daemon back
+    // to "iTerm2" so every downstream check (which matches "iTerm2" exactly or
+    // via contains("iTerm")) recognises it.
+    private static func canonicalTerminalApp(_ processName: String) -> String? {
+        if terminalApps.contains(processName) { return processName }
+        if processName.hasPrefix("iTermServer") { return "iTerm2" }
+        return nil
+    }
+
     private static func readProcessTable() -> [Int: ProcessInfo] {
         let output = runProcess("/bin/ps", ["-axww", "-o", "pid=,ppid=,comm="])
         var result: [Int: ProcessInfo] = [:]
@@ -473,9 +491,9 @@ final class SessionStore: ObservableObject {
                   let info = processTable[next]
             else { break }
             let base = (info.command as NSString).lastPathComponent
-            if terminalApps.contains(base) {
+            if let canonical = canonicalTerminalApp(base) {
                 chain.terminalPID = next
-                chain.terminalApp = base
+                chain.terminalApp = canonical
                 return chain
             }
             current = info.parentPID

--- a/shared/AppActivator.swift
+++ b/shared/AppActivator.swift
@@ -356,7 +356,11 @@ struct AppActivator {
             repeat with t in tabs of w
               repeat with s in sessions of t
                 try
-                  if (id of s as text) is target then
+                  -- Match on `unique id` (the persistent session GUID that
+                  -- both ITERM_SESSION_ID and our tab enrichment carry);
+                  -- keep `id` as a fallback for iTerm2 versions where the
+                  -- two properties diverge.
+                  if ((unique id of s) as text) is target or ((id of s) as text) is target then
                     tell w to select
                     tell t to select
                     tell s to select


### PR DESCRIPTION
## Problem

Pressing **⏎ Focus** on the Sessions tab did nothing — it never brought the session's window/tab to the front. The tab also showed reduced session data (no terminal name, tab label, or accent colour) for iTerm2 sessions.

## Root cause

iTerm2 3.5+ runs each session under a **detached `iTermServer-<version>` daemon** (session restoration) that is parented to `launchd`, not under the iTerm2 app — and the app itself isn't in the process parent chain to walk up to.

`SessionStore.walkParentChain` only did **exact matches** against `"iTerm2"`/`"iTerm"`, so the version-suffixed daemon name (e.g. `iTermServer-3.6.11`) never matched. `terminalApp` stayed `nil`, which:

- made `focusSelectedSession()` bail at its `bundleID(for:)` guard → **focus was a silent no-op**, and
- caused `ITerm2Integration.enrich` (which filters on `terminalApp.contains("iTerm")`) to skip enrichment → **no tabId / tabName / colour**.

## Changes

- **`SessionStore`** — new `canonicalTerminalApp(_:)` normalises the `iTermServer-*` daemon back to the canonical `"iTerm2"`, so every downstream check (bundleID lookup, iTerm enrichment, focus) recognises it. *(the unblocker)*
- **`Panel.focusSelectedSession()`** — route `session.tabId` to the activation param the terminal actually reads: `ipcHook` for VSCode/Cursor/Antigravity (`VSCODE_IPC_HOOK_CLI`), `sessionID` for iTerm2 (its session GUID). Previously `tabId` was dropped entirely, so focus landed on whatever window the app last had frontmost.
- **`AppActivator.focusIterm2Session`** — match iTerm2 sessions on `unique id` (the persistent GUID our enrichment and `ITERM_SESSION_ID` both carry), with `id` kept as a fallback.

## Testing

- `swiftc -typecheck panel/*.swift shared/*.swift` — clean.
- Verified live: with the daemon recognised, iTerm2 sessions show their terminal/tab metadata again and **⏎ jumps to the exact pane**.

## Follow-ups (not in this PR)

- `notify.sh:walk_session_chain` has the same `iTermServer` gap on the *nudge* focus path (partly masked by `TERM_PROGRAM`/`ITERM_SESSION_ID`).
- Zed is recognised by `notify.sh` but not by the Sessions tab, and isn't focusable in `AppActivator` at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
