### PR TITLE
fix(tickets): scroll viewport on cmd+up/down jump

### DIFF
--- a/panel/OutcomesView.swift
+++ b/panel/OutcomesView.swift
@@ -94,14 +94,21 @@ struct OutcomesView: View {
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .scrollIndicators(.visible)
-                    .onChange(of: nav.outcomeSelectedIndex) { _ in
-                        guard let selectedRowID else { return }
+                    // Watch the resolved row id, not the raw index, and scroll to
+                    // the id onChange hands us. Reading a separately-derived
+                    // `selectedRowID` capture here lagged the viewport one keypress
+                    // behind the selection — invisible when stepping ±1 (the row
+                    // stays near the viewport) but obvious on a ⌘↑/↓ jump, where the
+                    // pane didn't move until the next press. Mirrors the Sessions
+                    // tab's onChange(of: selectedPID) pattern.
+                    .onChange(of: selectedRowID) { newID in
+                        guard let newID else { return }
                         // Snap, don't animate. With key-repeat on a long list the
                         // 0.15s animations piled up, the scroll lagged the
                         // selection, then settled with an upward snap — the
                         // "bounce". Instant scroll keeps the selection pinned and
                         // the viewport tracking it smoothly.
-                        proxy.scrollTo(selectedRowID, anchor: .center)
+                        proxy.scrollTo(newID, anchor: .center)
                     }
                 }
             }


### PR DESCRIPTION
## Problem

On the Tickets tab, **⌘↑/↓** (jump to first/last row) moved the selection highlight but **not the scroll viewport** — the pane only caught up on the next regular ↑/↓ press.

## Root cause

The scroll was driven by:

```swift
.onChange(of: nav.outcomeSelectedIndex) { _ in
    guard let selectedRowID else { return }
    proxy.scrollTo(selectedRowID, anchor: .center)
}
```

It watched the raw *index* and scrolled to a **separately-derived `selectedRowID` captured from the body**, which lagged one keypress behind the index change. Stepping ±1 hid it (the row stays near the viewport), but a jump to the far end left the viewport parked until the next press advanced the scroll.

## Fix

Watch `selectedRowID` directly and scroll to the id `onChange` delivers — mirroring the working Sessions tab (`onChange(of: store.selectedPID) { newValue in proxy.scrollTo(newValue) }`). No behaviour change for stepping; the jump now moves the viewport on the first press. Kept the deliberate no-animation snap.

## Testing

- `swiftc -typecheck panel/*.swift shared/*.swift` — clean.
- Verified locally: ⌘↑/↓ snaps the Tickets pane to the first/last row immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
