### PR TITLE
feat(panel): usage history graph pane

### DIFF
--- a/Tests/StackNudgePanelCoreTests/UsageHistoryTests.swift
+++ b/Tests/StackNudgePanelCoreTests/UsageHistoryTests.swift
@@ -1,0 +1,518 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// The 24h usage graph replays transcripts rather than recording snapshots, so
+// these pin the parts that decide whether the plotted shape is truthful: bucket
+// alignment, window edges, the mtime prefilter, deduplication, and the token
+// arithmetic each agent's schema needs.
+final class UsageHistoryTests: XCTestCase {
+
+    // MARK: Fixtures
+
+    private func fixtureDirectory() -> String {
+        let dir = NSTemporaryDirectory() + "usage-history-\(UUID().uuidString)/"
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func write(_ lines: [String], to directory: String, name: String, modified: Date? = nil) -> String {
+        let path = directory + name
+        try? (lines.joined(separator: "\n") + "\n")
+            .write(toFile: path, atomically: true, encoding: .utf8)
+        if let modified {
+            try? FileManager.default.setAttributes([.modificationDate: modified], ofItemAtPath: path)
+        }
+        return path
+    }
+
+    private static let stamp: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    // A real-shape Claude assistant entry. Mirrors the live schema: timestamp at
+    // the top level, usage under .message.usage.
+    private func claudeLine(at when: Date,
+                            output: Int = 100,
+                            input: Int = 10,
+                            cacheRead: Int = 1_000,
+                            cacheCreate: Int = 500,
+                            uuid: String = UUID().uuidString) -> String {
+        """
+        {"type":"assistant","uuid":"\(uuid)","timestamp":"\(Self.stamp.string(from: when))",\
+        "message":{"model":"claude-opus-5","usage":{"input_tokens":\(input),\
+        "output_tokens":\(output),"cache_read_input_tokens":\(cacheRead),\
+        "cache_creation_input_tokens":\(cacheCreate)}}}
+        """
+    }
+
+    // A real-shape Codex token_count event. Note input_tokens already contains
+    // cached_input_tokens, which is what the reader has to unpick.
+    private func codexLine(at when: Date,
+                           input: Int = 15_000,
+                           cached: Int = 10_000,
+                           output: Int = 200,
+                           reasoning: Int = 60) -> String {
+        """
+        {"timestamp":"\(Self.stamp.string(from: when))","type":"event_msg",\
+        "payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":\(input),\
+        "cached_input_tokens":\(cached),"output_tokens":\(output),\
+        "reasoning_output_tokens":\(reasoning)}}}}
+        """
+    }
+
+    // MARK: Bucketing
+
+    func test_bucketsAlignToWallClockBoundaries() {
+        let dir = fixtureDirectory()
+        // 13:07:41 must land in the 13:05 bucket, not start one at :07.
+        let now = Date(timeIntervalSince1970: 1_785_150_000)  // arbitrary fixed instant
+        _ = write([claudeLine(at: now.addingTimeInterval(-600))], to: dir, name: "a.jsonl", modified: now)
+
+        let series = UsageHistoryReader.claudeSeries(now: now, root: dir)
+        for bucket in series.buckets {
+            let epoch = Int(bucket.start.timeIntervalSince1970)
+            XCTAssertEqual(epoch % series.bucketSeconds, 0, "bucket \(bucket.start) is off-boundary")
+        }
+    }
+
+    func test_windowIsFixedWidth_andZeroFilled() {
+        let dir = fixtureDirectory()
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        _ = write([claudeLine(at: now.addingTimeInterval(-3_600))], to: dir, name: "a.jsonl", modified: now)
+
+        let series = UsageHistoryReader.claudeSeries(now: now, root: dir)
+        // 24h of 5-minute buckets, every one present so the renderer never has
+        // to reason about gaps.
+        XCTAssertEqual(series.buckets.count, 288)
+        XCTAssertEqual(series.bucketSeconds, 300)
+        XCTAssertEqual(series.buckets.filter { $0.turns > 0 }.count, 1)
+        XCTAssertEqual(series.buckets.filter { $0.turns == 0 }.count, 287)
+    }
+
+    func test_turnsInSameBucket_accumulate() {
+        let dir = fixtureDirectory()
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        let when = now.addingTimeInterval(-1_800)
+        _ = write([
+            claudeLine(at: when, output: 100),
+            claudeLine(at: when.addingTimeInterval(30), output: 250),
+        ], to: dir, name: "a.jsonl", modified: now)
+
+        let series = UsageHistoryReader.claudeSeries(now: now, root: dir)
+        let active = series.buckets.filter { $0.turns > 0 }
+        XCTAssertEqual(active.count, 1)
+        XCTAssertEqual(active.first?.turns, 2)
+        XCTAssertEqual(active.first?.outputTokens, 350)
+    }
+
+    func test_entriesOlderThanWindow_areExcluded() {
+        let dir = fixtureDirectory()
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        // Same file holds one in-window and one long-expired entry; the file's
+        // mtime is recent, so it passes the prefilter and the entry timestamps
+        // have to do the filtering.
+        _ = write([
+            claudeLine(at: now.addingTimeInterval(-3_600), output: 111),
+            claudeLine(at: now.addingTimeInterval(-60 * 60 * 48), output: 999),
+        ], to: dir, name: "a.jsonl", modified: now)
+
+        let series = UsageHistoryReader.claudeSeries(now: now, root: dir)
+        XCTAssertEqual(series.total(for: .outputTokens), 111)
+    }
+
+    func test_filesUntouchedSinceWindowStart_areSkipped() {
+        let dir = fixtureDirectory()
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        // An entry that would be in-window by timestamp, but in a file last
+        // written two days ago. Skipping it is the optimisation that keeps the
+        // scan off ~389 MB of cold transcripts; a real file cannot contain
+        // entries newer than its own mtime.
+        _ = write([claudeLine(at: now.addingTimeInterval(-3_600), output: 777)],
+                  to: dir, name: "cold.jsonl", modified: now.addingTimeInterval(-60 * 60 * 48))
+
+        let series = UsageHistoryReader.claudeSeries(now: now, root: dir)
+        XCTAssertFalse(series.hasActivity)
+        XCTAssertEqual(series.total(for: .outputTokens), 0)
+    }
+
+    func test_duplicateUUIDAcrossFiles_countsOnce() {
+        let dir = fixtureDirectory()
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        let when = now.addingTimeInterval(-1_200)
+        let shared = "shared-uuid"
+        _ = write([claudeLine(at: when, output: 500, uuid: shared)], to: dir, name: "a.jsonl", modified: now)
+        _ = write([claudeLine(at: when, output: 500, uuid: shared)], to: dir, name: "b.jsonl", modified: now)
+
+        let series = UsageHistoryReader.claudeSeries(now: now, root: dir)
+        XCTAssertEqual(series.total(for: .outputTokens), 500)
+        XCTAssertEqual(series.total(for: .turns), 1)
+    }
+
+    // MARK: Robustness
+
+    func test_malformedAndIncompleteEntries_areSkipped() {
+        let dir = fixtureDirectory()
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        _ = write([
+            "{ not json at all",
+            #"{"type":"assistant","timestamp":"nonsense","message":{"usage":{"output_tokens":5}}}"#,
+            #"{"type":"assistant","message":{"usage":{"output_tokens":5}}}"#,          // no timestamp
+            #"{"type":"user","timestamp":"2026-07-27T12:00:00.000Z","message":{}}"#,   // not an assistant turn
+            claudeLine(at: now.addingTimeInterval(-600), output: 42),
+        ], to: dir, name: "a.jsonl", modified: now)
+
+        let series = UsageHistoryReader.claudeSeries(now: now, root: dir)
+        XCTAssertEqual(series.total(for: .outputTokens), 42)
+        XCTAssertEqual(series.total(for: .turns), 1)
+    }
+
+    func test_emptyDirectory_yieldsZeroFilledSeries() {
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        let series = UsageHistoryReader.claudeSeries(now: now, root: fixtureDirectory())
+        XCTAssertEqual(series.buckets.count, 288)
+        XCTAssertFalse(series.hasActivity)
+        XCTAssertEqual(series.total(for: .turns), 0)
+        XCTAssertEqual(series.peakValue(for: .outputTokens), 0)
+    }
+
+    func test_missingDirectory_doesNotCrash() {
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        let series = UsageHistoryReader.claudeSeries(now: now, root: "/nonexistent-\(UUID().uuidString)/")
+        XCTAssertEqual(series.buckets.count, 288)
+        XCTAssertFalse(series.hasActivity)
+    }
+
+    func test_timestampWithoutFractionalSeconds_parses() {
+        XCTAssertNotNil(UsageHistoryReader.parseTimestamp("2026-07-27T15:04:59Z"))
+        XCTAssertNotNil(UsageHistoryReader.parseTimestamp("2026-07-27T15:04:59.572Z"))
+        XCTAssertNil(UsageHistoryReader.parseTimestamp("not a timestamp"))
+    }
+
+    // MARK: Metrics
+
+    func test_metricsReadIndependentFields() {
+        let dir = fixtureDirectory()
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        _ = write([claudeLine(at: now.addingTimeInterval(-600),
+                              output: 400, input: 20, cacheRead: 9_000, cacheCreate: 1_000)],
+                  to: dir, name: "a.jsonl", modified: now)
+
+        let series = UsageHistoryReader.claudeSeries(now: now, root: dir)
+        XCTAssertEqual(series.total(for: .outputTokens), 400)
+        XCTAssertEqual(series.total(for: .inputAndCache), 20 + 9_000 + 1_000)
+        XCTAssertEqual(series.total(for: .turns), 1)
+        XCTAssertEqual(series.peakValue(for: .outputTokens), 400)
+        // Real work: uncached input + cache creation + output. Only the replays
+        // are left out.
+        XCTAssertEqual(series.total(for: .excludingCacheReads), 20 + 1_000 + 400)
+    }
+
+    // The whole point of this metric is which side of the line cache creation
+    // falls on: it's fresh content the model processed, so it counts, while cache
+    // reads are replays and don't. Getting that backwards is the likely mistake,
+    // and with cache reads ~30x cache creation in practice it would be obvious
+    // in the plot but silent in the arithmetic.
+    func test_excludingCacheReads_keepsCacheCreation_dropsCacheReads() {
+        let dir = fixtureDirectory()
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        _ = write([claudeLine(at: now.addingTimeInterval(-600),
+                              output: 300, input: 50, cacheRead: 500_000, cacheCreate: 20_000)],
+                  to: dir, name: "a.jsonl", modified: now)
+
+        let series = UsageHistoryReader.claudeSeries(now: now, root: dir)
+        XCTAssertEqual(series.total(for: .excludingCacheReads), 20_350)
+        XCTAssertEqual(series.total(for: .inputAndCache), 520_050)
+        // Sanity: dropping the reads has to make a real difference, or the metric
+        // is just input+cache under another name.
+        XCTAssertLessThan(series.total(for: .excludingCacheReads),
+                          series.total(for: .inputAndCache))
+    }
+
+    func test_codexExcludingCacheReads_hasNoCacheCreationToAdd() {
+        let dir = fixtureDirectory()
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        _ = write([codexLine(at: now.addingTimeInterval(-900),
+                             input: 15_000, cached: 10_000, output: 200, reasoning: 60)],
+                  to: dir, name: "rollout-test.jsonl", modified: now)
+
+        let series = UsageHistoryReader.codexSeries(now: now, root: dir)
+        // Codex reports no cache-creation figure, so this collapses to fresh
+        // input (15,000 less 10,000 cached) plus 260 output.
+        XCTAssertEqual(series.total(for: .excludingCacheReads), 5_260)
+    }
+
+    func test_metricCycleOrder_putsOutputFirst() {
+        // The graph opens on output tokens; ↑/↓ walk this order.
+        XCTAssertEqual(UsageMetric.allCases,
+                       [.outputTokens, .excludingCacheReads, .inputAndCache, .turns])
+    }
+
+    // MARK: Windows
+
+    func test_narrowerWindow_yieldsFewerBucketsAtSameResolution() {
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        let dir = fixtureDirectory()
+        _ = write([claudeLine(at: now.addingTimeInterval(-600))], to: dir, name: "a.jsonl", modified: now)
+
+        // Same 5-minute buckets throughout; only the count changes. This is what
+        // buys resolution on a narrow pane.
+        XCTAssertEqual(UsageHistoryReader.claudeSeries(now: now, window: .twentyFourHours, root: dir).buckets.count, 288)
+        XCTAssertEqual(UsageHistoryReader.claudeSeries(now: now, window: .twelveHours, root: dir).buckets.count, 144)
+        XCTAssertEqual(UsageHistoryReader.claudeSeries(now: now, window: .sixHours, root: dir).buckets.count, 72)
+    }
+
+    func test_narrowWindow_excludesOlderEntries() {
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        let dir = fixtureDirectory()
+        _ = write([
+            claudeLine(at: now.addingTimeInterval(-60 * 60), output: 100),        // 1h ago
+            claudeLine(at: now.addingTimeInterval(-60 * 60 * 9), output: 500),    // 9h ago
+        ], to: dir, name: "a.jsonl", modified: now)
+
+        XCTAssertEqual(UsageHistoryReader.claudeSeries(now: now, window: .twentyFourHours, root: dir)
+                        .total(for: .outputTokens), 600)
+        XCTAssertEqual(UsageHistoryReader.claudeSeries(now: now, window: .sixHours, root: dir)
+                        .total(for: .outputTokens), 100)
+    }
+
+    func test_windowCycleOrder() {
+        XCTAssertEqual(UsageWindow.allCases, [.sixHours, .twelveHours, .twentyFourHours])
+        XCTAssertEqual(UsageWindow.widest, .twentyFourHours)
+        XCTAssertEqual(UsageWindow.sixHours.label, "6h")
+    }
+
+    // MARK: Caching
+
+    // The point of the store: a second pass over unchanged files must not re-read
+    // them. Full parse of a real 24h window costs ~1050ms against ~94ms for the
+    // directory walk alone, so this is the difference that matters.
+    func test_secondRefresh_skipsUnchangedFiles() {
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        let dir = fixtureDirectory()
+        _ = write([claudeLine(at: now.addingTimeInterval(-600), output: 100)],
+                  to: dir, name: "a.jsonl", modified: now)
+        let store = UsageHistoryStore()
+
+        store.refresh(source: .claude, root: dir, now: now)
+        let first = store.lastRefreshStats
+        XCTAssertEqual(first.filesParsed, 1)
+        XCTAssertEqual(first.filesSkipped, 0)
+        XCTAssertGreaterThan(first.bytesParsed, 0)
+
+        store.refresh(source: .claude, root: dir, now: now)
+        let second = store.lastRefreshStats
+        XCTAssertEqual(second.filesParsed, 0)
+        XCTAssertEqual(second.filesSkipped, 1)
+        XCTAssertEqual(second.bytesParsed, 0)
+
+        // Totals survive the skip — the entries came from cache, not a re-read.
+        XCTAssertEqual(store.series(now: now).total(for: .outputTokens), 100)
+    }
+
+    // An appended line must be picked up without re-reading what came before.
+    func test_appendedLine_parsesOnlyTheNewBytes() {
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        let dir = fixtureDirectory()
+        let path = dir + "a.jsonl"
+        let firstLine = claudeLine(at: now.addingTimeInterval(-1_200), output: 100)
+        try? (firstLine + "\n").write(toFile: path, atomically: true, encoding: .utf8)
+
+        let store = UsageHistoryStore()
+        store.refresh(source: .claude, root: dir, now: now)
+        let firstBytes = store.lastRefreshStats.bytesParsed
+        XCTAssertEqual(store.series(now: now).total(for: .outputTokens), 100)
+
+        let secondLine = claudeLine(at: now.addingTimeInterval(-600), output: 250)
+        try? (firstLine + "\n" + secondLine + "\n").write(toFile: path, atomically: true, encoding: .utf8)
+
+        store.refresh(source: .claude, root: dir, now: now)
+        let appendBytes = store.lastRefreshStats.bytesParsed
+        XCTAssertEqual(store.series(now: now).total(for: .outputTokens), 350)
+        XCTAssertEqual(store.series(now: now).total(for: .turns), 2)
+
+        // Only the appended region was read, not the whole file again. Compare
+        // against the file's own size rather than against `firstBytes`: the two
+        // fixture lines are near-identical in length, so a first-vs-second
+        // comparison would pass or fail on line-length noise instead of on
+        // whether the read was incremental.
+        let fileSize = ((try? FileManager.default.attributesOfItem(atPath: path))?[.size] as? Int) ?? 0
+        XCTAssertGreaterThan(firstBytes, 0)
+        XCTAssertLessThanOrEqual(appendBytes, secondLine.utf8.count + 1)
+        XCTAssertLessThan(appendBytes, fileSize)
+    }
+
+    // A partial trailing line (a write caught mid-flush) must not be consumed, or
+    // its entry would be lost once the newline lands.
+    func test_partialTrailingLine_isPickedUpOnceComplete() {
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        let dir = fixtureDirectory()
+        let path = dir + "a.jsonl"
+        let complete = claudeLine(at: now.addingTimeInterval(-900), output: 100)
+        let pending = claudeLine(at: now.addingTimeInterval(-600), output: 400)
+
+        // Second line written without its terminating newline.
+        try? (complete + "\n" + pending).write(toFile: path, atomically: true, encoding: .utf8)
+        let store = UsageHistoryStore()
+        store.refresh(source: .claude, root: dir, now: now)
+        XCTAssertEqual(store.series(now: now).total(for: .outputTokens), 100)
+
+        try? (complete + "\n" + pending + "\n").write(toFile: path, atomically: true, encoding: .utf8)
+        store.refresh(source: .claude, root: dir, now: now)
+        XCTAssertEqual(store.series(now: now).total(for: .outputTokens), 500)
+        XCTAssertEqual(store.series(now: now).total(for: .turns), 2)
+    }
+
+    // A truncated or replaced file must be re-read from the start rather than
+    // resumed at a now-meaningless offset.
+    func test_truncatedFile_isReparsedFromStart() {
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        let dir = fixtureDirectory()
+        let path = dir + "a.jsonl"
+        let long = [claudeLine(at: now.addingTimeInterval(-1_200), output: 100),
+                    claudeLine(at: now.addingTimeInterval(-900), output: 100),
+                    claudeLine(at: now.addingTimeInterval(-600), output: 100)]
+        try? (long.joined(separator: "\n") + "\n").write(toFile: path, atomically: true, encoding: .utf8)
+
+        let store = UsageHistoryStore()
+        store.refresh(source: .claude, root: dir, now: now)
+        XCTAssertEqual(store.series(now: now).total(for: .turns), 3)
+
+        // Replace with a single, shorter entry.
+        let replacement = claudeLine(at: now.addingTimeInterval(-300), output: 7)
+        try? (replacement + "\n").write(toFile: path, atomically: true, encoding: .utf8)
+        store.refresh(source: .claude, root: dir, now: now)
+        XCTAssertEqual(store.series(now: now).total(for: .turns), 1)
+        XCTAssertEqual(store.series(now: now).total(for: .outputTokens), 7)
+    }
+
+    // Entries that age past the retained window must not accumulate forever.
+    func test_agedOutEntries_arePruned() {
+        let start = Date(timeIntervalSince1970: 1_785_150_000)
+        let dir = fixtureDirectory()
+        _ = write([claudeLine(at: start.addingTimeInterval(-600), output: 100)],
+                  to: dir, name: "a.jsonl", modified: start)
+
+        let store = UsageHistoryStore()
+        store.refresh(source: .claude, root: dir, now: start)
+        XCTAssertEqual(store.lastRefreshStats.entriesRetained, 1)
+
+        // Same file, but "now" has moved two days on: the file is cold and its
+        // entries are out of window, so nothing should be retained.
+        store.refresh(source: .claude, root: dir, now: start.addingTimeInterval(60 * 60 * 48))
+        XCTAssertEqual(store.lastRefreshStats.entriesRetained, 0)
+    }
+
+    // One store serves every client, so its cache has to be partitioned by
+    // source. Flattening a single shared map plotted Claude's history under
+    // Codex — the graph looked plausible and was simply the wrong agent's data.
+    func test_sourcesDoNotLeakIntoEachOther() {
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        let claudeDir = fixtureDirectory()
+        let codexDir = fixtureDirectory()
+        _ = write([claudeLine(at: now.addingTimeInterval(-600), output: 1_000)],
+                  to: claudeDir, name: "a.jsonl", modified: now)
+        _ = write([codexLine(at: now.addingTimeInterval(-600),
+                             input: 100, cached: 0, output: 7, reasoning: 0)],
+                  to: codexDir, name: "rollout-a.jsonl", modified: now)
+
+        let store = UsageHistoryStore()
+        store.refresh(source: .claude, root: claudeDir, now: now)
+        store.refresh(source: .codex, root: codexDir, now: now)
+
+        // Each source sees only its own turns, in either refresh order.
+        XCTAssertEqual(store.series(source: .claude, now: now).total(for: .outputTokens), 1_000)
+        XCTAssertEqual(store.series(source: .claude, now: now).total(for: .turns), 1)
+        XCTAssertEqual(store.series(source: .codex, now: now).total(for: .outputTokens), 7)
+        XCTAssertEqual(store.series(source: .codex, now: now).total(for: .turns), 1)
+    }
+
+    // The reported symptom: a client with no history of its own must come back
+    // empty rather than inheriting whatever was scanned before it.
+    func test_sourceWithNoFiles_staysEmptyAfterAnotherSourceWasScanned() {
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        let claudeDir = fixtureDirectory()
+        _ = write([claudeLine(at: now.addingTimeInterval(-600), output: 1_000)],
+                  to: claudeDir, name: "a.jsonl", modified: now)
+
+        let store = UsageHistoryStore()
+        store.refresh(source: .claude, root: claudeDir, now: now)
+        store.refresh(source: .codex, root: fixtureDirectory(), now: now)
+
+        XCTAssertTrue(store.series(source: .claude, now: now).hasActivity)
+        XCTAssertFalse(store.series(source: .codex, now: now).hasActivity)
+        XCTAssertEqual(store.series(source: .codex, now: now).total(for: .turns), 0)
+    }
+
+    // Refreshing one source must not evict or disturb another's cache.
+    func test_refreshingOneSource_leavesTheOtherIntact() {
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        let claudeDir = fixtureDirectory()
+        let codexDir = fixtureDirectory()
+        _ = write([claudeLine(at: now.addingTimeInterval(-600), output: 1_000)],
+                  to: claudeDir, name: "a.jsonl", modified: now)
+        _ = write([codexLine(at: now.addingTimeInterval(-600),
+                             input: 100, cached: 0, output: 7, reasoning: 0)],
+                  to: codexDir, name: "rollout-a.jsonl", modified: now)
+
+        let store = UsageHistoryStore()
+        store.refresh(source: .claude, root: claudeDir, now: now)
+        store.refresh(source: .codex, root: codexDir, now: now)
+        // Re-refresh Codex repeatedly; Claude's partition must be untouched.
+        store.refresh(source: .codex, root: codexDir, now: now)
+        store.refresh(source: .codex, root: codexDir, now: now)
+
+        XCTAssertEqual(store.series(source: .claude, now: now).total(for: .outputTokens), 1_000)
+    }
+
+    // Re-bucketing for another window must not touch the disk at all.
+    func test_seriesForDifferentWindow_doesNoIO() {
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        let dir = fixtureDirectory()
+        _ = write([claudeLine(at: now.addingTimeInterval(-60 * 60), output: 100),
+                   claudeLine(at: now.addingTimeInterval(-60 * 60 * 9), output: 500)],
+                  to: dir, name: "a.jsonl", modified: now)
+
+        let store = UsageHistoryStore()
+        store.refresh(source: .claude, root: dir, now: now)
+        let afterRefresh = store.lastRefreshStats
+
+        XCTAssertEqual(store.series(now: now, window: .twentyFourHours).total(for: .outputTokens), 600)
+        XCTAssertEqual(store.series(now: now, window: .sixHours).total(for: .outputTokens), 100)
+        // Stats untouched: no refresh happened, so no files were read.
+        XCTAssertEqual(store.lastRefreshStats, afterRefresh)
+    }
+
+    // MARK: Codex
+
+    func test_codexSeries_splitsCachedInputAndFoldsReasoning() {
+        let dir = fixtureDirectory()
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        _ = write([codexLine(at: now.addingTimeInterval(-900),
+                             input: 15_000, cached: 10_000, output: 200, reasoning: 60)],
+                  to: dir, name: "rollout-test.jsonl", modified: now)
+
+        let series = UsageHistoryReader.codexSeries(now: now, root: dir)
+        // Reasoning tokens bill as output.
+        XCTAssertEqual(series.total(for: .outputTokens), 260)
+        // input_tokens already includes the cached portion, so input+cache must
+        // come back to 15,000 rather than double-counting to 25,000.
+        XCTAssertEqual(series.total(for: .inputAndCache), 15_000)
+        XCTAssertEqual(series.total(for: .turns), 1)
+    }
+
+    func test_codexNonTokenCountEvents_areIgnored() {
+        let dir = fixtureDirectory()
+        let now = Date(timeIntervalSince1970: 1_785_150_000)
+        _ = write([
+            #"{"timestamp":"2026-07-27T12:00:00.000Z","type":"event_msg","payload":{"type":"agent_message"}}"#,
+            codexLine(at: now.addingTimeInterval(-900), output: 200, reasoning: 0),
+        ], to: dir, name: "rollout-test.jsonl", modified: now)
+
+        let series = UsageHistoryReader.codexSeries(now: now, root: dir)
+        XCTAssertEqual(series.total(for: .turns), 1)
+        XCTAssertEqual(series.total(for: .outputTokens), 200)
+    }
+}

--- a/Tests/StackNudgePanelCoreTests/UsageHistoryTests.swift
+++ b/Tests/StackNudgePanelCoreTests/UsageHistoryTests.swift
@@ -309,7 +309,7 @@ final class UsageHistoryTests: XCTestCase {
         XCTAssertEqual(second.bytesParsed, 0)
 
         // Totals survive the skip — the entries came from cache, not a re-read.
-        XCTAssertEqual(store.series(now: now).total(for: .outputTokens), 100)
+        XCTAssertEqual(store.series(source: .claude, now: now).total(for: .outputTokens), 100)
     }
 
     // An appended line must be picked up without re-reading what came before.
@@ -323,15 +323,15 @@ final class UsageHistoryTests: XCTestCase {
         let store = UsageHistoryStore()
         store.refresh(source: .claude, root: dir, now: now)
         let firstBytes = store.lastRefreshStats.bytesParsed
-        XCTAssertEqual(store.series(now: now).total(for: .outputTokens), 100)
+        XCTAssertEqual(store.series(source: .claude, now: now).total(for: .outputTokens), 100)
 
         let secondLine = claudeLine(at: now.addingTimeInterval(-600), output: 250)
         try? (firstLine + "\n" + secondLine + "\n").write(toFile: path, atomically: true, encoding: .utf8)
 
         store.refresh(source: .claude, root: dir, now: now)
         let appendBytes = store.lastRefreshStats.bytesParsed
-        XCTAssertEqual(store.series(now: now).total(for: .outputTokens), 350)
-        XCTAssertEqual(store.series(now: now).total(for: .turns), 2)
+        XCTAssertEqual(store.series(source: .claude, now: now).total(for: .outputTokens), 350)
+        XCTAssertEqual(store.series(source: .claude, now: now).total(for: .turns), 2)
 
         // Only the appended region was read, not the whole file again. Compare
         // against the file's own size rather than against `firstBytes`: the two
@@ -357,12 +357,12 @@ final class UsageHistoryTests: XCTestCase {
         try? (complete + "\n" + pending).write(toFile: path, atomically: true, encoding: .utf8)
         let store = UsageHistoryStore()
         store.refresh(source: .claude, root: dir, now: now)
-        XCTAssertEqual(store.series(now: now).total(for: .outputTokens), 100)
+        XCTAssertEqual(store.series(source: .claude, now: now).total(for: .outputTokens), 100)
 
         try? (complete + "\n" + pending + "\n").write(toFile: path, atomically: true, encoding: .utf8)
         store.refresh(source: .claude, root: dir, now: now)
-        XCTAssertEqual(store.series(now: now).total(for: .outputTokens), 500)
-        XCTAssertEqual(store.series(now: now).total(for: .turns), 2)
+        XCTAssertEqual(store.series(source: .claude, now: now).total(for: .outputTokens), 500)
+        XCTAssertEqual(store.series(source: .claude, now: now).total(for: .turns), 2)
     }
 
     // A truncated or replaced file must be re-read from the start rather than
@@ -378,14 +378,14 @@ final class UsageHistoryTests: XCTestCase {
 
         let store = UsageHistoryStore()
         store.refresh(source: .claude, root: dir, now: now)
-        XCTAssertEqual(store.series(now: now).total(for: .turns), 3)
+        XCTAssertEqual(store.series(source: .claude, now: now).total(for: .turns), 3)
 
         // Replace with a single, shorter entry.
         let replacement = claudeLine(at: now.addingTimeInterval(-300), output: 7)
         try? (replacement + "\n").write(toFile: path, atomically: true, encoding: .utf8)
         store.refresh(source: .claude, root: dir, now: now)
-        XCTAssertEqual(store.series(now: now).total(for: .turns), 1)
-        XCTAssertEqual(store.series(now: now).total(for: .outputTokens), 7)
+        XCTAssertEqual(store.series(source: .claude, now: now).total(for: .turns), 1)
+        XCTAssertEqual(store.series(source: .claude, now: now).total(for: .outputTokens), 7)
     }
 
     // Entries that age past the retained window must not accumulate forever.
@@ -479,8 +479,8 @@ final class UsageHistoryTests: XCTestCase {
         store.refresh(source: .claude, root: dir, now: now)
         let afterRefresh = store.lastRefreshStats
 
-        XCTAssertEqual(store.series(now: now, window: .twentyFourHours).total(for: .outputTokens), 600)
-        XCTAssertEqual(store.series(now: now, window: .sixHours).total(for: .outputTokens), 100)
+        XCTAssertEqual(store.series(source: .claude, now: now, window: .twentyFourHours).total(for: .outputTokens), 600)
+        XCTAssertEqual(store.series(source: .claude, now: now, window: .sixHours).total(for: .outputTokens), 100)
         // Stats untouched: no refresh happened, so no files were read.
         XCTAssertEqual(store.lastRefreshStats, afterRefresh)
     }

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -31,6 +31,7 @@ private enum KeyCode {
     static let nKey:      UInt16 = 45
     static let pKey:      UInt16 = 35
     static let mKey:      UInt16 = 46
+    static let wKey:      UInt16 = 13
 }
 
 // Floating, non-activating panel. Shown via global hotkey; receives key
@@ -1329,7 +1330,13 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     }
 
     // Public hook for the Usage tab's "Sync now" keystroke.
-    func syncQuotaNow() { runQuotaProbe() }
+    // R in the Usage tab. Re-probes the live quota and re-reads the transcript
+    // history — the graph is derived from files that may have grown since the
+    // last scan, and the freshness window would otherwise skip it.
+    func syncQuotaNow() {
+        runQuotaProbe()
+        nav.refreshUsageSeries(force: true)
+    }
 
     // MARK: - Usage tab detail scrolling
 
@@ -2616,12 +2623,24 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                 switch event.keyCode {
                 case KeyCode.escape:
                     hidePanel()
+                case KeyCode.rightArrow:
+                    // Step forward through the carousel; a no-op on the last
+                    // pane rather than wrapping, so → is a safe key to lean on.
+                    nav.advanceUsagePane()
                 case KeyCode.leftArrow:
-                    nav.usageDetailFocused = false
+                    // Walk back through the carousel, then out to the client
+                    // list — one more press of the same key the user came in on.
+                    if !nav.retreatUsagePane() { nav.usageDetailFocused = false }
                 case KeyCode.upArrow:
-                    scrollDetailBy(-40)
+                    // The history pane doesn't scroll, so ↑/↓ are free there.
+                    if nav.usagePane == .history { nav.cycleUsageMetric(forward: false) }
+                    else { scrollDetailBy(-40) }
                 case KeyCode.downArrow:
-                    scrollDetailBy(40)
+                    if nav.usagePane == .history { nav.cycleUsageMetric(forward: true) }
+                    else { scrollDetailBy(40) }
+                case KeyCode.wKey where nav.usagePane == .history:
+                    // Re-buckets cached entries; no rescan, so it lands instantly.
+                    nav.cycleUsageWindow()
                 case KeyCode.rKey:
                     syncQuotaNow()
                 case KeyCode.pKey:
@@ -2640,6 +2659,9 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
             case KeyCode.downArrow:
                 nav.selectNextUsageClient()
             case KeyCode.rightArrow, KeyCode.returnKey, KeyCode.numpadEnter:
+                // Entering always lands on the first carousel pane, so → from
+                // the client list is a predictable two-press path to the graph.
+                nav.usagePane = .quota
                 nav.usageDetailFocused = true
             case KeyCode.rKey:
                 syncQuotaNow()
@@ -2828,6 +2850,9 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
             top ? selectFirstSession() : selectLastSession()
         case .usage:
             if nav.usageDetailFocused {
+                // Nothing to jump to on the history pane — let the keystroke
+                // through rather than inventing a behaviour for it.
+                guard nav.usagePane != .history else { return false }
                 scrollDetailToEdge(top: top)
             } else {
                 top ? nav.selectFirstUsageClient() : nav.selectLastUsageClient()

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -465,6 +465,27 @@ final class PanelNav: ObservableObject {
     // When true, keyboard focus is inside the Usage detail pane: ↑/↓ scroll it
     // rather than switching client. →/Enter steps in; ←/Esc steps back out.
     @Published var usageDetailFocused: Bool = false
+    // Which pane of the detail carousel is showing. While the detail holds
+    // focus, → steps forward through the panes and ← steps back — stepping back
+    // off the first pane hands focus to the client list, so the carousel reads
+    // as one more press of the same key rather than a separate focus level.
+    @Published var usagePane: UsagePane = .quota
+    // Series metric the history pane plots. ↑/↓ cycle it (that pane has nothing
+    // to scroll, unlike the quota pane).
+    @Published var usageMetric: UsageMetric = .outputTokens
+    // Window the history pane covers. W cycles it. Narrower windows are a
+    // re-bucket of the same cached entries, so switching costs no I/O.
+    @Published var usageWindow: UsageWindow = .widest
+    // Long-lived parse cache. Owned per-nav rather than global so nothing leaks
+    // between instances, and so tests can drive a clean one.
+    private let usageStore = UsageHistoryStore()
+    // Replayed transcript history for the selected client, keyed so switching
+    // client doesn't show another client's numbers while a scan is in flight.
+    @Published var usageSeries: UsageSeries?
+    @Published var usageSeriesClient: UsageClient?
+    @Published var usageSeriesLoading: Bool = false
+    private var usageSeriesScannedAt: Date?
+    private var usageSeriesScanning = false
 
     // Connected clients that currently have quota to show, in display order.
     var availableUsageClients: [UsageClient] {
@@ -503,6 +524,115 @@ final class PanelNav: ObservableObject {
     // ⌘↑/↓ — jump to the first / last connected client.
     func selectFirstUsageClient() { guard !availableUsageClients.isEmpty else { return }; usageClientIndex = 0 }
     func selectLastUsageClient()  { let count = availableUsageClients.count; guard count > 0 else { return }; usageClientIndex = count - 1 }
+
+    // MARK: - Usage detail carousel
+
+    var selectedUsageClient: UsageClient? {
+        let clients = availableUsageClients
+        guard !clients.isEmpty else { return nil }
+        return clients[clampedUsageClientIndex]
+    }
+
+    // The cached series, but only when it belongs to the client on screen — a
+    // scan that finished for a previous selection must not render under a new one.
+    func usageSeries(for client: UsageClient) -> UsageSeries? {
+        guard usageSeriesClient == client else { return nil }
+        return usageSeries
+    }
+
+    // → while the detail holds focus. Returns false when already on the last
+    // pane so the caller knows the keystroke had nothing to do.
+    @discardableResult
+    func advanceUsagePane() -> Bool {
+        let panes = UsagePane.allCases
+        guard let index = panes.firstIndex(of: usagePane), index + 1 < panes.count else { return false }
+        usagePane = panes[index + 1]
+        if usagePane == .history { refreshUsageSeries() }
+        return true
+    }
+
+    // ← while the detail holds focus. Returns false on the first pane, which is
+    // the caller's signal to hand focus back to the client list.
+    @discardableResult
+    func retreatUsagePane() -> Bool {
+        let panes = UsagePane.allCases
+        guard let index = panes.firstIndex(of: usagePane), index > 0 else { return false }
+        usagePane = panes[index - 1]
+        return true
+    }
+
+    func cycleUsageMetric(forward: Bool) {
+        let metrics = UsageMetric.allCases
+        let index = metrics.firstIndex(of: usageMetric) ?? 0
+        let next = forward ? (index + 1) % metrics.count
+                           : (index - 1 + metrics.count) % metrics.count
+        usageMetric = metrics[next]
+    }
+
+    // W on the history pane. Re-buckets the cached entries for the new window
+    // rather than re-reading anything, so this is synchronous and instant — the
+    // store always retains the widest window for exactly this reason.
+    func cycleUsageWindow() {
+        let windows = UsageWindow.allCases
+        let index = windows.firstIndex(of: usageWindow) ?? 0
+        usageWindow = windows[(index + 1) % windows.count]
+        guard let client = selectedUsageClient,
+              let source = client.historySource,
+              usageSeries(for: client) != nil
+        else { return }
+        usageSeries = usageStore.series(source: source, window: usageWindow)
+    }
+
+    // Replay the selected client's transcripts on a background queue. The store
+    // skips files that haven't changed and resumes mid-file for those that have,
+    // so a repeat call costs the directory walk (~94 ms) rather than a full parse
+    // (~1050 ms). The freshness gate is therefore short — just enough to stop key
+    // repeat from queueing work. `force` is the R key, which always re-reads.
+    func refreshUsageSeries(force: Bool = false) {
+        guard let client = selectedUsageClient, let source = client.historySource else {
+            usageSeries = nil
+            usageSeriesClient = selectedUsageClient
+            return
+        }
+        guard !usageSeriesScanning else { return }
+        if !force,
+           usageSeriesClient == client,
+           let scannedAt = usageSeriesScannedAt,
+           Date().timeIntervalSince(scannedAt) < Self.usageSeriesFreshness {
+            return
+        }
+
+        // Only show the spinner on a first read; a warm re-read lands fast enough
+        // that flashing a loading state would just be a flicker.
+        let isFirstRead = usageSeries == nil || usageSeriesClient != client
+        usageSeriesScanning = true
+        usageSeriesLoading = isFirstRead
+        let store = usageStore
+
+        DispatchQueue.global(qos: .utility).async {
+            // Only the I/O happens off-main. Bucketing is deliberately left to the
+            // completion below rather than done here against a captured window:
+            // pressing W during an in-flight scan would otherwise have its
+            // re-bucket silently reverted by this completion, leaving the header
+            // claiming one window while the chart showed another.
+            store.refresh(source: source, retaining: .widest)
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                // Pure computation over entries already in memory (~1 ms), so
+                // running it on main is cheaper than the risk of a stale window.
+                self.usageSeries = store.series(source: source, window: self.usageWindow)
+                self.usageSeriesClient = client
+                self.usageSeriesScannedAt = Date()
+                self.usageSeriesLoading = false
+                self.usageSeriesScanning = false
+            }
+        }
+    }
+
+    // Short enough that the graph feels live, long enough that holding a key
+    // down doesn't queue redundant walks. The incremental store is what makes
+    // this affordable — it was 60s when every refresh meant a full re-parse.
+    private static let usageSeriesFreshness: TimeInterval = 5
     // Transient feedback for the "Check for updates…" action row.
     // Set by PanelController around UpdateChecker.check(); cleared
     // back to .idle a few seconds after a terminal result so the

--- a/panel/SessionUsage.swift
+++ b/panel/SessionUsage.swift
@@ -41,6 +41,41 @@ enum UsageClient: String, CaseIterable, Hashable {
         case .antigravity: return "Antigravity"
         }
     }
+
+    // Where this client's replayable token history lives, or nil when it has
+    // none. Claude and Codex both write per-turn token usage with a timestamp
+    // into their transcripts. Antigravity's history.jsonl carries only prompt
+    // text, timestamp and workspace — no token data at all — and its quota comes
+    // from a live API call, so there's nothing to plot retrospectively.
+    //
+    // Returning the source rather than a Bool keeps the mapping exhaustive: a new
+    // client can't silently inherit another agent's transcript format.
+    var historySource: UsageHistoryStore.Source? {
+        switch self {
+        case .claude:      return .claude
+        case .codex:       return .codex
+        case .antigravity: return nil
+        }
+    }
+
+    var hasReplayableHistory: Bool { historySource != nil }
+}
+
+// Panes of the Usage tab's inner carousel, in step order. → walks forward while
+// the detail holds focus; ← walks back and then out to the client list.
+enum UsagePane: CaseIterable {
+    case quota
+    case history
+
+    var label: String {
+        switch self {
+        case .quota:   return "Quota"
+        // Not "24h" — the window is user-cyclable, so naming it here would go
+        // stale the moment they switch to 6h. The active window shows in the
+        // chart header instead.
+        case .history: return "History"
+        }
+    }
 }
 
 // MARK: - Usage tab UI
@@ -66,10 +101,19 @@ struct UsageView: View {
             }
 
             PageFooter {
-                FooterHint(label: footerStatusLabel, keys: [])
                 if nav.usageDetailFocused {
-                    FooterHint(label: "Scroll", keys: ["↑↓"])
-                    FooterHint(label: "Top/Bottom", keys: ["⌘↑↓"])
+                    // The history pane has nothing to scroll, so ↑/↓ cycle the
+                    // plotted metric there instead — and ⌘↑↓ has no meaning.
+                    if nav.usagePane == .history {
+                        FooterHint(label: "Metric", keys: ["↑↓"])
+                        FooterHint(label: "Window", keys: ["W"])
+                    } else {
+                        FooterHint(label: "Scroll", keys: ["↑↓"])
+                        FooterHint(label: "Top/Bottom", keys: ["⌘↑↓"])
+                    }
+                    if nav.usagePane != UsagePane.allCases.last {
+                        FooterHint(label: UsagePane.allCases.last?.label ?? "Next", keys: ["→"])
+                    }
                     FooterHint(label: "Back", keys: ["←"])
                 } else {
                     if nav.availableUsageClients.count > 1 {
@@ -88,8 +132,12 @@ struct UsageView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        // Always enter the tab in client-list focus, never stuck inside the pane.
-        .onAppear { nav.usageDetailFocused = false }
+        // Always enter the tab in client-list focus on the first carousel pane,
+        // never stuck inside the pane or on a pane the user last left behind.
+        .onAppear {
+            nav.usageDetailFocused = false
+            nav.usagePane = .quota
+        }
     }
 
     // Left: one row per connected client (↑/↓ or click to select). Right: the
@@ -103,6 +151,11 @@ struct UsageView: View {
                     clientRow(client, isSelected: client == selected)
                 }
                 Spacer(minLength: 0)
+                // Sync freshness lives here rather than in the footer: it
+                // describes the whole tab (not one carousel pane), and the
+                // footer had run out of room once the carousel added its own
+                // hints. The column already ended in slack space.
+                syncStatus
             }
             .frame(width: 104)
             .padding(.vertical, 10)
@@ -110,18 +163,15 @@ struct UsageView: View {
 
             Divider()
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: 14) {
-                    tiers(for: selected)
+            VStack(alignment: .leading, spacing: 0) {
+                paneIndicator
+                switch nav.usagePane {
+                case .quota:   quotaPane(for: selected)
+                case .history: historyPane(for: selected)
                 }
-                .padding(.horizontal, 14)
-                .padding(.vertical, 14)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(ThinScrollers())
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .scrollIndicators(.visible)
-            // Focus ring when the user has stepped into the pane (↑/↓ scroll).
+            // Focus ring when the user has stepped into the carousel.
             .overlay(alignment: .top) {
                 if nav.usageDetailFocused {
                     RoundedRectangle(cornerRadius: 6)
@@ -132,6 +182,53 @@ struct UsageView: View {
             }
         }
         .frame(maxHeight: .infinity)
+    }
+
+    // Carousel position. Always rendered so the second pane is discoverable
+    // without pressing → to find out it exists; dimmed until the carousel
+    // actually holds focus, matching how the client rows de-emphasise once
+    // focus moves on.
+    private var paneIndicator: some View {
+        HStack(spacing: 6) {
+            ForEach(UsagePane.allCases, id: \.self) { pane in
+                let active = pane == nav.usagePane
+                Text(pane.label)
+                    .font(.caption2.weight(active ? .semibold : .regular))
+                    .foregroundStyle(active
+                                     ? (nav.usageDetailFocused ? Color.accentColor : Color.primary)
+                                     : Color.primary.opacity(0.35))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        RoundedRectangle(cornerRadius: 4, style: .continuous)
+                            .fill(active ? Color.accentColor.opacity(nav.usageDetailFocused ? 0.14 : 0.06)
+                                         : Color.clear)
+                    )
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        nav.usagePane = pane
+                        nav.usageDetailFocused = true
+                        if pane == .history { nav.refreshUsageSeries() }
+                    }
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 8)
+    }
+
+    private func quotaPane(for client: UsageClient) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                tiers(for: client)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(ThinScrollers())
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .scrollIndicators(.visible)
     }
 
     private func clientRow(_ client: UsageClient, isSelected: Bool) -> some View {
@@ -206,6 +303,127 @@ struct UsageView: View {
                 }
             }
         }
+    }
+
+    // MARK: - History pane
+
+    // Replayed transcript history for the selected client. Deliberately labelled
+    // as token throughput rather than quota: the bars on the previous pane come
+    // from the provider's own quota accounting, which is weighted per model and
+    // plan and counts usage from other machines, so the two will not agree.
+    @ViewBuilder
+    private func historyPane(for client: UsageClient) -> some View {
+        if !client.hasReplayableHistory {
+            historyMessage(
+                icon: "clock.badge.questionmark",
+                title: "No history for \(client.displayName)",
+                detail: "\(client.displayName) doesn't record token usage to disk, so there's nothing to replay. Its quota above is read live."
+            )
+        } else if let series = nav.usageSeries(for: client), series.hasActivity {
+            let metric = nav.usageMetric
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text(metric.label)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .textCase(.uppercase)
+                    // The window lives here rather than in the pane label, since
+                    // W cycles it.
+                    Text(nav.usageWindow.label)
+                        .font(.caption2.monospacedDigit().weight(.semibold))
+                        .foregroundStyle(Color.green)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                                .fill(Color.green.opacity(0.14))
+                        )
+                    Spacer()
+                    Text(metricValue(series.total(for: metric), metric))
+                        .font(.caption.monospacedDigit().weight(.semibold))
+                        .foregroundStyle(.primary)
+                }
+                UsageSparkline(series: series, metric: metric)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                axisLabels(series)
+                if let peak = series.peakBucket(for: metric), peak.value(for: metric) > 0 {
+                    Text("Peak \(metricValue(peak.value(for: metric), metric)) at \(Self.clockLabel(peak.start))")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+        } else if nav.usageSeriesLoading {
+            historyLoading
+        } else {
+            historyMessage(
+                icon: "chart.line.flattrend.xyaxis",
+                title: "No activity in the last 24 hours",
+                detail: "This replays \(client.displayName)'s transcripts, so it fills in as soon as there are turns to plot."
+            )
+        }
+    }
+
+    private var historyLoading: some View {
+        historyPlaceholder {
+            ProgressView().controlSize(.small)
+            Text("Reading transcripts…")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func historyMessage(icon: String, title: String, detail: String) -> some View {
+        historyPlaceholder {
+            Image(systemName: icon)
+                .font(.title3)
+                .foregroundStyle(.secondary)
+            Text(title)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Text(detail)
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 280)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func historyPlaceholder<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        VStack(spacing: 8) { content() }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(.vertical, 20)
+    }
+
+    // Four evenly spaced clock labels across the window — as many as fit legibly
+    // in the ~465pt the pane gets at the panel's default width.
+    private func axisLabels(_ series: UsageSeries) -> some View {
+        let span = series.windowEnd.timeIntervalSince(series.windowStart)
+        let stops = (0...3).map { series.windowStart.addingTimeInterval(span * Double($0) / 3.0) }
+        return HStack(spacing: 0) {
+            ForEach(stops.indices, id: \.self) { index in
+                Text(Self.clockLabel(stops[index]))
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.tertiary)
+                if index < stops.count - 1 { Spacer(minLength: 0) }
+            }
+        }
+    }
+
+    private func metricValue(_ value: Int, _ metric: UsageMetric) -> String {
+        metric == .turns ? "\(value)" : TokenFormat.short(value)
+    }
+
+    private static let clockFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return formatter
+    }()
+
+    private static func clockLabel(_ date: Date) -> String {
+        clockFormatter.string(from: date)
     }
 
     private func creditsRow(_ agy: AntigravityQuotaSnapshot) -> some View {
@@ -331,8 +549,20 @@ struct UsageView: View {
         return .green
     }
 
-    private var footerStatusLabel: String {
-        if !nav.quotaTrackingEnabled { return "Tracking off" }
+    // Foot of the client column. Wraps rather than truncating — the column is
+    // 104pt wide and "Updated 15m ago" doesn't fit on one line there.
+    private var syncStatus: some View {
+        Text(syncStatusLabel)
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.horizontal, 8)
+            .padding(.top, 6)
+    }
+
+    // No "tracking off" case: the column only renders inside clientSplit, which
+    // is gated on quotaTrackingEnabled — trackingDisabledState owns that message.
+    private var syncStatusLabel: String {
         if nav.quotaSyncing { return "Syncing…" }
         guard let updated = nav.quotaLastUpdated else { return "Never synced" }
         return "Updated \(RelativeTime.string(updated, style: .abbreviated))"
@@ -340,3 +570,81 @@ struct UsageView: View {
 
 }
 
+
+// Hand-drawn area chart. Swift Charts is available (deployment target is macOS
+// 13) but its axis and legend chrome costs more room than the plot itself at
+// this size — the pane gets ~465x140pt — and the rest of the panel is drawn by
+// hand, so this keeps the look consistent and the swiftc build dependency-free.
+//
+// Every bucket is plotted, empty ones included: over a real 24h only ~22% of
+// five-minute buckets have activity, so filling to a baseline reads as bursts of
+// work, where a line that skips the gaps reads as broken data.
+private struct UsageSparkline: View {
+
+    let series: UsageSeries
+    let metric: UsageMetric
+
+    // The same green the quota bars use at low utilization, and the one the
+    // mascots and Settings toggles use — this plots token counts, which have no
+    // threshold semantics, so it stays green throughout rather than ramping to
+    // yellow/red the way a utilization bar does.
+    private static let plotColor = Color.green
+
+    var body: some View {
+        GeometryReader { geometry in
+            let width  = geometry.size.width
+            let height = geometry.size.height
+            let peak   = max(1, series.peakValue(for: metric))
+            let values = series.buckets.map { $0.value(for: metric) }
+            // Guard the single-bucket case so the divisor can't be zero.
+            let step   = values.count > 1 ? width / CGFloat(values.count - 1) : width
+            let lastX  = CGFloat(max(0, values.count - 1)) * step
+
+            let pointY: (Int) -> CGFloat = { value in
+                height - (CGFloat(value) / CGFloat(peak)) * height
+            }
+
+            ZStack {
+                Path { path in
+                    path.move(to: CGPoint(x: 0, y: height))
+                    for (index, value) in values.enumerated() {
+                        path.addLine(to: CGPoint(x: CGFloat(index) * step, y: pointY(value)))
+                    }
+                    path.addLine(to: CGPoint(x: lastX, y: height))
+                    path.closeSubpath()
+                }
+                .fill(
+                    LinearGradient(
+                        colors: [Self.plotColor.opacity(0.45), Self.plotColor.opacity(0.08)],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+
+                Path { path in
+                    for (index, value) in values.enumerated() {
+                        let point = CGPoint(x: CGFloat(index) * step, y: pointY(value))
+                        if index == 0 { path.move(to: point) } else { path.addLine(to: point) }
+                    }
+                }
+                .stroke(Self.plotColor, style: StrokeStyle(lineWidth: 1.2, lineJoin: .round))
+
+                // Baseline, so an all-quiet stretch still reads as an axis
+                // rather than as empty space.
+                Path { path in
+                    path.move(to: CGPoint(x: 0, y: height - 0.5))
+                    path.addLine(to: CGPoint(x: width, y: height - 0.5))
+                }
+                .stroke(Color.primary.opacity(0.15), lineWidth: 1)
+            }
+            // The peak value is printed rather than drawing a y-axis: one number
+            // is enough to scale the shape mentally, and ticks would eat most of
+            // the pane's height.
+            .overlay(alignment: .topTrailing) {
+                Text(metric == .turns ? "\(peak)" : TokenFormat.short(peak))
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+}

--- a/panel/UsageHistory.swift
+++ b/panel/UsageHistory.swift
@@ -1,0 +1,541 @@
+import Foundation
+
+// MARK: - Series model
+
+// One time bucket of a usage series. Token fields are sums over every agent
+// turn that landed in the bucket; `turns` counts the turns themselves.
+struct UsageBucket: Equatable {
+    let start: Date
+    var inputTokens:       Int = 0
+    var outputTokens:      Int = 0
+    var cacheReadTokens:   Int = 0
+    var cacheCreateTokens: Int = 0
+    var turns:             Int = 0
+}
+
+// What the graph plots, in ↑/↓ cycle order. Output tokens is the default because
+// input+cache is dominated by cache reads — over a real 24h it ran ~190x the
+// output total, so sharing one linear axis would flatten output into the
+// baseline.
+//
+// `excludingCacheReads` is the "real work" view: everything the model actually
+// processed, minus the cheap replays. Cache *creation* counts because that is
+// fresh content genuinely run through the model and merely stored for reuse;
+// cache *reads* are excluded because they dominate everything else and flatten
+// the shape. Measured over a real 24h: 25.9M against 3.7M output and 699M cache
+// reads, so it lands ~7x the output-only series and reads as a distinct curve.
+//
+// Excluding cache creation as well would leave uncached input + output, which
+// measured just 0.8% above output-only — a near-duplicate series, not worth a
+// position in the cycle.
+enum UsageMetric: CaseIterable {
+    case outputTokens
+    case excludingCacheReads
+    case inputAndCache
+    case turns
+
+    var label: String {
+        switch self {
+        case .outputTokens:        return "Output tokens"
+        case .excludingCacheReads: return "Tokens (no cache reads)"
+        case .inputAndCache:       return "Input + cache"
+        case .turns:               return "Turns"
+        }
+    }
+}
+
+extension UsageBucket {
+    func value(for metric: UsageMetric) -> Int {
+        switch metric {
+        case .outputTokens: return outputTokens
+        // Everything but the replays. `inputTokens` is already the uncached
+        // portion for both agents — Claude reports cache reads and cache
+        // creation as separate fields, and the Codex reader subtracts its cached
+        // count out of `input_tokens` — so only cacheReadTokens is left out here.
+        case .excludingCacheReads: return inputTokens + cacheCreateTokens + outputTokens
+        case .inputAndCache:       return inputTokens + cacheReadTokens + cacheCreateTokens
+        case .turns:               return turns
+        }
+    }
+}
+
+// Window the graph covers. Shorter windows exist mainly for resolution: at 5
+// minute buckets a 24h window packs 288 buckets into the ~465pt the pane gets
+// (1.6pt each, sparkline territory), where 6h gives 72 buckets at ~6.5pt each
+// and reads as distinct bars.
+enum UsageWindow: CaseIterable {
+    case sixHours
+    case twelveHours
+    case twentyFourHours
+
+    var hours: Int {
+        switch self {
+        case .sixHours:        return 6
+        case .twelveHours:     return 12
+        case .twentyFourHours: return 24
+        }
+    }
+
+    var label: String { "\(hours)h" }
+
+    // The widest window, and therefore how much history the store retains. Every
+    // shorter window is bucketed from the same cached entries, so switching
+    // scope costs no I/O at all.
+    static var widest: UsageWindow { .twentyFourHours }
+}
+
+// A trailing-window series. Every bucket is present and zero-filled rather than
+// only the active ones: over a real 24h only ~22% of 5-minute buckets had any
+// activity, and a line drawn across genuine holes reads as broken data instead
+// of as idle time. Buckets are aligned to wall-clock multiples of
+// `bucketSeconds`, and the last one is the in-progress bucket.
+struct UsageSeries: Equatable {
+    let buckets: [UsageBucket]
+    let bucketSeconds: Int
+
+    var windowStart: Date { buckets.first?.start ?? Date(timeIntervalSince1970: 0) }
+    var windowEnd: Date {
+        guard let last = buckets.last else { return Date(timeIntervalSince1970: 0) }
+        return last.start.addingTimeInterval(Double(bucketSeconds))
+    }
+
+    var hasActivity: Bool { buckets.contains { $0.turns > 0 } }
+
+    func total(for metric: UsageMetric) -> Int {
+        buckets.reduce(0) { $0 + $1.value(for: metric) }
+    }
+
+    func peakValue(for metric: UsageMetric) -> Int {
+        buckets.reduce(0) { max($0, $1.value(for: metric)) }
+    }
+
+    func peakBucket(for metric: UsageMetric) -> UsageBucket? {
+        buckets.max { $0.value(for: metric) < $1.value(for: metric) }
+    }
+}
+
+// MARK: - Parsed entry
+
+// One agent turn, kept in the store so re-bucketing for a different window — or
+// a refresh where nothing changed — never re-reads or re-parses anything.
+struct UsageEntry: Equatable {
+    let when: Date
+    // Stable per-turn id where the agent provides one (Claude's `uuid`), used to
+    // drop turns replayed into a second transcript by a resumed or forked
+    // session. nil for agents with no such id.
+    let identity: String?
+    let inputTokens:       Int
+    let outputTokens:      Int
+    let cacheReadTokens:   Int
+    let cacheCreateTokens: Int
+}
+
+// MARK: - Store
+
+// Caches parsed transcript entries so repeat reads are cheap.
+//
+// Measured on a real 24h window (~88 MB across 47 warm transcripts): a full
+// uncached pass costs ~1050 ms, of which the directory walk and stat is ~94 ms,
+// raw I/O plus line splitting is ~208 ms, and JSON plus timestamp parsing is
+// ~749 ms — 71% of the total. Caching parsed entries therefore removes the
+// dominant cost, taking a no-change refresh down to roughly the ~94 ms walk.
+//
+// Transcripts are append-only, so a file whose size and mtime are unchanged is
+// skipped outright, and a file that grew is parsed only from the byte offset
+// where the last complete line ended.
+final class UsageHistoryStore {
+
+    enum Source {
+        case claude
+        case codex
+
+        var defaultRoot: String {
+            switch self {
+            case .claude: return "\(NSHomeDirectory())/.claude/projects"
+            case .codex:  return "\(NSHomeDirectory())/.codex/sessions"
+            }
+        }
+
+        // Byte pattern every interesting line must contain, applied before any
+        // JSON parsing.
+        var marker: StaticString {
+            switch self {
+            case .claude: return "\"assistant\""
+            case .codex:  return "token_count"
+            }
+        }
+    }
+
+    // What a refresh actually did. Exposed so the cache's behaviour is
+    // assertable rather than assumed.
+    struct RefreshStats: Equatable {
+        var filesParsed     = 0
+        var filesSkipped    = 0
+        var bytesParsed     = 0
+        var entriesRetained = 0
+    }
+
+    private struct CachedFile {
+        var size: Int
+        var modified: Date
+        // Offset just past the last complete line consumed. A trailing partial
+        // line (a write caught mid-flush) is deliberately left unconsumed and
+        // picked up once its newline lands.
+        var parsedUpTo: Int
+        var entries: [UsageEntry]
+    }
+
+    // Partitioned by source, not a flat path map: the same store serves every
+    // client, and a series must never merge another agent's entries. Flattening
+    // one shared map here silently showed Claude's history under Codex.
+    private var cache: [Source: [String: CachedFile]] = [:]
+    private var stats = RefreshStats()
+    // Guards `cache` and `stats` only. File I/O and parsing happen outside it, so
+    // a background refresh never blocks a main-thread re-bucket for a scope
+    // change.
+    private let lock = NSLock()
+
+    var lastRefreshStats: RefreshStats {
+        lock.lock(); defer { lock.unlock() }
+        return stats
+    }
+
+    // MARK: Refresh
+
+    // Bring the cache up to date for `source`, retaining `retaining` hours of
+    // history. Safe to call repeatedly; the cost of a call that finds nothing
+    // changed is the directory walk plus a stat per file.
+    func refresh(source: Source,
+                 root: String? = nil,
+                 now: Date = Date(),
+                 retaining: UsageWindow = .widest) {
+        let directory = root ?? source.defaultRoot
+        let cutoff = now.addingTimeInterval(-Double(retaining.hours * 3600))
+        var fresh = RefreshStats()
+
+        for candidate in Self.transcriptFiles(under: directory, modifiedAfter: cutoff) {
+            lock.lock()
+            let cached = cache[source]?[candidate.path]
+            lock.unlock()
+
+            // Unchanged since the last pass — the append-only guarantee means
+            // there is nothing new to read.
+            if let cached, cached.size == candidate.size, cached.modified == candidate.modified {
+                fresh.filesSkipped += 1
+                continue
+            }
+
+            // Shrunk means truncated or replaced, so the cached entries can't be
+            // trusted; anything else is treated as an append and resumes from the
+            // last complete line. A whole-file rewrite that happened to grow
+            // would be mis-resumed, which is why identity-based deduplication
+            // stays in the merge step below rather than being dropped as
+            // redundant.
+            let resumeFrom = (cached.map { candidate.size < $0.size ? 0 : $0.parsedUpTo }) ?? 0
+            var entries = resumeFrom == 0 ? [] : (cached?.entries ?? [])
+
+            let consumed = Self.forEachLine(of: candidate.path,
+                                            from: resumeFrom,
+                                            containing: source.marker) { line in
+                if let entry = Self.parse(line: line, source: source) { entries.append(entry) }
+            }
+
+            fresh.filesParsed += 1
+            fresh.bytesParsed += max(0, consumed - resumeFrom)
+
+            // Drop anything that has aged out so memory tracks the window rather
+            // than the session.
+            entries.removeAll { $0.when < cutoff }
+
+            lock.lock()
+            cache[source, default: [:]][candidate.path] = CachedFile(size: candidate.size,
+                                                                     modified: candidate.modified,
+                                                                     parsedUpTo: consumed,
+                                                                     entries: entries)
+            lock.unlock()
+        }
+
+        lock.lock()
+        // Evict files that have gone cold. A file last written before the cutoff
+        // cannot hold an in-window entry, which is the same argument the scan
+        // prefilter rests on. Only this source's partition is touched — another
+        // client's cache is none of this refresh's business.
+        let surviving = (cache[source] ?? [:]).filter { $0.value.modified > cutoff }
+        cache[source] = surviving
+        fresh.entriesRetained = surviving.values.reduce(0) { $0 + $1.entries.count }
+        stats = fresh
+        lock.unlock()
+    }
+
+    // MARK: Bucketing
+
+    // Bucket one source's cached entries into a series. Pure computation over
+    // entries already in memory — no I/O — so a scope change is effectively free.
+    // `source` is required rather than defaulted: getting it wrong silently plots
+    // the wrong agent's history.
+    func series(source: Source,
+                now: Date = Date(),
+                window: UsageWindow = .widest,
+                bucketSeconds: Int = UsageHistoryStore.defaultBucketSeconds) -> UsageSeries {
+        lock.lock()
+        let all = (cache[source] ?? [:]).values.flatMap { $0.entries }
+        lock.unlock()
+
+        var accumulator = Accumulator(now: now, windowHours: window.hours, bucketSeconds: bucketSeconds)
+        for entry in all { accumulator.add(entry) }
+        return accumulator.series()
+    }
+
+    // Refresh then bucket, for callers that want both in one step.
+    func refreshedSeries(source: Source,
+                         root: String? = nil,
+                         now: Date = Date(),
+                         window: UsageWindow = .widest,
+                         bucketSeconds: Int = UsageHistoryStore.defaultBucketSeconds) -> UsageSeries {
+        // Always retain the widest window so narrower ones are a re-bucket of the
+        // same cached entries rather than another scan.
+        refresh(source: source, root: root, now: now, retaining: .widest)
+        return series(source: source, now: now, window: window, bucketSeconds: bucketSeconds)
+    }
+
+    static let defaultBucketSeconds = 300
+
+    // MARK: Accumulator
+
+    // Folds entries into wall-clock-aligned buckets, then zero-fills.
+    private struct Accumulator {
+        let firstBucketStart: Date
+        let bucketSeconds: Int
+        let bucketCount: Int
+
+        private var totals: [Int: UsageBucket] = [:]
+        private var seenIdentities: Set<String> = []
+
+        init(now: Date, windowHours: Int, bucketSeconds: Int) {
+            self.bucketSeconds = bucketSeconds
+            self.bucketCount = max(1, (windowHours * 3600) / bucketSeconds)
+            // Align the newest bucket down to a wall-clock boundary so buckets
+            // land on :00/:05/:10 rather than drifting with launch time, then
+            // count backwards for a fixed bucket count. The effective window is
+            // therefore up to one bucket short of `windowHours`, which keeps the
+            // series a stable width for the renderer.
+            let alignedNow = floor(now.timeIntervalSince1970 / Double(bucketSeconds)) * Double(bucketSeconds)
+            let firstEpoch = alignedNow - Double((bucketCount - 1) * bucketSeconds)
+            self.firstBucketStart = Date(timeIntervalSince1970: firstEpoch)
+        }
+
+        mutating func add(_ entry: UsageEntry) {
+            // Resumed or forked sessions can replay earlier turns into a second
+            // transcript. Measured duplication over a real 24h was zero, but this
+            // also covers a file being re-read after a rewrite, so it earns its
+            // keep beyond the replay case.
+            if let identity = entry.identity, !seenIdentities.insert(identity).inserted { return }
+
+            let offset = entry.when.timeIntervalSince(firstBucketStart)
+            guard offset >= 0 else { return }
+            let index = Int(offset) / bucketSeconds
+            guard index < bucketCount else { return }
+
+            let start = firstBucketStart.addingTimeInterval(Double(index * bucketSeconds))
+            var bucket = totals[index] ?? UsageBucket(start: start)
+            bucket.inputTokens       += entry.inputTokens
+            bucket.outputTokens      += entry.outputTokens
+            bucket.cacheReadTokens   += entry.cacheReadTokens
+            bucket.cacheCreateTokens += entry.cacheCreateTokens
+            bucket.turns             += 1
+            totals[index] = bucket
+        }
+
+        func series() -> UsageSeries {
+            let buckets = (0..<bucketCount).map { index in
+                totals[index] ?? UsageBucket(
+                    start: firstBucketStart.addingTimeInterval(Double(index * bucketSeconds))
+                )
+            }
+            return UsageSeries(buckets: buckets, bucketSeconds: bucketSeconds)
+        }
+    }
+
+    // MARK: Line parsing
+
+    private static func parse(line: Data, source: Source) -> UsageEntry? {
+        switch source {
+        case .claude: return parseClaude(line: line)
+        case .codex:  return parseCodex(line: line)
+        }
+    }
+
+    private static func parseClaude(line: Data) -> UsageEntry? {
+        guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
+              (object["type"] as? String) == "assistant",
+              let rawTimestamp = object["timestamp"] as? String,
+              let when = parseTimestamp(rawTimestamp),
+              let message = object["message"] as? [String: Any],
+              let usage = message["usage"] as? [String: Any]
+        else { return nil }
+        return UsageEntry(
+            when: when,
+            identity: object["uuid"] as? String,
+            inputTokens:       usage["input_tokens"]               as? Int ?? 0,
+            outputTokens:      usage["output_tokens"]              as? Int ?? 0,
+            cacheReadTokens:   usage["cache_read_input_tokens"]     as? Int ?? 0,
+            cacheCreateTokens: usage["cache_creation_input_tokens"] as? Int ?? 0
+        )
+    }
+
+    private static func parseCodex(line: Data) -> UsageEntry? {
+        guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
+              let rawTimestamp = object["timestamp"] as? String,
+              let when = parseTimestamp(rawTimestamp),
+              let payload = object["payload"] as? [String: Any],
+              (payload["type"] as? String) == "token_count",
+              let info = payload["info"] as? [String: Any],
+              let last = info["last_token_usage"] as? [String: Any]
+        else { return nil }
+        // Codex's `input_tokens` already includes `cached_input_tokens`, so the
+        // cached portion is split out rather than added — otherwise "input +
+        // cache" would double-count it. Reasoning tokens are billed as output, so
+        // they fold into the output total. There is no cache-creation figure.
+        let rawInput  = last["input_tokens"]            as? Int ?? 0
+        let cached    = last["cached_input_tokens"]     as? Int ?? 0
+        let output    = last["output_tokens"]           as? Int ?? 0
+        let reasoning = last["reasoning_output_tokens"] as? Int ?? 0
+        return UsageEntry(
+            when: when,
+            // Rollout events carry no stable id, so replays can't be detected for
+            // Codex. Its rollouts are append-only in practice.
+            identity: nil,
+            inputTokens:       max(0, rawInput - cached),
+            outputTokens:      output + reasoning,
+            cacheReadTokens:   cached,
+            cacheCreateTokens: 0
+        )
+    }
+
+    // MARK: File plumbing
+
+    private struct Candidate {
+        let path: String
+        let size: Int
+        let modified: Date
+    }
+
+    // Transcript files that could hold an in-window entry. A file last written
+    // before the window cannot contain entries inside it, because entries are
+    // appended as they happen — that prefilter narrows a ~389 MB transcript tree
+    // to the ~47 warm sessions, and the walk itself costs ~94 ms.
+    private static func transcriptFiles(under directory: String, modifiedAfter cutoff: Date) -> [Candidate] {
+        let keys: [URLResourceKey] = [.contentModificationDateKey, .isRegularFileKey, .fileSizeKey]
+        guard let enumerator = FileManager.default.enumerator(
+            at: URL(fileURLWithPath: directory),
+            includingPropertiesForKeys: keys,
+            options: [.skipsHiddenFiles, .skipsPackageDescendants]
+        ) else { return [] }
+
+        var candidates: [Candidate] = []
+        for case let url as URL in enumerator {
+            guard url.pathExtension == "jsonl",
+                  let values = try? url.resourceValues(forKeys: Set(keys)),
+                  values.isRegularFile == true,
+                  let modified = values.contentModificationDate,
+                  modified > cutoff
+            else { continue }
+            candidates.append(Candidate(path: url.path,
+                                        size: values.fileSize ?? 0,
+                                        modified: modified))
+        }
+        return candidates
+    }
+
+    // Walks a JSONL file from `offset`, invoking `body` for each complete line
+    // containing `marker`, and returns the offset just past the last complete
+    // line — the resume point for the next pass.
+    //
+    // Deliberately avoids decoding the file into a String and splitting it: that
+    // route measured 4.09s against a real 24h window versus 0.99s for this one.
+    // Swift's String is Unicode-correct, which makes a whole-file decode plus
+    // per-line `contains` the dominant cost. memchr/memmem do the newline split
+    // and marker search in C, and only surviving lines are copied into a Data.
+    @discardableResult
+    private static func forEachLine(of path: String,
+                                    from offset: Int,
+                                    containing marker: StaticString,
+                                    _ body: (Data) -> Void) -> Int {
+        guard let fileData = try? Data(contentsOf: URL(fileURLWithPath: path), options: .mappedIfSafe)
+        else { return offset }
+
+        var consumed = offset
+        fileData.withUnsafeBytes { raw in
+            guard let base = raw.baseAddress, offset < raw.count else { return }
+            let bytes = base.assumingMemoryBound(to: UInt8.self)
+            let total = raw.count
+            let markerStart = marker.utf8Start
+            let markerLength = marker.utf8CodeUnitCount
+
+            var cursor = offset
+            while cursor < total {
+                let remaining = total - cursor
+                let lineStart = bytes + cursor
+                // No newline left means a partial trailing line; leave it
+                // unconsumed so it is read once complete.
+                guard let newline = memchr(lineStart, 0x0A, remaining) else { break }
+                let lineLength = UnsafeRawPointer(newline) - UnsafeRawPointer(lineStart)
+
+                if lineLength >= markerLength,
+                   memmem(lineStart, lineLength, markerStart, markerLength) != nil {
+                    body(Data(bytes: lineStart, count: lineLength))
+                }
+                cursor += lineLength + 1
+                consumed = cursor
+            }
+        }
+        return consumed
+    }
+
+    // Both formatters are built once — instantiating one per line dominates the
+    // parse otherwise. Claude stamps fractional seconds; the plain variant is
+    // the fallback for any writer that doesn't.
+    private static let fractionalFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static let plainFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    static func parseTimestamp(_ raw: String) -> Date? {
+        fractionalFormatter.date(from: raw) ?? plainFormatter.date(from: raw)
+    }
+}
+
+// MARK: - Uncached convenience
+
+// One-shot reads with no cache, for tests and any caller that wants a clean
+// pass. The app goes through a long-lived UsageHistoryStore instead so repeat
+// reads stay cheap; keeping these separate means tests share no state.
+enum UsageHistoryReader {
+
+    static func claudeSeries(now: Date = Date(),
+                             window: UsageWindow = .widest,
+                             bucketSeconds: Int = UsageHistoryStore.defaultBucketSeconds,
+                             root: String? = nil) -> UsageSeries {
+        UsageHistoryStore().refreshedSeries(source: .claude, root: root, now: now,
+                                            window: window, bucketSeconds: bucketSeconds)
+    }
+
+    static func codexSeries(now: Date = Date(),
+                            window: UsageWindow = .widest,
+                            bucketSeconds: Int = UsageHistoryStore.defaultBucketSeconds,
+                            root: String? = nil) -> UsageSeries {
+        UsageHistoryStore().refreshedSeries(source: .codex, root: root, now: now,
+                                            window: window, bucketSeconds: bucketSeconds)
+    }
+
+    static func parseTimestamp(_ raw: String) -> Date? {
+        UsageHistoryStore.parseTimestamp(raw)
+    }
+}


### PR DESCRIPTION
## What

Adds a usage-history graph to the Usage tab as a second pane of the detail
carousel. `→` steps in to Quota as before, `→` again reaches History; `←` walks
back and then out to the client list, so it's one more press of the key you came
in on. A `Quota · History` indicator makes the second pane discoverable without
having to press `→` to find out it exists.

The graph replays agent transcripts rather than recording snapshots forward, so
it is **fully retroactive** — populated the first time it's opened, with no
accumulation period.

- `↑/↓` cycle the metric (that pane has nothing to scroll)
- `W` cycles the window: 6h / 12h / 24h
- `R` re-reads, as it already did

## Why it isn't the quota curve

The bars on the previous pane come from the provider's own quota accounting,
which is weighted per model and plan and counts usage from other machines. This
graph is token throughput derived from transcripts. The two will not agree, so it
is labelled as tokens and never as quota.

## Metrics

Three token metrics span three orders of magnitude on real data, which is why
they are separate series rather than one stacked chart:

| metric | real 24h | vs output |
|---|---|---|
| output tokens | 3,650,157 | 1x |
| excluding cache reads | 25,878,812 | 7.1x |
| input + cache | 698,506,194 | 191x |

Cache **creation** counts as real work — fresh content the model processed, merely
stored for reuse. Cache **reads** are the replays, and they are what swamps the
axis. A fourth variant (uncached input + output) was built and dropped: it
measured 0.8% above output-only, so it plotted as a visually identical curve.

## Performance

Profiling a real 24h window (~88 MB across 47 warm transcripts) split the cold
pass three ways: directory walk + stat 94 ms, raw I/O + line splitting 208 ms,
JSON + timestamp parse 749 ms — 71% of the total.

Two things follow from that:

- **The scan works on raw bytes.** The obvious implementation (decode each file to
  `String`, split on newlines, `contains`) measured **4.09 s**. Swift's `String` is
  Unicode-correct, making a whole-file decode the dominant cost. `memchr`/`memmem`
  do the newline split and marker prefilter in C, and only surviving lines are
  copied into a `Data` for `JSONSerialization`: **0.99 s**, verified to produce
  identical bucket totals.
- **Parsed entries are cached.** Transcripts are append-only, so a file whose size
  and mtime are unchanged is skipped, and one that grew is parsed only from the
  offset where the last complete line ended. Measured **752 ms cold → 9 ms warm, an
  83.6x speedup**, with 47/47 files skipped and 0 bytes re-read. That is what let
  the freshness gate drop from 60 s to 5 s, so the graph feels live.

The store always retains the widest window, so `W` is a re-bucket of entries
already in memory — **1.17 ms, no I/O**. That is why the window is a scope control
rather than extra carousel panes.

Not persisted to disk: a cold pass is sub-second on a background queue, and a disk
cache would add invalidation and staleness for little gain.

## Rendering

Hand-drawn `Path` area chart rather than Swift Charts. At ~465x140pt the Charts
axis and legend chrome costs more room than the plot, and the rest of the panel is
drawn by hand. Every bucket is plotted including empty ones: over a real 24h only
~22% of five-minute buckets have activity, so filling to a baseline reads as
bursts of work where a line skipping the gaps reads as broken data.

Bucket width stays 5 minutes at every window, so narrowing buys resolution: 288
buckets at 1.6pt each (24h) → 144 at 3.2pt (12h) → 72 at 6.5pt (6h).

## Per-client support

| client | history | why |
|---|---|---|
| Claude | yes | `timestamp` + full `message.usage` per assistant turn |
| Codex | yes | `token_count` events with `last_token_usage` |
| Antigravity | no | `history.jsonl` holds prompt text only, no token data |

Antigravity shows an explicit "no history for this client" state rather than an
empty chart. Codex's `input_tokens` already includes `cached_input_tokens`, so the
cached portion is subtracted rather than added, and reasoning tokens fold into
output.

## Footer

Moving the sync-status label into the foot of the client column was necessary, not
cosmetic. Measured against the 532pt available at the 560pt minimum panel width,
the focused footer had been 519.1pt — 13pt of headroom — and the carousel's own
hint pushed it to 569.9pt, overflowing. With the status in the column it is 475pt.
It also belongs there: it describes the whole tab, not one pane.

## Testing

`UsageHistoryTests` covers bucket alignment and zero-fill, window edges, the mtime
prefilter, identity deduplication, malformed and partial lines, per-agent token
arithmetic, cross-source isolation, and the cache (skip, incremental append,
truncation, pruning, no-I/O re-bucketing).

`swift test` cannot run locally — no `XCTest` without Xcode, which fails the whole
existing suite. The logic was additionally verified by compiling all panel sources
against a throwaway harness driving the real types, including against live
transcripts: 61/61 assertions pass. `swiftc -typecheck` and `./build.sh` are clean
with no new warnings.

## Notes for review

Two bugs were found and fixed during review rather than shipped, both worth a look:

1. **Window race.** The refresh captured the selected window at dispatch time and
   bucketed off-main, so pressing `W` during an in-flight scan had its re-bucket
   reverted by the completion — header claiming one window over another's data.
   Only I/O runs off-main now; bucketing happens in the completion against the
   current window.
2. **Cross-source cache leak.** One store serves every client, and its cache was a
   flat path map while `series()` flattened all of it — so selecting Codex plotted
   Claude's history. The cache is now partitioned by source, and `series(source:)`
   takes the source as a required parameter so it cannot be silently omitted.

A design plan with the full profiling breakdown exists at
`docs/plans/usage-history-graph.md`, left uncommitted to match the existing
untracked plan doc in that directory. Happy to include it if wanted.
