### PR TITLE
fix(panel): keyboard-navigate the unwired-agents banner

### DIFF
--- a/Tests/StackNudgePanelCoreTests/SettingsRowTests.swift
+++ b/Tests/StackNudgePanelCoreTests/SettingsRowTests.swift
@@ -70,6 +70,74 @@ final class SettingsRowTests: XCTestCase {
         XCTAssertEqual(nav.index(of: .update), 1)
     }
 
+    // The reconciliation banner contributes one indexed row per button, so
+    // ↑/↓ can reach both Set up and Not now. Only the row layout is asserted
+    // here — wireAllUnwiredAgents / dismissAllUnwiredAgents write to agent
+    // hook configs and ~/.stack-nudge, so exercising them would touch the
+    // real home directory.
+    func test_unwiredBanner_prependsBothButtonRows() {
+        let nav = PanelNav()
+        XCTAssertFalse(nav.settingsRows.contains(.wireAgents))
+        XCTAssertFalse(nav.settingsRows.contains(.dismissAgents))
+
+        nav.unwiredAgents = [.antigravity, .codex]
+        XCTAssertEqual(nav.index(of: .wireAgents), 0)
+        XCTAssertEqual(nav.index(of: .dismissAgents), 1)
+    }
+
+    func test_unwiredBanner_sitsAbovePermissionsAndUpdate() {
+        let nav = PanelNav()
+        nav.unwiredAgents = [.codex]
+        nav.missingPermissions = [.accessibility]
+        nav.updateAvailable = "1.2.3"
+        XCTAssertEqual(nav.settingsRows.first, .wireAgents)
+        XCTAssertEqual(nav.index(of: .dismissAgents), 1)
+        XCTAssertEqual(nav.index(of: .permissions), 2)
+        XCTAssertEqual(nav.index(of: .update), 3)
+    }
+
+    // Arrows must not act on either banner row — Set up rewrites hook configs
+    // and Not now persists a dismissal, so both are Enter-only.
+    func test_unwiredBanner_ignoresCycle() {
+        let nav = PanelNav()
+        nav.unwiredAgents = [.antigravity]
+        nav.selectedSettingIndex = nav.index(of: .wireAgents)
+        nav.cycleForward()
+        nav.cycleBackward()
+        XCTAssertEqual(nav.unwiredAgents, [.antigravity])
+
+        nav.selectedSettingIndex = nav.index(of: .dismissAgents)
+        nav.cycleForward()
+        nav.cycleBackward()
+        XCTAssertEqual(nav.unwiredAgents, [.antigravity])
+        XCTAssertTrue(nav.dismissedAgents.isEmpty)
+    }
+
+    // The footer dims its Cycle hint from this, so it has to agree with
+    // applyCycle's no-op branch row for row.
+    func test_selectedRowRespondsToArrows_matchesCycleBehaviour() {
+        let nav = PanelNav()
+        // Both conditional rows present so index(of:) resolves them for real
+        // rather than falling back to 0.
+        nav.unwiredAgents = [.codex]
+        nav.missingPermissions = [.accessibility]
+
+        for row in [SettingsRow.wireAgents, .dismissAgents, .quit, .editPhrases,
+                    .openConfig, .releaseNotes, .checkUpdates, .checkPermissions,
+                    .uninstall, .disconnectGithub] {
+            nav.selectedSettingIndex = nav.index(of: row)
+            XCTAssertEqual(nav.selectedRow, row)
+            XCTAssertFalse(nav.selectedRowRespondsToArrows, "\(row) should ignore arrows")
+        }
+
+        for row in [SettingsRow.banner, .muteDuration, .theme, .historyPerSession,
+                    .permissions, .hotkey] {
+            nav.selectedSettingIndex = nav.index(of: row)
+            XCTAssertEqual(nav.selectedRow, row)
+            XCTAssertTrue(nav.selectedRowRespondsToArrows, "\(row) should act on arrows")
+        }
+    }
+
     func test_indexRowRoundTrip() {
         let nav = PanelNav()
         for row in nav.settingsRows {

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -134,6 +134,9 @@ enum GithubSignIn: Equatable {
 // change with no renumbering — and the applyCycle switch over this is
 // exhaustive, so the compiler flags any row left unhandled.
 enum SettingsRow: Hashable {
+    // One slot per button in the agent-reconciliation banner, so both are
+    // keyboard-reachable rather than mouse-only.
+    case wireAgents, dismissAgents
     case permissions, update, hotkey
     case banner, muteWhenFocused, mute, muteDuration, pinPanel, keepOpenWhenEmpty, launchAtLogin
     case widget, widgetCorner, widgetOpacity, widgetContent, mascot, theme
@@ -639,6 +642,9 @@ final class PanelNav: ObservableObject {
     // chase.
     var settingsRows: [SettingsRow] {
         var rows: [SettingsRow] = []
+        // The reconciliation banner renders above the permissions and update
+        // rows, so it indexes above them too — Set up first, then Not now.
+        if !unwiredAgents.isEmpty { rows += [.wireAgents, .dismissAgents] }
         if !missingPermissions.isEmpty { rows.append(.permissions) }
         if updateAvailable != nil { rows.append(.update) }
         rows += [.hotkey,
@@ -779,6 +785,27 @@ final class PanelNav: ObservableObject {
         dismissedAgents.insert(agent.rawValue)
         saveDismissedAgents()
         refreshUnwiredAgents()
+    }
+
+    // Keyboard/click entry points for the banner's two buttons, wiring or
+    // dismissing every agent the banner lists. Both snapshot `unwiredAgents`
+    // first: wireSingleAgent and dismissUnwiredAgent each re-run
+    // refreshUnwiredAgents, which rewrites the array mid-loop.
+    func wireAllUnwiredAgents() {
+        for agent in unwiredAgents { wireSingleAgent(agent) }
+        resetSelectionIfBannerCleared()
+    }
+
+    func dismissAllUnwiredAgents() {
+        for agent in unwiredAgents { dismissUnwiredAgent(agent) }
+        resetSelectionIfBannerCleared()
+    }
+
+    // Both banner rows vanish the instant it's actioned, so a stale index would
+    // leave the keyboard highlight on whichever row slid up into that slot.
+    // Selection stays put if a wire failed and the banner is still showing.
+    private func resetSelectionIfBannerCleared() {
+        if unwiredAgents.isEmpty { selectedSettingIndex = 0 }
     }
 
     private static let dismissedAgentsPath =
@@ -942,6 +969,8 @@ final class PanelNav: ObservableObject {
     // row enters record mode.
     func activate() {
         switch selectedRow {
+        case .wireAgents:    wireAllUnwiredAgents()
+        case .dismissAgents: dismissAllUnwiredAgents()
         case .permissions: actions?.checkPermissions()
         case .update: actions?.beginUpdate()
         case .hotkey: startRecordingHotkey()
@@ -965,6 +994,30 @@ final class PanelNav: ObservableObject {
 
     func cycleForward()  { applyCycle(forward: true) }
     func cycleBackward() { applyCycle(forward: false) }
+
+    // Whether ←/→ do anything on the selected row — mirrors applyCycle's no-op
+    // branch so the Settings footer can dim the Cycle hint instead of
+    // advertising a key the row ignores. Exhaustive over SettingsRow for the
+    // same reason applyCycle is: a new row can't silently inherit a wrong hint.
+    var selectedRowRespondsToArrows: Bool {
+        switch selectedRow {
+        case .wireAgents, .dismissAgents,
+             .disconnectGithub, .editPhrases, .checkPermissions, .openConfig,
+             .releaseNotes, .checkUpdates, .uninstall, .quit, .none:
+            return false
+        case .permissions, .update, .hotkey, .speakHotkey,
+             .banner, .muteWhenFocused, .mute, .muteDuration, .pinPanel,
+             .keepOpenWhenEmpty, .launchAtLogin,
+             .widget, .widgetCorner, .widgetOpacity, .widgetContent, .mascot, .theme,
+             .soundEnabled, .agentDoneSound, .permissionSound,
+             .voiceEnabled, .voice, .voiceSpeed, .downloadVoiceModel,
+             .quotaTracking, .quotaAlerts, .alertThreshold, .pollFrequency,
+             .contextAlert, .showRemaining,
+             .githubLinks, .hideShipped,
+             .historyPerSession:
+            return true
+        }
+    }
 
     // Shared by Settings row 11 and the Usage tab's 'p' keystroke. On
     // pause, drop the cached snapshot so the Usage tab doesn't sit on
@@ -1157,8 +1210,12 @@ final class PanelNav: ObservableObject {
             let next = forward ? (idx + 1) % list.count : (idx - 1 + list.count) % list.count
             eventsPerSession = list[next]
             ConfigFile.write(key: "STACKNUDGE_EVENTS_PER_SESSION", value: String(eventsPerSession))
-        // Action rows have nothing to cycle.
-        case .disconnectGithub, .editPhrases, .checkPermissions, .openConfig,
+        // Action rows have nothing to cycle. The two banner rows deliberately
+        // ignore arrows even though .permissions/.update act on them: Set up
+        // rewrites agent hook configs and Not now persists a dismissal, so
+        // neither should fire on an arrow-key graze. Enter/Space only.
+        case .wireAgents, .dismissAgents,
+             .disconnectGithub, .editPhrases, .checkPermissions, .openConfig,
              .releaseNotes, .checkUpdates, .uninstall, .quit, .none:
             break
         }

--- a/panel/Settings.swift
+++ b/panel/Settings.swift
@@ -28,10 +28,12 @@ struct SettingsView: View {
                         muteBanner
                         // Reconciliation banner — appears above all other
                         // rows when one or more detected agents lack our
-                        // notify.sh hook. Not part of the keyboard index;
-                        // mouse-only at v1. After Set up is clicked, the
-                        // success state takes over the slot for a few
-                        // seconds before disappearing.
+                        // notify.sh hook. Its two buttons are keyboard-indexed
+                        // (.wireAgents / .dismissAgents, pinned ahead of
+                        // .permissions to match this render order). After Set
+                        // up is actioned, the success state takes over the slot
+                        // for a few seconds before disappearing — that state is
+                        // inert, so it isn't indexed.
                         if !nav.unwiredAgents.isEmpty {
                             unwiredAgentsRow(nav.unwiredAgents)
                         } else if !nav.recentlyWiredAgents.isEmpty {
@@ -155,7 +157,13 @@ struct SettingsView: View {
                 } else {
                     FooterHint(label: "Move",  keys: ["↑", "↓"])
                     FooterHint(label: "Top/Bottom", keys: ["⌘↑↓"])
+                    // Always rendered so the footer doesn't reflow as selection
+                    // moves, dimmed on the rows where ←/→ do nothing (the
+                    // banner's buttons and the action rows) — same treatment
+                    // the events page gives its Snooze hint. Enter acts on
+                    // every row, so "Act" never dims.
                     FooterHint(label: "Cycle", keys: ["←", "→"])
+                        .opacity(nav.selectedRowRespondsToArrows ? 1.0 : 0.35)
                     FooterHint(label: "Act",   keys: ["⏎"])
                     FooterHint(label: "Back",  keys: ["Esc"])
                 }
@@ -264,12 +272,18 @@ struct SettingsView: View {
     }
 
     // Reconciliation banner. Shown above all other settings rows when one
-    // or more detected agents lack a notify.sh hook entry. Two click
-    // targets: "Set up" (wire every unwired agent) and "Not now" (dismiss
-    // for this/future launches until the agent's state changes again).
-    // Not part of the keyboard-indexed nav at v1 — mouse-only.
+    // or more detected agents lack a notify.sh hook entry. Two targets:
+    // "Set up" (wire every unwired agent) and "Not now" (dismiss for
+    // this/future launches until the agent's state changes again). Each takes
+    // a keyboard index of its own, so ↑/↓ steps through them and Enter acts;
+    // clicking routes through the same nav methods and syncs the selection so
+    // mouse and keyboard don't disagree about what's focused.
     @ViewBuilder
     private func unwiredAgentsRow(_ agents: [BootstrapAgent]) -> some View {
+        let setUpIndex   = nav.index(of: .wireAgents)
+        let dismissIndex = nav.index(of: .dismissAgents)
+        let setUpSelected   = nav.selectedSettingIndex == setUpIndex
+        let dismissSelected = nav.selectedSettingIndex == dismissIndex
         HStack(alignment: .top, spacing: 10) {
             Image(systemName: "sparkle")
                 .font(.body)
@@ -289,7 +303,8 @@ struct SettingsView: View {
                     .fixedSize(horizontal: false, vertical: true)
                 HStack(spacing: 8) {
                     Button {
-                        for agent in agents { nav.wireSingleAgent(agent) }
+                        nav.selectedSettingIndex = setUpIndex
+                        nav.wireAllUnwiredAgents()
                     } label: {
                         Text("Set up")
                             .font(.caption.weight(.semibold))
@@ -299,17 +314,33 @@ struct SettingsView: View {
                                 RoundedRectangle(cornerRadius: 6, style: .continuous)
                                     .fill(Color.accentColor)
                             )
+                            // Already accent-filled, so it can't deepen its own
+                            // fill the way the plain rows do — a ring reads as
+                            // focus without restating the fill.
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                    .strokeBorder(Color.primary.opacity(setUpSelected ? 0.7 : 0), lineWidth: 2)
+                            )
                             .foregroundStyle(.white)
                     }
                     .buttonStyle(.plain)
+                    .id(setUpIndex)
                     Button {
-                        for agent in agents { nav.dismissUnwiredAgent(agent) }
+                        nav.selectedSettingIndex = dismissIndex
+                        nav.dismissAllUnwiredAgents()
                     } label: {
                         Text("Not now")
                             .font(.caption)
                             .foregroundStyle(.secondary)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 4)
+                            .background(
+                                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                    .fill(dismissSelected ? Color.accentColor.opacity(0.22) : Color.clear)
+                            )
                     }
                     .buttonStyle(.plain)
+                    .id(dismissIndex)
                 }
                 .padding(.top, 2)
             }


### PR DESCRIPTION
## Problem

When Antigravity or Codex is installed but not wired to `notify.sh`, the Settings tab pins a "Wire up N agents?" banner with **Set up** and **Not now** buttons. Neither was reachable by keyboard:

- Settings nav is driven entirely by `PanelNav.settingsRows`, which had no case for either button, so ↑/↓/Tab could never select them and ⏎ could never fire them.
- SwiftUI focus couldn't cover for it either: the buttons are `.buttonStyle(.plain)` with no `.focusable()`, and the panel intercepts every key in settings mode before the view hierarchy sees it.
- There was no keyboard equivalent elsewhere — `runBootstrap` is only wired from the first-launch wizard, never from a Settings row.

Unlike the mute banner (whose Resume is duplicated by the `.mute` row), wiring an agent had no keyboard path at all. The old comments called this out as "mouse-only at v1".

## Change

Each button now takes a keyboard index of its own — `.wireAgents` and `.dismissAgents`, prepended to `settingsRows` ahead of `.permissions`/`.update` so the index order matches the render order. ↑/↓ steps through them, ⏎ acts, and clicking routes through the same nav methods so mouse and keyboard agree on what's focused.

Set up gets a focus ring (it's already accent-filled, so it can't deepen its own fill like the plain rows do); Not now gets the standard row pill.

`←/→` deliberately do nothing on both rows: Set up rewrites agent hook configs and Not now persists a dismissal, so neither should fire on an arrow-key graze.

## Footer accuracy

That left the footer advertising "Cycle ←→" on rows where arrows do nothing. New `selectedRowRespondsToArrows` mirrors `applyCycle`'s no-op branch and dims the hint when it doesn't apply — following the events page's Snooze-hint precedent of rendering always and dimming, since the footer is right-anchored and removing a middle hint would shift the others as selection moves.

This also fixes a pre-existing inaccuracy: the whole Actions section (Edit phrases, Open config, Quit, Uninstall, …) plus Disconnect GitHub were all advertising Cycle while ignoring arrows. `Act ⏎` stays lit everywhere because Enter acts on every row, and `.permissions`/`.update`/`.hotkey`/`.speakHotkey`/`.downloadVoiceModel` keep Cycle lit because arrows genuinely fire there as an Enter alias.

Both new switches are exhaustive over `SettingsRow`, so a future row can't silently inherit a wrong hint or an unhandled arrow.

## Testing

Three cases added to `SettingsRowTests`: both rows prepended in order, banner above permissions+update, arrows inert on both, and `selectedRowRespondsToArrows` asserted in both directions across every row category. Row-layout only — the action methods write to real hook configs and `~/.stack-nudge`, so they're kept out of the suite.

`swift test` can't run locally (no XCTest without Xcode — that fails the whole existing suite, not just this file), so the logic was additionally verified by compiling all panel sources against a throwaway harness driving the real `PanelNav`: 15/15 assertions pass, covering every `SettingsRow` case for the footer property plus the cached-voice layout swap. `swiftc -typecheck panel/*.swift shared/*.swift` is clean.
