### PR TITLE
fix(panel): stop the top bar shifting when a Stop row is selected

### DIFF
--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -333,7 +333,6 @@ struct PanelContentView: View {
             } else {
                 if let primary = primaryActionLabel {
                     FooterHint(label: primary, keys: ["⏎"], primary: true)
-                    FooterDivider()
                 }
                 FooterHint(label: "Select",  keys: ["↑", "↓"])
                 FooterHint(label: "Top/Bottom", keys: ["⌘↑↓"])


### PR DESCRIPTION
## Problem

On the Events tab, selecting a "done" (Stop) row shifted the whole panel — top bar and brand mark included — a few px to the left. Permission (`askUserQuestion`) rows and an empty list were fine. It came and went, which made it look like a scrollbar glitch.

## Cause

The footer hint row is built from `.fixedSize()` pills that never shrink. A Stop row's wider labels (`Open editor` + `Dismiss`) push the hint row to ~618px. At the default/min panel widths (600 / 560) that's wider than the window, so SwiftUI sizes the panel content to the footer's intrinsic width and **centers** it inside the fixed-width host — dragging the top bar left by half the overflow. A permission row's narrower labels (`Approve` + `Deny`) total ~600px and just fit, so no shift. Empty list → tiny footer → fits.

## Fix

Remove the `FooterDivider` between the primary action and the navigation hints in the Events footer. That trims ~19px, bringing the Stop-row footer to within the panel width so it no longer overflows and the panel stays put.

## Testing

Reproduced in a faithful SwiftUI harness under `AppleShowScrollBars = Always` at 600px — brand-mark X was `3.2` (shifted) with the divider, `12.0` (correct) without. Verified live by injecting Stop events into the running panel.

**Note:** this lands the Stop-row footer at ~exactly the panel width, so it has little margin — dragging the panel narrower than ~600px (min is still 560) could re-trigger it. A follow-up could bump `panelMinWidth` to give headroom if that proves annoying.
