### PR TITLE
fix(usage): locate claude in ~/.local/bin; drop stale codex tiers

### DIFF
--- a/panel/CodexUsage.swift
+++ b/panel/CodexUsage.swift
@@ -107,6 +107,12 @@ final class CodexQuotaProbe {
               let used = (dict["used_percent"] as? NSNumber)?.doubleValue else { return nil }
         let resetsAt = (dict["resets_at"] as? NSNumber)
             .map { Date(timeIntervalSince1970: $0.doubleValue) }
+        // A window whose reset time has already passed has since rolled over;
+        // the captured used_percent is stale and no longer reflects the current
+        // window. Drop it so the Usage tab doesn't show old numbers with a
+        // "resets N days ago" (happens when Codex hasn't run recently and the
+        // newest rollout is older than its own rate-limit window).
+        if let resetsAt, resetsAt < Date() { return nil }
         return QuotaTier(utilization: used, resetsAt: resetsAt)
     }
 }

--- a/panel/ProcessOutput.swift
+++ b/panel/ProcessOutput.swift
@@ -64,12 +64,13 @@ enum ProcessOutput {
             .first { FileManager.default.isExecutableFile(atPath: $0) }
     }
 
-    // Resolve the `claude` CLI. Same minimal-PATH rationale as gh(); the
-    // ~/.claude/local fallback covers users who installed via the curl-bash
-    // installer rather than Homebrew.
+    // Resolve the `claude` CLI. Same minimal-PATH rationale as gh(). The
+    // native installer (current default) symlinks into ~/.local/bin; the
+    // ~/.claude/local fallback covers the older curl-bash/migration installer.
     static func claude() -> String? {
         let home = NSHomeDirectory()
         return [
+            "\(home)/.local/bin/claude",
             "/opt/homebrew/bin/claude",
             "/usr/local/bin/claude",
             "\(home)/.claude/local/claude",


### PR DESCRIPTION
Two Usage-tab fixes.

### Claude usage doesn't show (regression from #130)
`#130` moved Claude quota onto the `claude` CLI, resolved via `ProcessOutput.claude()`. That list only probed `/opt/homebrew/bin`, `/usr/local/bin`, and `~/.claude/local`. Claude Code's current native installer symlinks the binary into `~/.local/bin`, which isn't on a launchd-spawned app's minimal PATH, so the probe returns nil → hard-fail → `nav.quota` stays nil → `.claude` never enters `availableUsageClients` and the tab shows no Claude row (and no error, since other clients are present).

Fix: add `~/.local/bin/claude` (first) to the probe list. Parsing of `claude --print --output-format json /usage` is unchanged and confirmed still matches the current output.

### Codex shows stale windows with past reset times (pre-existing)
`CodexQuotaProbe` reads the newest `~/.codex/sessions` rollout and renders its `rate_limits` with no freshness check. When Codex hasn't run recently, the newest rollout is older than its own window, so it shows old `used_percent` with a reset time in the past (e.g. "resets 1 week ago" for the 5h window).

Fix: in `tier()`, drop a tier whose `resets_at` is already in the past — that window has rolled over and the captured percentage is stale. When both tiers are stale, `.codex` drops out of `availableUsageClients` (same "no current data" behaviour as an unavailable Claude).

### Testing
`swiftc -typecheck panel/*.swift shared/*.swift` clean. Verified the live `claude /usage` output parses and reproduced the stale-Codex case against a 9-day-old rollout locally.