### PR TITLE
fix(update): restart the stackvox daemon after an app update

### DIFF
--- a/panel/Updater.swift
+++ b/panel/Updater.swift
@@ -203,6 +203,7 @@ final class Updater {
         setPhase(.done)
         appendLog("Restarting…")
         try kickstartLaunchd()
+        restartDaemon()          // pick up the stackvox engine the swap just installed
         relaunchInstalledBundle()
         scheduleAutoQuit()
     }
@@ -480,12 +481,12 @@ final class Updater {
 
     // MARK: - Launchd
 
-    private func kickstartLaunchd() throws {
+    private func kickstartLaunchd(_ label: String = Bootstrap.appLabel) throws {
         let uid = getuid()
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/bin/launchctl")
         task.arguments = ["kickstart", "-k",
-                          "gui/\(uid)/\(Bootstrap.appLabel)"]
+                          "gui/\(uid)/\(label)"]
         task.standardOutput = Pipe()
         task.standardError = Pipe()
         try task.run()
@@ -494,7 +495,23 @@ final class Updater {
             // Not fatal — the kickstart can fail if the agent isn't loaded
             // (e.g. fresh dev install). The new bundle is in place; user
             // can hit the hotkey to launch it manually next time.
-            appendLog("launchctl kickstart exited \(task.terminationStatus) (non-fatal)")
+            appendLog("launchctl kickstart \(label) exited \(task.terminationStatus) (non-fatal)")
+        }
+    }
+
+    /// Restart the stackvox TTS daemon so it re-execs the engine the atomic
+    /// swap just placed on disk. The daemon is a long-running `stackvox serve`
+    /// launchd job; without an explicit kickstart it keeps running the
+    /// pre-update engine until the next login or crash, so engine fixes
+    /// (streaming playback, pronunciation, …) silently don't take effect after
+    /// an app update. Non-fatal: launchd KeepAlive brings it back on next login
+    /// regardless, and shell installs that never registered the daemon agent
+    /// simply get a harmless "not loaded" kickstart.
+    private func restartDaemon() {
+        do {
+            try kickstartLaunchd(Bootstrap.daemonLabel)
+        } catch {
+            appendLog("daemon kickstart failed: \(error) (non-fatal)")
         }
     }
 


### PR DESCRIPTION
## Summary

The in-app updater swaps a new bundle (with a fresh stackvox venv) into place but only kickstarted the **panel** launchd agent — never the **daemon**. So the long-running `stackvox serve` kept executing the *pre-update* engine until the next login or crash, and engine fixes (streaming playback, pronunciation, …) silently didn't take effect after an app update. This is how you can end up with a new client but a stale daemon doing the actual playback.

## Changes

- `panel/Updater.swift`: parameterize `kickstartLaunchd(_ label:)` and add `restartDaemon()`, called right after the atomic swap. It kickstarts `com.stackonehq.stack-nudge-daemon` so the daemon re-execs the stackvox engine the swap just installed.
- Non-fatal by design: launchd `KeepAlive` already brings the daemon back on next login, and shell installs that never registered the daemon agent just get a harmless "not loaded" kickstart.

## Testing

- `swiftc -typecheck panel/*.swift shared/*.swift` — clean (only the pre-existing `onChange(of:perform:)` deprecation warnings, unrelated to this change).
- Not yet exercised through a full release-to-release in-app update (that needs a packaged build). To verify manually after an update: confirm the daemon PID changed — `launchctl print gui/$(id -u)/com.stackonehq.stack-nudge-daemon` — and that `stackvox status` reports the updated engine version.

Pairs with a companion stackvox change that makes `stackvox status` print a client/daemon version-skew warning, so any remaining drift is visible rather than silent.

## Related issues

_None._
