### PR TITLE
fix(voice): speak the welcome shortcut as words

### DIFF
--- a/notify.sh
+++ b/notify.sh
@@ -732,7 +732,15 @@ case "$OS" in
         # Fired once by install.sh so the user sees what a notification
         # looks like and macOS prompts for notification permission while
         # they're still in the install terminal, not mid-work later.
-        notify_macos "stack-nudge" "You're all set. Press ⌘⌥N to open the panel." "$SOUND_STOP" ""
+        #
+        # The banner keeps the ⌘⌥ glyphs; the spoken variant spells them out.
+        # stackvox's --normalize doesn't expand modifier glyphs, so leaving the
+        # voice text to default to the banner text made the engine read the
+        # shortcut as nothing. Passing "" here did NOT opt out of speech — the
+        # ${4:-$message} default treats empty as unset and falls back to the
+        # glyph text, which is exactly what went wrong.
+        notify_macos "stack-nudge" "You're all set. Press ⌘⌥N to open the panel." "$SOUND_STOP" \
+          "You're all set. Press command option N to open the panel."
         ;;
       *)
         voice_msg=$(voice_phrase_for stop)


### PR DESCRIPTION
## Problem

The post-install `welcome` event announces the panel shortcut, and the voice engine
reads the modifier glyphs as nothing — so a new install hears "You're all set.
Press N to open the panel."

`stackvox --normalize` doesn't expand modifier glyphs, and the event-speech path
doesn't pass that flag anyway, so the fix belongs at the source.

## Cause

Slightly worse than "no voice text was set". The call passed `""` as the fourth
argument, which *looks* like opting out of speech:

```sh
notify_macos "stack-nudge" "You're all set. Press ⌘⌥N to open the panel." "$SOUND_STOP" ""
```

But `notify_macos` defaults that parameter with `local voice_message="${4:-$message}"`,
and `:-` treats an **empty string as unset** — so it silently fell back to the
banner text, glyphs included. Verified against the real defaulting logic:

```
BEFORE (4th arg ""):
  banner=[You're all set. Press ⌘⌥N to open the panel.]
  voice =[You're all set. Press ⌘⌥N to open the panel.]

AFTER (worded 4th arg):
  banner=[You're all set. Press ⌘⌥N to open the panel.]
  voice =[You're all set. Press command option N to open the panel.]
```

## Change

Pass a spoken variant that spells the modifiers out. The banner keeps the `⌘⌥N`
glyphs — only the speech changes.

`welcome` was the only call site passing `""`; every other event passes a real
`voice_phrase_for` result, which is why this only affected new installs. It is also
the only user-facing glyph string in `notify.sh`.

The comment records the `${4:-$message}` trap so nobody re-introduces it by passing
an empty string to mean "no speech".

## Testing

`bash -n` and `shellcheck --severity=warning` clean — the two checks CI runs on
shell. The before/after above was produced by exercising the same parameter
defaulting as `notify_macos`, so the fallback behaviour is demonstrated rather than
assumed.

Worth a live check on merge, since it is audio: `~/.stack-nudge/notify.sh stack-nudge welcome`
