### PR TITLE
fix(panel): prune agent infrastructure from the sessions pane and carry renames into notifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,14 @@
 
 .DEFAULT_GOAL := help
 
-APP := $(HOME)/Applications/stack-nudge.app
+# Bundle name must match what build.sh emits and install.sh installs
+# (build/StackNudge.app -> ~/Applications/StackNudge.app). It used to read
+# `stack-nudge.app` here, so `make reload` removed a path that didn't exist
+# and then died on `cp -R build/stack-nudge.app` under `set -e` — and `make
+# dev` swallowed that with `|| true`, so the watch loop silently reloaded
+# nothing for the whole session.
+BUILT_APP := build/StackNudge.app
+APP := $(HOME)/Applications/StackNudge.app
 APP_LABEL := com.stackonehq.stack-nudge
 BUILD_LOG := /tmp/stack-nudge-dev.log
 WATCH_DIRS := panel shared notify.sh phrases
@@ -11,7 +18,7 @@ WATCH_DIRS := panel shared notify.sh phrases
 .PHONY: help
 help:
 	@echo "stack-nudge targets:"
-	@echo "  make build      build stack-nudge.app into build/"
+	@echo "  make build      build StackNudge.app into build/"
 	@echo "  make install    full install (build + copy + register hooks + launchd)"
 	@echo "  make uninstall  remove app, hooks, launchd agents, ~/.stack-nudge/"
 	@echo "  make reload     rebuild + replace installed app + bounce the daemon"
@@ -66,7 +73,7 @@ reload:
 		exit 1; \
 	fi; \
 	rm -rf "$(APP)"; \
-	cp -R build/stack-nudge.app "$(APP)"; \
+	cp -R "$(BUILT_APP)" "$(APP)"; \
 	if [ -d "$$HOME/.stack-nudge" ]; then \
 		cp notify.sh "$$HOME/.stack-nudge/notify.sh"; \
 		if [ -d phrases ]; then \

--- a/Tests/StackNudgePanelCoreTests/ProcessOutputTests.swift
+++ b/Tests/StackNudgePanelCoreTests/ProcessOutputTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// The time-bounded read has one non-obvious requirement: it must drain stdout
+// *while* waiting for the child, not after it. Draining afterwards deadlocks
+// any command whose output outgrows the ~64KB pipe buffer — the child blocks
+// writing, we block waiting, and the timeout fires on a command that was
+// working perfectly. `ps -axo args=` is over 250KB on a busy machine, so this
+// silently emptied the entire Sessions pane.
+final class ProcessOutputTests: XCTestCase {
+
+    // Comfortably past the pipe buffer: ~589KB.
+    private let bigOutputLineCount = 100_000
+
+    func test_read_withTimeout_returnsOutputLargerThanThePipeBuffer() {
+        let actual = ProcessOutput.read("/usr/bin/seq", ["1", "\(bigOutputLineCount)"], timeout: 10)
+        XCTAssertNotNil(actual, "large output must not read as a timeout")
+        XCTAssertGreaterThan(actual?.utf8.count ?? 0, 64 * 1024,
+                             "test is only meaningful above the pipe buffer")
+        XCTAssertEqual(actual?.split(separator: "\n").count, bigOutputLineCount,
+                       "output must be complete, not truncated at the buffer")
+    }
+
+    func test_read_untimed_returnsOutputLargerThanThePipeBuffer() {
+        let actual = ProcessOutput.read("/usr/bin/seq", ["1", "\(bigOutputLineCount)"])
+        XCTAssertEqual(actual.split(separator: "\n").count, bigOutputLineCount)
+    }
+
+    // The timeout still has to fire for something that genuinely never returns
+    // — that's what keeps a hung lsof from freezing the session poll.
+    func test_read_withTimeout_returnsNilWhenTheChildOutlivesTheDeadline() {
+        let actual = ProcessOutput.read("/bin/sleep", ["5"], timeout: 0.5)
+        XCTAssertNil(actual)
+    }
+
+    func test_read_withTimeout_returnsNilOnSpawnFailure() {
+        let actual = ProcessOutput.read("/nonexistent/binary", [], timeout: 1)
+        XCTAssertNil(actual, "nil distinguishes 'never ran' from 'ran, printed nothing'")
+    }
+
+    func test_read_withTimeout_distinguishesEmptyOutputFromFailure() {
+        let actual = ProcessOutput.read("/usr/bin/true", [], timeout: 5)
+        XCTAssertEqual(actual, "", "a successful run with no output is an empty string, not nil")
+    }
+}

--- a/Tests/StackNudgePanelCoreTests/SessionLabelTests.swift
+++ b/Tests/StackNudgePanelCoreTests/SessionLabelTests.swift
@@ -1,0 +1,197 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// One cascade, used by the Sessions row, the nudge row, the banner title and
+// the spoken phrase. Before this existed each of those resolved names
+// differently: the nudge row never saw a name set inside the agent, and the
+// banner only ever matched Claude sessions, so a renamed Codex session was
+// announced by its folder name.
+final class SessionLabelTests: XCTestCase {
+
+    private func session(pid: Int = 1,
+                         agent: String = "claude",
+                         projectPath: String? = "/Users/x/stackone",
+                         projectName: String? = "stackone",
+                         customName: String? = nil,
+                         liveTitle: String? = nil,
+                         liveTitleSource: String? = nil,
+                         tabId: String? = nil) -> Session {
+        Session(
+            id: pid, pid: pid, agent: agent,
+            projectPath: projectPath, projectName: projectName,
+            terminalPID: 2, terminalApp: "iTerm2", elapsed: nil,
+            customName: customName, status: .active,
+            tabId: tabId, tabName: nil,
+            liveTitle: liveTitle, liveTitleSource: liveTitleSource
+        )
+    }
+
+    private func event(agent: String = "claude-code",
+                       projectPath: String? = "/Users/x/stackone",
+                       agentPID: Int? = 1,
+                       sessionID: String? = nil,
+                       claudeSessionID: String? = nil) -> NudgeEvent {
+        NudgeEvent(
+            agent: agent, kind: .stop, title: "Claude Code", message: "Done",
+            projectPath: projectPath,
+            agentPID: agentPID, sessionID: sessionID,
+            claudeSessionID: claudeSessionID
+        )
+    }
+
+    // MARK: - Sessions
+
+    func test_chosenName_paneRenameWins() {
+        let actual = SessionLabel.chosenName(for: session(customName: "logs traceability",
+                                                          liveTitle: "renamed in agent",
+                                                          liveTitleSource: "user"))
+        XCTAssertEqual(actual, "logs traceability")
+    }
+
+    func test_chosenName_agentRenameIsUsed() {
+        let actual = SessionLabel.chosenName(for: session(liveTitle: "ENG-1185 logs",
+                                                          liveTitleSource: "user"))
+        XCTAssertEqual(actual, "ENG-1185 logs")
+    }
+
+    // Claude Code 2.1+ hands every session a derived name like "stackone-89".
+    // Treating those as user intent made every banner read
+    // "Claude Code — stackone-89", which is exactly what a rename that didn't
+    // come through looks like.
+    func test_chosenName_derivedAgentNameIsIgnored() {
+        let actual = SessionLabel.chosenName(for: session(liveTitle: "stackone-89",
+                                                          liveTitleSource: "derived"))
+        XCTAssertNil(actual)
+    }
+
+    // Older Claude Code reports no source at all; keep trusting the name there
+    // so this doesn't silently regress those installs.
+    func test_chosenName_noSourceReportedIsTrusted() {
+        let actual = SessionLabel.chosenName(for: session(liveTitle: "my session",
+                                                          liveTitleSource: nil))
+        XCTAssertEqual(actual, "my session")
+    }
+
+    func test_chosenName_legacyPlaceholderIsIgnored() {
+        let actual = SessionLabel.chosenName(for: session(liveTitle: "main-agent",
+                                                          liveTitleSource: nil))
+        XCTAssertNil(actual)
+    }
+
+    func test_chosenName_blankNamesAreIgnored() {
+        XCTAssertNil(SessionLabel.chosenName(for: session(customName: "   ", liveTitle: "  ")))
+    }
+
+    func test_displayName_fallsBackToProjectThenFallback() {
+        XCTAssertEqual(SessionLabel.displayName(for: session(), fallback: "a session"),
+                       "stackone")
+        XCTAssertEqual(
+            SessionLabel.displayName(for: session(projectPath: nil, projectName: nil),
+                                     fallback: "a session"),
+            "a session"
+        )
+    }
+
+    // MARK: - Events
+
+    func test_chosenName_forEvent_matchesByAgentPID() {
+        let persistence = SessionPersistence(path: Self.scratchFile())
+        let actual = SessionLabel.chosenName(
+            for: event(agentPID: 42),
+            in: [session(pid: 42, customName: "the renamed one")],
+            persistence: persistence
+        )
+        XCTAssertEqual(actual, "the renamed one")
+    }
+
+    // A Codex/Gemini/Antigravity event carries no Claude session UUID. The old
+    // banner join keyed on that field alone, so those agents could never pick
+    // up a rename.
+    func test_chosenName_forEvent_worksForNonClaudeAgents() {
+        let persistence = SessionPersistence(path: Self.scratchFile())
+        let actual = SessionLabel.chosenName(
+            for: event(agent: "codex", agentPID: 7, claudeSessionID: nil),
+            in: [session(pid: 7, agent: "codex", customName: "sandbox spike")],
+            persistence: persistence
+        )
+        XCTAssertEqual(actual, "sandbox spike")
+    }
+
+    // Once the process is gone the process list can't answer, so the on-disk
+    // store is the only source left.
+    func test_chosenName_forEvent_fallsBackToPersistence() {
+        let persistence = SessionPersistence(path: Self.scratchFile())
+        persistence.setCustomName(agent: "claude", projectPath: "/Users/x/stackone", "from disk")
+
+        let actual = SessionLabel.chosenName(for: event(agentPID: 999),
+                                             in: [],
+                                             persistence: persistence)
+        XCTAssertEqual(actual, "from disk")
+    }
+
+    func test_chosenName_forEvent_nilWhenNobodyNamedIt() {
+        let persistence = SessionPersistence(path: Self.scratchFile())
+        let actual = SessionLabel.chosenName(for: event(agentPID: 1),
+                                             in: [session(pid: 1)],
+                                             persistence: persistence)
+        XCTAssertNil(actual, "a project folder is not a name anyone chose")
+    }
+
+    func test_displayName_forEvent_fallsBackToProjectFolder() {
+        let persistence = SessionPersistence(path: Self.scratchFile())
+        let actual = SessionLabel.displayName(for: event(agentPID: 1),
+                                               in: [session(pid: 1)],
+                                               persistence: persistence)
+        XCTAssertEqual(actual, "stackone")
+    }
+
+    func test_tabIdentifier_prefersTerminalSessionIDOverIPCHook() {
+        let withBoth = NudgeEvent(agent: "claude-code", kind: .stop, title: "t", message: "m",
+                                  ipcHook: "/sock/window.sock", sessionID: "ABC-123")
+        XCTAssertEqual(SessionLabel.tabIdentifier(for: withBoth), "ABC-123")
+
+        let hookOnly = NudgeEvent(agent: "claude-code", kind: .stop, title: "t", message: "m",
+                                  ipcHook: "/sock/window.sock", sessionID: "")
+        XCTAssertEqual(SessionLabel.tabIdentifier(for: hookOnly), "/sock/window.sock")
+
+        let neither = NudgeEvent(agent: "claude-code", kind: .stop, title: "t", message: "m")
+        XCTAssertNil(SessionLabel.tabIdentifier(for: neither))
+    }
+
+    private static func scratchFile() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("session-label-tests-\(UUID().uuidString).json")
+    }
+}
+
+// The hook picks the phrase but can't resolve session names, so it now sends
+// the template unsubstituted and the app fills in the label.
+final class VoicePhraseTests: XCTestCase {
+
+    func test_spoken_substitutesTheLabel() {
+        XCTAssertEqual(VoicePhrase.spoken(template: "%s is ready for you", label: "auth"),
+                       "auth is ready for you")
+    }
+
+    func test_spoken_expandsSlugsIntoWords() {
+        XCTAssertEqual(VoicePhrase.spoken(template: "task complete in %s", label: "stackone-cli"),
+                       "task complete in stack one C L I")
+    }
+
+    // No label to say, no template (older installed hook), or a phrase with no
+    // placeholder: the caller falls back to what the hook already substituted.
+    func test_spoken_nilWhenNothingToSubstitute() {
+        XCTAssertNil(VoicePhrase.spoken(template: "%s is ready", label: nil))
+        XCTAssertNil(VoicePhrase.spoken(template: "%s is ready", label: ""))
+        XCTAssertNil(VoicePhrase.spoken(template: nil, label: "auth"))
+        XCTAssertNil(VoicePhrase.spoken(template: "all done", label: "auth"))
+    }
+
+    // Substitution is a literal replace, not printf: a user-supplied phrase
+    // from phrases.user.json with a stray % must not corrupt the output.
+    func test_spoken_leavesOtherPercentTokensAlone() {
+        XCTAssertEqual(VoicePhrase.spoken(template: "%s is 100%% done", label: "auth"),
+                       "auth is 100%% done")
+    }
+}

--- a/Tests/StackNudgePanelCoreTests/SessionStoreTests.swift
+++ b/Tests/StackNudgePanelCoreTests/SessionStoreTests.swift
@@ -1,0 +1,220 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// Agent detection runs on `ps` args, and Claude Code 2.1 turned that into a
+// minefield: the daemon, the background pty hosts and the spare process are
+// all executables called `claude`. Every one of them was landing in the
+// Sessions pane as a row, and because none of them exits when a session does,
+// the finished-session prune could never reach them. The daemon in particular
+// is parented to launchd and lives for weeks.
+//
+// Arg strings here are copied verbatim from `ps -axo args=` on a machine
+// running Claude Code 2.1.220, so they pin the real shapes rather than a
+// guess at them.
+final class DetectAgentTests: XCTestCase {
+
+    func test_detectAgent_interactiveClaude() {
+        XCTAssertEqual(SessionStore.detectAgent(args: "claude"), "claude")
+    }
+
+    func test_detectAgent_resumedSession_isNotMistakenForASubcommand() {
+        // The resumed-session UUID is a positional argument, so the
+        // subcommand scan has to stop at the flag it belongs to.
+        XCTAssertEqual(
+            SessionStore.detectAgent(args: "claude --resume a80e8b9d-0868-4541-92de-3e5eae6b4e4b"),
+            "claude"
+        )
+        XCTAssertEqual(
+            SessionStore.detectAgent(args: "claude --resume=86ae070c-bdaf-49fa-a68e-8f8474146aa5 --fork-session"),
+            "claude"
+        )
+    }
+
+    func test_detectAgent_absolutePathClaude() {
+        XCTAssertEqual(SessionStore.detectAgent(args: "/opt/homebrew/bin/claude --permission-mode auto"),
+                       "claude")
+    }
+
+    func test_detectAgent_daemon_isNotASession() {
+        let args = "/Users/x/.local/bin/claude daemon run --json-path /Users/x/.claude/daemon.json"
+            + " --log-file /Users/x/.claude/daemon.log --origin transient"
+        XCTAssertNil(SessionStore.detectAgent(args: args))
+    }
+
+    func test_detectAgent_backgroundPtyHost_isNotASession() {
+        let args = "claude bg-pty-host --bg-pty-host /tmp/cc-daemon-502/d6d4ed8d/spare/9ea21c85.pty.sock"
+            + " 200 50 -- /Users/x/.local/share/claude/versions/2.1.220"
+        XCTAssertNil(SessionStore.detectAgent(args: args))
+    }
+
+    func test_detectAgent_backgroundSpare_isNotASession() {
+        let args = "claude bg-spare --bg-spare /tmp/cc-daemon-502/d6d4ed8d/spare/9ea21c85.claim.sock"
+        XCTAssertNil(SessionStore.detectAgent(args: args))
+    }
+
+    // The app-bundle helper leads with a flag rather than a subcommand, and it
+    // inherits the project cwd — which is what made it the worst of the four.
+    // It read as a genuine session in that project, one that had usually
+    // already ended.
+    func test_detectAgent_appBundlePtyHost_isNotASession() {
+        let args = "/Users/x/.local/share/claude/ClaudeCode.app/Contents/MacOS/claude"
+            + " --bg-pty-host /tmp/cc-daemon-502/d6d4ed8d/pty/a4085187.sock 118 77"
+            + " -- /Users/x/.local/share/claude/versions/2.1.220 --session-id a4085187"
+        XCTAssertNil(SessionStore.detectAgent(args: args))
+    }
+
+    func test_detectAgent_nodeHostedAgents() {
+        XCTAssertEqual(SessionStore.detectAgent(args: "node /opt/homebrew/lib/node_modules/gemini-cli/index.js"),
+                       "gemini")
+        XCTAssertEqual(SessionStore.detectAgent(args: "node /Users/x/.npm/codex/bin/codex.js"),
+                       "codex")
+        XCTAssertEqual(SessionStore.detectAgent(args: "codex"), "codex")
+        XCTAssertEqual(SessionStore.detectAgent(args: "agy"), "agy")
+    }
+
+    // Similarly-named neighbours that share a prefix with an agent binary.
+    func test_detectAgent_nonAgentProcesses() {
+        XCTAssertNil(SessionStore.detectAgent(args: "/Users/x/.local/bin/codex-code-mode-host"))
+        XCTAssertNil(SessionStore.detectAgent(args: "/bin/zsh -c source /Users/x/.claude/shell-snapshots/s.sh"))
+        XCTAssertNil(SessionStore.detectAgent(args: "/Users/x/.local/share/claude/versions/2.1.220 --session-id a4085187"))
+        XCTAssertNil(SessionStore.detectAgent(args: ""))
+    }
+}
+
+// The visible-state ladder: a session that's running stays, one that just
+// exited lingers briefly so the user sees it end, and one that ended a while
+// ago goes away.
+final class SessionReconcileTests: XCTestCase {
+
+    private let now = Date(timeIntervalSince1970: 1_785_688_512)
+
+    private func session(pid: Int,
+                         status: SessionStatus = .active,
+                         customName: String? = nil,
+                         liveStatus: String? = nil,
+                         lastActivityAt: Date? = nil) -> Session {
+        Session(
+            id: pid, pid: pid, agent: "claude",
+            projectPath: "/Users/x/proj", projectName: "proj",
+            terminalPID: 1, terminalApp: "iTerm2", elapsed: "01:00",
+            customName: customName, status: status,
+            tabId: nil, tabName: nil,
+            liveStatus: liveStatus, lastActivityAt: lastActivityAt
+        )
+    }
+
+    func test_reconcile_stillRunningStaysActive() {
+        let actual = SessionStore.reconcile(previous: [session(pid: 1)],
+                                            found: [session(pid: 1)],
+                                            now: now)
+        XCTAssertEqual(actual.count, 1)
+        XCTAssertEqual(actual.first?.status, .active)
+    }
+
+    func test_reconcile_disappearedIsMarkedFinished() {
+        let actual = SessionStore.reconcile(previous: [session(pid: 1)],
+                                            found: [],
+                                            now: now)
+        XCTAssertEqual(actual.first?.status, .finished(at: now))
+    }
+
+    func test_reconcile_recentlyFinishedIsKept() {
+        let justEnded = session(pid: 1, status: .finished(at: now.addingTimeInterval(-5)))
+        let actual = SessionStore.reconcile(previous: [justEnded], found: [], now: now)
+        XCTAssertEqual(actual.count, 1, "a session that ended 5s ago should still be on screen")
+    }
+
+    func test_reconcile_longFinishedIsPruned() {
+        let stale = session(pid: 1, status: .finished(at: now.addingTimeInterval(-31)))
+        let actual = SessionStore.reconcile(previous: [stale], found: [], now: now)
+        XCTAssertTrue(actual.isEmpty, "a session that ended over 30s ago should be pruned")
+    }
+
+    func test_reconcile_finishedSessionIsNotResurrected() {
+        // Two polls with nothing running: mark finished, then drop.
+        let first = SessionStore.reconcile(previous: [session(pid: 1)], found: [], now: now)
+        let second = SessionStore.reconcile(previous: first, found: [],
+                                            now: now.addingTimeInterval(31))
+        XCTAssertTrue(second.isEmpty)
+    }
+
+    func test_reconcile_inMemoryNameSurvivesAPoll() {
+        let renamed = session(pid: 1, customName: "logs traceability")
+        let actual = SessionStore.reconcile(previous: [renamed],
+                                            found: [session(pid: 1)],
+                                            now: now)
+        XCTAssertEqual(actual.first?.customName, "logs traceability")
+    }
+
+    func test_reconcile_seededNameAppliesWhenNoneInMemory() {
+        let actual = SessionStore.reconcile(previous: [session(pid: 1)],
+                                            found: [session(pid: 1, customName: "from disk")],
+                                            now: now)
+        XCTAssertEqual(actual.first?.customName, "from disk")
+    }
+
+    func test_reconcile_newSessionsAreAdded() {
+        let actual = SessionStore.reconcile(previous: [session(pid: 1)],
+                                            found: [session(pid: 1), session(pid: 2)],
+                                            now: now)
+        XCTAssertEqual(Set(actual.map(\.pid)), [1, 2])
+    }
+
+    // Live above dormant above finished. A tab left open for a week is still a
+    // session, but it shouldn't sit above the one that's working right now.
+    func test_reconcile_sortsLiveThenDormantThenFinished() {
+        let dormant = session(pid: 1, lastActivityAt: now.addingTimeInterval(-8 * 24 * 3600))
+        let finished = session(pid: 2, status: .finished(at: now.addingTimeInterval(-5)))
+        let live = session(pid: 3, lastActivityAt: now.addingTimeInterval(-10))
+
+        let actual = SessionStore.reconcile(previous: [dormant, finished, live],
+                                            found: [dormant, live],
+                                            now: now)
+        XCTAssertEqual(actual.map(\.pid), [3, 1, 2])
+    }
+
+    func test_reconcile_busySortsAboveIdleWithinLiveTier() {
+        let idle = session(pid: 1, liveStatus: "idle", lastActivityAt: now)
+        let busy = session(pid: 2, liveStatus: "busy", lastActivityAt: now.addingTimeInterval(-60))
+        let actual = SessionStore.reconcile(previous: [idle, busy], found: [idle, busy], now: now)
+        XCTAssertEqual(actual.map(\.pid), [2, 1])
+    }
+}
+
+final class SessionDormancyTests: XCTestCase {
+
+    private let now = Date(timeIntervalSince1970: 1_785_688_512)
+
+    private func session(status: SessionStatus, lastActivityAt: Date?) -> Session {
+        Session(
+            id: 1, pid: 1, agent: "claude", projectPath: "/x", projectName: "x",
+            terminalPID: 2, terminalApp: "iTerm2", elapsed: nil,
+            customName: nil, status: status, tabId: nil, tabName: nil,
+            lastActivityAt: lastActivityAt
+        )
+    }
+
+    func test_isDormant_afterADayOfNoActivity() {
+        let actual = session(status: .active, lastActivityAt: now.addingTimeInterval(-25 * 3600))
+        XCTAssertTrue(actual.isDormant(asOf: now))
+    }
+
+    func test_isDormant_recentActivity() {
+        let actual = session(status: .active, lastActivityAt: now.addingTimeInterval(-60))
+        XCTAssertFalse(actual.isDormant(asOf: now))
+    }
+
+    // No activity signal at all (any agent without a sidecar) means we can't
+    // tell dormant from busy, so we don't claim either.
+    func test_isDormant_noActivitySignal() {
+        let actual = session(status: .active, lastActivityAt: nil)
+        XCTAssertFalse(actual.isDormant(asOf: now))
+    }
+
+    func test_isDormant_finishedSessionIsNotDormant() {
+        let actual = session(status: .finished(at: now),
+                             lastActivityAt: now.addingTimeInterval(-8 * 24 * 3600))
+        XCTAssertFalse(actual.isDormant(asOf: now), "finished is already its own state")
+    }
+}

--- a/notify.sh
+++ b/notify.sh
@@ -175,9 +175,20 @@ repo_name_expanded() {
 # TEMPLATES_NOTIFICATION for permission events) and format it with the
 # repo name. Phrase files live next to notify.sh in phrases/<lang>.sh
 # so they're co-located with the script wherever it's installed.
+#
+# Results come back in two globals rather than on stdout: the app needs the
+# chosen template with its %s intact so it can substitute the session's name
+# (which lives in the app's own store, invisible from here), and it has to be
+# the *same* pick as the substituted phrase, which a second function couldn't
+# guarantee because the pool is sampled at random. VOICE_PHRASE stays the
+# fallback for un-renamed sessions and for an app older than this field.
+VOICE_PHRASE=""
+VOICE_TEMPLATE=""
 voice_phrase_for() {
   local event="$1"
   local lang repo
+  VOICE_PHRASE=""
+  VOICE_TEMPLATE=""
 
   if [[ -x "$STACKVOX" ]]; then
     lang=$(voice_to_lang "$VOICE_NAME")
@@ -193,7 +204,7 @@ voice_phrase_for() {
   local lang_file="$phrases_dir/$lang.sh"
   [[ -f "$lang_file" ]] || lang_file="$phrases_dir/en.sh"
   if [[ ! -f "$lang_file" ]]; then
-    echo "$repo"
+    VOICE_PHRASE="$repo"
     return
   fi
 
@@ -275,16 +286,17 @@ voice_phrase_for() {
   esac
 
   if [[ ${#templates[@]} -eq 0 ]]; then
-    echo "$repo"
+    VOICE_PHRASE="$repo"
     return
   fi
 
   local template="${templates[$((RANDOM % ${#templates[@]}))]}"
+  VOICE_TEMPLATE="$template"
   # Substitute the repo name into the %s placeholder ourselves rather than
   # letting the phrase be a printf format string — a phrase (especially a
   # user-supplied one from phrases.user.json) with stray % tokens would
   # otherwise corrupt or truncate the spoken output.
-  printf '%s' "${template//%s/$repo}"
+  VOICE_PHRASE="${template//%s/$repo}"
 }
 
 PANEL_SOCK="${HOME}/.stack-nudge/panel.sock"
@@ -446,6 +458,9 @@ walk_session_chain() {
 # we have ~15 fields.
 # Args: title message bundle_id window_title has_action(true|false)
 #       fifo_path voice_message sound_name bypass_mute(true|false)
+# The matching voice template rides along from the VOICE_TEMPLATE global that
+# voice_phrase_for sets, alongside the other globals read here ($AGENT, $PWD,
+# the session chain) rather than being threaded through as a tenth positional.
 post_to_panel() {
   ensure_app_running
   [[ ! -S "$PANEL_SOCK" ]] && return
@@ -472,6 +487,7 @@ post_to_panel() {
   NUDGE_HAS_ACTION="$5" \
   NUDGE_FIFO="${6:-}" \
   NUDGE_VOICE_MESSAGE="${7:-}" \
+  NUDGE_VOICE_TEMPLATE="${VOICE_TEMPLATE:-}" \
   NUDGE_SOUND="${8:-}" \
   NUDGE_BYPASS_MUTE="${9:-false}" \
   NUDGE_SOCK="$PANEL_SOCK" \
@@ -535,6 +551,7 @@ optional = {
     "claude_session_id": hook_field("session_id"),
     "transcript_path":   hook_field("transcript_path"),
     "voice_message": env.get("NUDGE_VOICE_MESSAGE"),
+    "voice_template": env.get("NUDGE_VOICE_TEMPLATE"),
     "sound_name":    env.get("NUDGE_SOUND"),
 }
 for key, value in optional.items():
@@ -761,8 +778,10 @@ case "$OS" in
         # pool, formatted with the repo name — same shape as
         # stackone-say-hooks.
         ctx=$(permission_context)
-        voice_msg=$(voice_phrase_for permission)
-        notify_macos "$TITLE" "${ctx:-Waiting for your approval}" "$SOUND_PERMISSION" "$voice_msg"
+        # Called plainly, not in a command substitution: the results come back
+        # in globals and a subshell would drop VOICE_TEMPLATE.
+        voice_phrase_for permission
+        notify_macos "$TITLE" "${ctx:-Waiting for your approval}" "$SOUND_PERMISSION" "$VOICE_PHRASE"
         ;;
       welcome)
         # Fired once by install.sh so the user sees what a notification
@@ -779,8 +798,8 @@ case "$OS" in
           "You're all set. Press command option N to open the panel."
         ;;
       *)
-        voice_msg=$(voice_phrase_for stop)
-        notify_macos "$TITLE" "Done" "$SOUND_STOP" "$voice_msg"
+        voice_phrase_for stop
+        notify_macos "$TITLE" "Done" "$SOUND_STOP" "$VOICE_PHRASE"
         ;;
     esac
     ;;

--- a/panel/CompactView.swift
+++ b/panel/CompactView.swift
@@ -313,7 +313,7 @@ struct CompactView: View {
 
     @ViewBuilder
     private var sessionBadge: some View {
-        let activeCount = sessions.sessions.filter { $0.status == .active }.count
+        let activeCount = sessions.liveSessions.count
         if activeCount > 0 {
             HStack(spacing: 3) {
                 Circle()
@@ -432,19 +432,19 @@ struct CompactView: View {
     }
 
     private var busiestSession: Session? {
-        sessions.sessions.first { $0.status == .active && $0.liveStatus == "busy" }
+        sessions.liveSessions.first { $0.liveStatus == "busy" }
     }
 
     private var mostRecentActive: Session? {
-        sessions.sessions.first { $0.status == .active }
+        sessions.liveSessions.first
     }
 
     // Stable, PID-sorted list of every currently-active session. Drives
-    // the pill's rotation when ≥2 are alive at the same time.
+    // the pill's rotation when ≥2 are alive at the same time. Dormant
+    // sessions are excluded — rotating through a week-old idle tab tells
+    // the user nothing and pushes the sessions they care about off-screen.
     private var activeSessions: [Session] {
-        sessions.sessions
-            .filter { $0.status == .active }
-            .sorted { $0.pid < $1.pid }
+        sessions.liveSessions.sorted { $0.pid < $1.pid }
     }
 
     // Rotate sessions only when nothing more important is on screen and
@@ -469,9 +469,7 @@ struct CompactView: View {
     }
 
     private func displayName(_ s: Session) -> String {
-        if let custom = s.customName, !custom.isEmpty { return custom }
-        if let name = s.liveTitle, !name.isEmpty, name != "main-agent" { return name }
-        return s.projectName ?? "session"
+        SessionLabel.displayName(for: s, fallback: "session")
     }
 
     private func glyph(for e: NudgeEvent) -> String {

--- a/panel/EventListener.swift
+++ b/panel/EventListener.swift
@@ -168,6 +168,7 @@ private struct NudgeEventDTO: Decodable {
     let iterm_tab_name: String?
     let fifo_path: String?
     let voice_message: String?
+    let voice_template: String?
     let sound_name: String?
     let bypass_mute: Bool?
     // Claude Code's session UUID (distinct from session_id, which is the
@@ -213,6 +214,7 @@ private struct NudgeEventDTO: Decodable {
             itermTabName: iterm_tab_name,
             fifoPath: Self.validatedFifoPath(fifo_path),
             voiceMessage: voice_message,
+            voiceTemplate: voice_template,
             soundName: sound_name,
             bypassMute: bypass_mute ?? false,
             claudeSessionID: claude_session_id,

--- a/panel/EventStore.swift
+++ b/panel/EventStore.swift
@@ -50,6 +50,11 @@ struct NudgeEvent: Identifiable, Equatable {
     // `message` — the banner shows the tool / file context, the voice
     // speaks a conversational sentence).
     let voiceMessage: String?
+    // Same phrase with its `%s` placeholder still in place, so the app can
+    // substitute the session's name (which only the app knows) instead of the
+    // cwd basename the hook substituted into voiceMessage. nil from an older
+    // installed notify.sh, in which case voiceMessage is all we have.
+    let voiceTemplate: String?
     // Name of a /System/Library/Sounds/*.aiff chime to play. Picked by
     // notify.sh based on event kind (Glass for stop, Ping for permission)
     // and overridable via STACKNUDGE_SOUND_STOP / STACKNUDGE_SOUND_PERMISSION.
@@ -75,6 +80,7 @@ struct NudgeEvent: Identifiable, Equatable {
          itermTabName: String? = nil,
          fifoPath: String? = nil,
          voiceMessage: String? = nil,
+         voiceTemplate: String? = nil,
          soundName: String? = nil,
          bypassMute: Bool = false,
          claudeSessionID: String? = nil,
@@ -101,6 +107,7 @@ struct NudgeEvent: Identifiable, Equatable {
         self.itermTabName = itermTabName
         self.fifoPath = fifoPath
         self.voiceMessage = voiceMessage
+        self.voiceTemplate = voiceTemplate
         self.soundName = soundName
         self.bypassMute = bypassMute
         self.claudeSessionID = claudeSessionID
@@ -122,6 +129,7 @@ struct NudgeEvent: Identifiable, Equatable {
             itermTabName: itermTabName,
             fifoPath: fifoPath,
             voiceMessage: voiceMessage,
+            voiceTemplate: voiceTemplate,
             soundName: soundName,
             bypassMute: bypassMute,
             claudeSessionID: claudeSessionID,

--- a/panel/ITerm2Integration.swift
+++ b/panel/ITerm2Integration.swift
@@ -122,6 +122,14 @@ final class ITerm2Integration: TerminalIntegration {
         // Pipe-delimited output is cheaper to parse than JSON from
         // AppleScript and avoids quoting headaches. Pane TTYs never
         // contain "|", so the delimiter is unambiguous.
+        //
+        // `autoName` in preference to the `name` property: `name` is the
+        // composed session title, which appends the running job, so every
+        // agent tab read as "✳ Some task (claude)". autoName is the label
+        // without that suffix. It is *not* a signal of user intent — a manual
+        // rename, an OSC title escape and the profile name all write the same
+        // variable — which is why this feeds the pane's meta row only and not
+        // the session label used in notifications. See SessionLabel.
         let script = """
         tell application "iTerm2"
             if not running then return ""
@@ -133,6 +141,9 @@ final class ITerm2Integration: TerminalIntegration {
                             set ttyPath to tty of s
                             set sessionId to unique id of s
                             set sessionName to name of s
+                            try
+                                tell s to set sessionName to (get variable named "autoName")
+                            end try
                             set output to output & ttyPath & "|" & sessionId & "|" & sessionName & linefeed
                         end try
                     end repeat

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -79,6 +79,13 @@ struct PanelContentView: View {
     @ObservedObject var nav: PanelNav
     @ObservedObject var phrases: PhrasesViewModel
 
+    // The disk-backed name store. Observed here (rather than inside EventRow)
+    // so resolving a nudge's session label stays a render-time lookup that
+    // reacts to a rename, while each row's inputs stay down to the resolved
+    // string — handing every row the whole session array would rebuild all of
+    // them on every 3s poll.
+    @EnvironmentObject private var persistence: SessionPersistence
+
     let onGrantPermissions: () -> Void
 
     var body: some View {
@@ -166,7 +173,7 @@ struct PanelContentView: View {
                 .padding(.trailing, 4)
 
             tab(.events,   label: "Events",   count: store.events.count)
-            tab(.sessions, label: "Sessions", count: sessions.sessions.filter { $0.status == .active }.count)
+            tab(.sessions, label: "Sessions", count: sessions.liveSessions.count)
             tab(.usage,    label: "Usage",    count: 0)
             tab(.outcomes, label: "Tickets",  count: ticketGroupCount)
             tab(.settings, label: "Settings", count: 0,
@@ -299,7 +306,12 @@ struct PanelContentView: View {
                 LazyVStack(spacing: 2) {
                     ForEach(store.events) { event in
                         EventRow(event: event,
-                                 selected: store.selectedID == event.id)
+                                 selected: store.selectedID == event.id,
+                                 sessionLabel: SessionLabel.displayName(
+                                     for: event,
+                                     in: sessions.sessions,
+                                     persistence: persistence
+                                 ))
                             .id(event.id)
                             .contentShape(Rectangle())
                             .onTapGesture { store.selectedID = event.id }
@@ -381,11 +393,10 @@ struct EventRow: View {
 
     let event: NudgeEvent
     let selected: Bool
-
-    // The disk-backed name store. Observed so a rename in the Sessions
-    // tab immediately re-renders any visible event for the same
-    // (agent, projectPath) — render-time lookup, not ingest-time snapshot.
-    @EnvironmentObject private var persistence: SessionPersistence
+    // Resolved by the parent (see PanelContentView.persistence) so a rename
+    // still re-renders the row without every row observing the whole session
+    // list. nil when we know neither a name nor a project for this event.
+    let sessionLabel: String?
 
 
     var body: some View {
@@ -475,31 +486,8 @@ struct EventRow: View {
         return until > Date()
     }
 
-    // Show the user-chosen session name when one is set, otherwise the
-    // project folder's basename. Lookup is keyed by (agent, projectPath,
-    // tabId) — iTerm contributes its session id, VSCode/Cursor
-    // contribute the IPC hook path. Falls back to (agent, projectPath)
-    // transparently for events without a tab-scoped id and for
-    // pre-Stage-2 persistence entries.
-    private var sessionLabel: String? {
-        if let custom = persistence.customName(
-            agent: event.agent,
-            projectPath: event.projectPath,
-            tabId: tabIdentifier
-        ) {
-            return custom
-        }
-        guard let project = event.projectPath else { return nil }
-        return (project as NSString).lastPathComponent
-    }
-
-    // First non-empty of [iTerm session id, VSCode IPC hook]. Each
-    // terminal contributes whatever it has; the lookup layer doesn't
-    // care which one fired as long as it's stable per tab/window.
     private var tabIdentifier: String? {
-        if let sid = event.sessionID, !sid.isEmpty { return sid }
-        if let hook = event.ipcHook, !hook.isEmpty { return hook }
-        return nil
+        SessionLabel.tabIdentifier(for: event)
     }
 
     // iTerm2 tab/session label shown next to the session chip, but only
@@ -1965,12 +1953,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     private func labelForClaudeSession(id: String) -> String {
         guard let session = sessions.sessions.first(where: { $0.claudeSessionID == id })
         else { return "a session" }
-        if let custom = session.customName, !custom.isEmpty { return custom }
-        if let name = session.liveTitle,
-           !name.isEmpty, name != "main-agent" {
-            return name
-        }
-        return session.projectName ?? "a session"
+        return SessionLabel.displayName(for: session, fallback: "a session")
     }
 
     private func postContextBanner(tokens: Int, model: String?, sessionLabel: String) {
@@ -2034,12 +2017,24 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         if config.soundEnabled, !config.voiceEnabled, let sound = event.soundName {
             Speaker.playSound(named: sound)
         }
-        if config.voiceEnabled, let phrase = event.voiceMessage, !phrase.isEmpty {
+        if config.voiceEnabled, let phrase = voicePhrase(for: event), !phrase.isEmpty {
             Speaker.speak(phrase, voice: config.voiceName, speed: config.voiceSpeed)
         }
 
         guard config.bannerEnabled else { return }
         postBanner(for: event)
+    }
+
+    // Speech says the session's name when it has one. The hook picks the
+    // phrase but can't resolve names (they live in the app), so it sends the
+    // template with its %s intact alongside the cwd-substituted string; we
+    // fill in the resolved label and fall back to the hook's own version
+    // when there's no name to say, or when an older installed notify.sh
+    // didn't send a template at all.
+    private func voicePhrase(for event: NudgeEvent) -> String? {
+        VoicePhrase.spoken(template: event.voiceTemplate,
+                           label: sessionLabel(for: event))
+            ?? event.voiceMessage
     }
 
     // Returns true if the event's source editor window appears to be the
@@ -2109,24 +2104,23 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     // identifier is a fresh UUID each time (macOS replaces by identifier);
     // event.id stays in userInfo so click handlers can find the source.
     // Banner title with session label appended when we can resolve one.
-    // Default project name is suppressed (already implied by the title);
-    // only meaningful custom/claudeName labels are shown.
+    // Default project name is suppressed (already implied by the title); only
+    // a name someone actually chose is shown.
+    //
+    // This used to join event to session on Claude's session UUID alone, so a
+    // rename never reached the banner for any other agent, and it accepted
+    // Claude Code's auto-derived name — which 2.1+ gives every session, so
+    // every banner read "Claude Code — stackone-89" whether or not anything
+    // had been renamed. SessionLabel handles both.
     private func bannerTitle(for event: NudgeEvent) -> String {
-        guard let id = event.claudeSessionID else { return event.title }
-        guard let session = sessions.sessions.first(where: { $0.claudeSessionID == id })
-        else { return event.title }
-        let custom = session.customName?.trimmingCharacters(in: .whitespaces)
-        let claude = session.liveTitle?.trimmingCharacters(in: .whitespaces)
-        let label: String?
-        if let custom, !custom.isEmpty {
-            label = custom
-        } else if let claude, !claude.isEmpty, claude != "main-agent" {
-            label = claude
-        } else {
-            label = nil
-        }
-        guard let label else { return event.title }
+        guard let label = sessionLabel(for: event) else { return event.title }
         return "\(event.title) — \(label)"
+    }
+
+    private func sessionLabel(for event: NudgeEvent) -> String? {
+        SessionLabel.chosenName(for: event,
+                                in: sessions.sessions,
+                                persistence: SessionPersistence.shared)
     }
 
     private func postBanner(for event: NudgeEvent) {

--- a/panel/ProcessOutput.swift
+++ b/panel/ProcessOutput.swift
@@ -12,8 +12,12 @@ enum ProcessOutput {
         task.arguments = args
         let outPipe = Pipe()
         task.standardOutput = outPipe
-        task.standardError = Pipe()
+        // nullDevice rather than a Pipe nobody reads: an undrained pipe blocks
+        // the child forever once it writes past the ~64KB buffer. Discarding
+        // stderr is the same contract, without the hang.
+        task.standardError = FileHandle.nullDevice
         do { try task.run() } catch { return "" }
+        // Drain before waiting — the reverse order deadlocks on large output.
         let data = outPipe.fileHandleForReading.readDataToEndOfFile()
         task.waitUntilExit()
         return String(data: data, encoding: .utf8) ?? ""
@@ -21,8 +25,7 @@ enum ProcessOutput {
 
     // Time-bounded variant. Returns nil on spawn failure or timeout (so the
     // caller can distinguish "ran and got empty stdout" from "never finished").
-    // On timeout we send SIGTERM, wait briefly, then SIGKILL — the pipe's
-    // writer end closes either way so the readDataToEndOfFile below can't hang.
+    // On timeout we send SIGTERM, wait briefly, then SIGKILL.
     // Optional cwd pins the child's working directory — used by the Claude CLI
     // probe so its session-jsonl files always land in a known, scrub-able dir.
     static func read(_ path: String, _ args: [String], timeout: TimeInterval, cwd: String? = nil) -> String? {
@@ -32,28 +35,45 @@ enum ProcessOutput {
         if let cwd { task.currentDirectoryURL = URL(fileURLWithPath: cwd) }
         let outPipe = Pipe()
         task.standardOutput = outPipe
-        task.standardError = Pipe()
+        task.standardError = FileHandle.nullDevice
 
-        let group = DispatchGroup()
-        group.enter()
-        task.terminationHandler = { _ in group.leave() }
+        let exited = DispatchGroup()
+        exited.enter()
+        task.terminationHandler = { _ in exited.leave() }
 
         do { try task.run() } catch {
             // Balance the enter() — terminationHandler never fires if run() throws.
-            group.leave()
+            exited.leave()
             return nil
         }
 
-        if group.wait(timeout: .now() + timeout) == .timedOut {
+        // Drain stdout concurrently with the wait, never after it. Waiting for
+        // exit first deadlocks any child that outgrows the ~64KB pipe buffer:
+        // it blocks writing, we block waiting, and the timeout fires on a
+        // command that was working fine. `ps -axo args=` clears 250KB on a
+        // busy machine, which is how this emptied the whole sessions pane.
+        let drained = DispatchGroup()
+        var output = Data()
+        drained.enter()
+        DispatchQueue.global(qos: .utility).async {
+            output = outPipe.fileHandleForReading.readDataToEndOfFile()
+            drained.leave()
+        }
+
+        if exited.wait(timeout: .now() + timeout) == .timedOut {
             task.terminate()
-            if group.wait(timeout: .now() + 1) == .timedOut, task.isRunning {
+            if exited.wait(timeout: .now() + 1) == .timedOut, task.isRunning {
                 kill(task.processIdentifier, SIGKILL)
-                _ = group.wait(timeout: .now() + 1)
+                _ = exited.wait(timeout: .now() + 1)
             }
+            // Death closes the child's write end, so the drain unblocks.
+            _ = drained.wait(timeout: .now() + 1)
             return nil
         }
-        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
-        return String(data: data, encoding: .utf8) ?? ""
+        // EOF arrives when the write end closes at exit; the group's ordering
+        // is what publishes `output` to this thread.
+        guard drained.wait(timeout: .now() + timeout) != .timedOut else { return nil }
+        return String(data: output, encoding: .utf8) ?? ""
     }
 
     // Resolve the `gh` CLI from common install locations. A launchd-spawned app

--- a/panel/SessionLabel.swift
+++ b/panel/SessionLabel.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+// Single source of truth for "what do we call this session".
+//
+// Three surfaces used to answer that question three different ways and
+// disagreed with each other: the Sessions row read the process list, the
+// Events row read only the on-disk name store (so it never saw a name set
+// inside the agent), and the banner joined events to sessions on Claude's
+// session UUID alone (so a Codex / Gemini / Antigravity banner could never
+// pick up a rename at all). The spoken nudge didn't resolve anything — the
+// hook baked the cwd basename into the phrase before the app ever saw it.
+//
+// Priority is by provenance, strongest intent first:
+//   1. customName — the user renamed it in the Sessions pane.
+//   2. a name the user set inside the agent (Claude Code's sidecar `name`).
+//   3. the cwd basename, which nobody chose, so callers that need a name
+//      rather than a label ask for `chosenName` and get nil here.
+//
+// Deliberately excluded: the terminal tab name. On iTerm2 a manual rename,
+// an OSC title escape and the profile name all write the same `autoName`
+// variable, so there is no way to read "the user chose this" back out — and
+// Claude Code rewrites the tab title every turn, so a manual tab rename
+// doesn't survive anyway. The pane still shows the tab name in its meta row,
+// where churn is harmless.
+enum SessionLabel {
+
+    // Agent-assigned names that carry no user intent. "main-agent" is what
+    // pre-2.1 Claude Code called every session. 2.1+ derives a per-cwd name
+    // instead ("stackone-89") and stamps a nameSource, which is why matching
+    // the old literal alone stopped being enough: every session suddenly had
+    // a plausible-looking name, and banners started reading
+    // "Claude Code — stackone-89" whether or not anyone had renamed anything.
+    static let placeholderNames: Set<String> = ["main-agent"]
+
+    // nameSource values that mean "the agent made this up". A source we don't
+    // recognise counts as user intent: the failure we care about is dropping a
+    // real rename, and a new source string is far more likely to be a way for
+    // the user to set a name than another kind of auto-generation.
+    static let generatedNameSources: Set<String> = [
+        "derived", "default", "auto", "generated",
+    ]
+
+    // MARK: - Sessions
+
+    // The name a human chose for this session, or nil if nobody has.
+    static func chosenName(for session: Session) -> String? {
+        if let custom = session.customName?.trimmingCharacters(in: .whitespaces),
+           !custom.isEmpty {
+            return custom
+        }
+        return userSetLiveTitle(of: session)
+    }
+
+    // What a row/pill shows as its title.
+    static func displayName(for session: Session, fallback: String) -> String {
+        chosenName(for: session) ?? session.projectName ?? fallback
+    }
+
+    // The agent's own session name, but only when the agent tells us a human
+    // set it. nil source means the agent doesn't report one (older Claude Code,
+    // other agents), so we keep the pre-existing behaviour of trusting the name
+    // and only filtering the known placeholder.
+    private static func userSetLiveTitle(of session: Session) -> String? {
+        guard let title = session.liveTitle?.trimmingCharacters(in: .whitespaces),
+              !title.isEmpty,
+              !placeholderNames.contains(title)
+        else { return nil }
+        if let source = session.liveTitleSource?.trimmingCharacters(in: .whitespaces).lowercased(),
+           generatedNameSources.contains(source) {
+            return nil
+        }
+        return title
+    }
+
+    // MARK: - Events
+
+    // The name a human chose for the session this event came from.
+    //
+    // Prefers the live session, which is where a rename made inside the agent
+    // shows up, and matches it the same way the Events tab does — agent PID
+    // first, falling back to project path plus tab id. Then falls back to the
+    // disk-backed store, which is the only source left once the session's
+    // process is gone.
+    static func chosenName(for event: NudgeEvent,
+                           in sessions: [Session],
+                           persistence: SessionPersistence) -> String? {
+        if let session = sessions.first(where: { sessionMatches(event: event, session: $0) }),
+           let name = chosenName(for: session) {
+            return name
+        }
+        return persistence.customName(
+            agent: event.agent,
+            projectPath: event.projectPath,
+            tabId: tabIdentifier(for: event)
+        )
+    }
+
+    // What a nudge row shows as its session chip: a chosen name, else the
+    // project folder.
+    static func displayName(for event: NudgeEvent,
+                            in sessions: [Session],
+                            persistence: SessionPersistence) -> String? {
+        if let name = chosenName(for: event, in: sessions, persistence: persistence) {
+            return name
+        }
+        guard let project = event.projectPath else { return nil }
+        return (project as NSString).lastPathComponent
+    }
+
+    // First non-empty of [terminal session id, VSCode IPC hook]. Each terminal
+    // contributes whatever it has; the lookup layer doesn't care which one
+    // fired as long as it's stable per tab/window.
+    static func tabIdentifier(for event: NudgeEvent) -> String? {
+        if let sid = event.sessionID, !sid.isEmpty { return sid }
+        if let hook = event.ipcHook, !hook.isEmpty { return hook }
+        return nil
+    }
+}
+
+// Builds the spoken phrase. The hook picks a phrase template at random and
+// used to substitute the cwd basename itself, which meant speech could never
+// say a renamed session's name. It now sends the template with its `%s`
+// placeholder intact (plus the already-substituted string for older installs)
+// and we fill in whichever label resolved.
+enum VoicePhrase {
+
+    // nil when there's nothing better to say than what the hook already
+    // substituted — caller falls back to event.voiceMessage.
+    static func spoken(template: String?, label: String?) -> String? {
+        guard let template, template.contains("%s"),
+              let label, !label.isEmpty
+        else { return nil }
+        return template.replacingOccurrences(of: "%s", with: expandForSpeech(label))
+    }
+
+    // Light expansion so a slug reads as words. Mirrors notify.sh's
+    // repo_name_raw, which still handles the hook-side fallback phrase; the
+    // two only need to agree in behaviour, not implementation, and this side
+    // is the one that sees user-chosen names.
+    static func expandForSpeech(_ name: String) -> String {
+        let words = name
+            .replacingOccurrences(of: "-", with: " ")
+            .replacingOccurrences(of: "_", with: " ")
+            .split(separator: " ", omittingEmptySubsequences: true)
+            .map { word -> String in
+                switch word.lowercased() {
+                case "cli":      return "C L I"
+                case "api":      return "A P I"
+                case "mcp":      return "M C P"
+                case "hris":     return "H R I S"
+                case "ai":       return "A I"
+                case "stackone": return "stack one"
+                default:         return String(word)
+                }
+            }
+        return words.joined(separator: " ")
+    }
+}

--- a/panel/SessionStore.swift
+++ b/panel/SessionStore.swift
@@ -32,8 +32,27 @@ struct Session: Identifiable, Equatable {
     // + AntigravityLocalServer). They drive the busy/idle dot, the status line,
     // and the busy-first sort; nil for agents that expose no live state.
     var liveTitle: String?            // session name (Claude sidecar; "main-agent" = default)
+    // Where liveTitle came from. Claude Code 2.1+ auto-derives a name for
+    // every session ("stackone-89") and stamps nameSource: "derived"; only a
+    // name the user chose carries intent. nil for agents/versions that don't
+    // report a source — treated as user-set so older Claude Code keeps
+    // behaving as it did. See SessionLabel.
+    var liveTitleSource: String?
     var liveStatus: String?           // "busy" | "idle" | other
     var lastActivityAt: Date?         // last-activity timestamp
+
+    // A session whose process is alive but which hasn't done anything for a
+    // day. These pile up when tabs are left open for weeks: still focusable,
+    // so hiding them would be wrong, but they shouldn't crowd the top of the
+    // list or count towards "how many agents are working". Only claimable
+    // when we have a live-activity signal at all — no signal means we can't
+    // tell dormant from busy, so we don't guess.
+    static let dormantAfter: TimeInterval = 24 * 60 * 60
+
+    func isDormant(asOf now: Date = Date()) -> Bool {
+        guard status == .active, let lastActivityAt else { return false }
+        return now.timeIntervalSince(lastActivityAt) > Self.dormantAfter
+    }
 }
 
 // Decoded shape of ~/.claude/sessions/<pid>.json. Only the fields we
@@ -42,6 +61,7 @@ struct Session: Identifiable, Equatable {
 private struct ClaudeSessionSidecar: Decodable {
     let sessionId: String?
     let name: String?
+    let nameSource: String?
     let status: String?
     let updatedAt: Double?
 }
@@ -180,9 +200,45 @@ final class SessionStore: ObservableObject {
     }
 
     private func merge(_ found: [Session]) {
-        let foundByPID = Dictionary(uniqueKeysWithValues: found.map { ($0.pid, $0) })
-        let now = Date()
-        let cutoff = now.addingTimeInterval(-30) // hide finished sessions after 30s
+        // Seed names from disk before reconciling, so a session that keeps its
+        // (agent, projectPath[, tabId]) identity keeps its name across process
+        // churn and restarts. noteSeen only writes once per key per launch.
+        let seeded = found.map { session -> Session in
+            guard let persisted = persistence.customName(
+                agent: session.agent,
+                projectPath: session.projectPath,
+                tabId: session.tabId
+            ) else { return session }
+            persistence.noteSeen(
+                agent: session.agent,
+                projectPath: session.projectPath,
+                tabId: session.tabId
+            )
+            var copy = session
+            copy.customName = persisted
+            return copy
+        }
+
+        sessions = Self.reconcile(previous: sessions, found: seeded, now: Date())
+
+        if let sel = selectedPID, !sessions.contains(where: { $0.pid == sel }) {
+            selectedPID = sessions.first?.pid
+        } else if selectedPID == nil {
+            selectedPID = sessions.first?.pid
+        }
+    }
+
+    // How long a session stays visible after its process exits, so the user
+    // gets to see that it finished rather than having the row vanish.
+    static let finishedRetention: TimeInterval = 30
+
+    // The pure half of merge: previous list + fresh snapshot -> next list.
+    // Sessions still running are refreshed from the snapshot, ones that just
+    // disappeared are marked finished, and ones that finished more than
+    // `finishedRetention` ago are dropped.
+    static func reconcile(previous: [Session], found: [Session], now: Date) -> [Session] {
+        let foundByPID = Dictionary(found.map { ($0.pid, $0) }, uniquingKeysWith: { first, _ in first })
+        let cutoff = now.addingTimeInterval(-finishedRetention)
 
         var next: [Session] = []
 
@@ -190,10 +246,13 @@ final class SessionStore: ObservableObject {
         // persists. We also re-apply the freshly-enriched tabId/tabName
         // from the live snapshot — a tab rename or pane move should
         // propagate without waiting for the session to restart.
-        for var existing in sessions {
+        for var existing in previous {
             if let live = foundByPID[existing.pid] {
                 existing = live.with(
-                    customName: existing.customName,
+                    // In-memory name wins: it's what the user just typed. The
+                    // snapshot's name is the one seeded from disk, so it acts
+                    // as the fallback.
+                    customName: existing.customName ?? live.customName,
                     status: .active,
                     tabId: live.tabId,
                     tabName: live.tabName
@@ -212,36 +271,19 @@ final class SessionStore: ObservableObject {
             }
         }
 
-        // Add genuinely new sessions, seeding customName from persistence
-        // so a renamed (agent, projectPath[, tabId]) keeps its name across
-        // restarts and across process churn within a single launch.
         let knownPIDs = Set(next.map(\.pid))
-        for var session in found where !knownPIDs.contains(session.pid) {
-            if let persisted = persistence.customName(
-                agent: session.agent,
-                projectPath: session.projectPath,
-                tabId: session.tabId
-            ) {
-                session.customName = persisted
-                persistence.noteSeen(
-                    agent: session.agent,
-                    projectPath: session.projectPath,
-                    tabId: session.tabId
-                )
-            }
-            next.append(session)
-        }
+        next.append(contentsOf: found.filter { !knownPIDs.contains($0.pid) })
 
-        // Sort: active first, busy above non-busy within active, then by
-        // most-recent lastActivityAt (or process pid as tiebreaker so
-        // ordering stays stable when sidecar timestamps are absent).
-        // Distant past for sessions with no updatedAt sinks them below
-        // any timestamped session.
+        // Sort in tiers — live, dormant, finished — then busy above non-busy
+        // within a tier, then by most-recent lastActivityAt (or process pid as
+        // tiebreaker so ordering stays stable when sidecar timestamps are
+        // absent). Distant past for sessions with no updatedAt sinks them
+        // below any timestamped session.
         let distantPast = Date.distantPast
         next.sort { lhs, rhs in
-            let lActive = lhs.status == .active
-            let rActive = rhs.status == .active
-            if lActive != rActive { return lActive && !rActive }
+            let lRank = sortRank(lhs, now: now)
+            let rRank = sortRank(rhs, now: now)
+            if lRank != rRank { return lRank < rRank }
 
             let lBusy = lhs.liveStatus == "busy"
             let rBusy = rhs.liveStatus == "busy"
@@ -253,38 +295,50 @@ final class SessionStore: ObservableObject {
             return lhs.pid < rhs.pid
         }
 
-        sessions = next
+        return next
+    }
 
-        if let sel = selectedPID, !sessions.contains(where: { $0.pid == sel }) {
-            selectedPID = sessions.first?.pid
-        } else if selectedPID == nil {
-            selectedPID = sessions.first?.pid
+    private static func sortRank(_ session: Session, now: Date) -> Int {
+        switch session.status {
+        case .finished: return 2
+        case .active:   return session.isDormant(asOf: now) ? 1 : 0
         }
+    }
+
+    // Sessions that are alive *and* have done something recently. This is what
+    // the tab badge and the mascot pill count: a day-old idle tab is still a
+    // session, but reporting it as one of "6 agents working" is noise.
+    var liveSessions: [Session] {
+        let now = Date()
+        return sessions.filter { $0.status == .active && !$0.isDormant(asOf: now) }
     }
 
     // MARK: - Discovery
 
-    // Parse ps output as `pid etime <full args>`. Agent detection is done on
-    // args because `comm` is truncated by ps and node-hosted agents (gemini,
+    // Parse ps output as `pid etime tty <full args>`. Agent detection is done
+    // on args because `comm` is truncated by ps and node-hosted agents (gemini,
     // codex when installed via npm) show comm as "node" with the script
-    // path in args.
+    // path in args. tty comes along because it's the version-proof way to tell
+    // an interactive session from agent infrastructure (see below).
     private static func discover() -> [Session] {
-        let lines = runProcess("/bin/ps", ["-axo", "pid=,etime=,args="])
+        let lines = runProcess("/bin/ps", ["-axo", "pid=,etime=,tty=,args="])
             .split(separator: "\n")
 
-        var candidates: [(pid: Int, elapsed: String, agent: String)] = []
+        var candidates: [(pid: Int, elapsed: String, hasTTY: Bool, agent: String)] = []
         for raw in lines {
             let line = String(raw).trimmingCharacters(in: .whitespaces)
-            // pid (digits) <ws> etime <ws> args...
-            let parts = line.split(separator: " ", maxSplits: 2,
+            // pid (digits) <ws> etime <ws> tty <ws> args...
+            let parts = line.split(separator: " ", maxSplits: 3,
                                    omittingEmptySubsequences: true)
-            guard parts.count >= 3 else { continue }
+            guard parts.count >= 4 else { continue }
             guard let pid = Int(parts[0]) else { continue }
             let etime = String(parts[1])
-            let args = String(parts[2])
+            let tty = String(parts[2])
+            let args = String(parts[3])
 
             guard let agent = detectAgent(args: args) else { continue }
-            candidates.append((pid: pid, elapsed: etime, agent: agent))
+            candidates.append((pid: pid, elapsed: etime,
+                               hasTTY: tty != "??" && !tty.isEmpty, agent: agent))
         }
 
         let pids = candidates.map(\.pid)
@@ -293,11 +347,19 @@ final class SessionStore: ObservableObject {
 
         var found: [Session] = []
         for candidate in candidates {
-            let cwd = cwdByPID[candidate.pid]
-            let chain = walkParentChain(from: candidate.pid, processTable: processTable)
             let sidecar = (candidate.agent == "claude")
                 ? readClaudeSidecar(pid: candidate.pid)
                 : nil
+            // An interactive agent always owns a pty. A `claude` process with
+            // neither a controlling terminal nor a session sidecar is
+            // infrastructure, not a session: it can't be focused, it can't be
+            // meaningfully killed, and it outlives the session it belongs to,
+            // so it showed up as a row the finished-session prune could never
+            // reach. The subcommand denylist in detectAgent catches the ones
+            // we know by name; this catches whatever 2.2 invents next.
+            if candidate.agent == "claude", !candidate.hasTTY, sidecar == nil { continue }
+            let cwd = cwdByPID[candidate.pid]
+            let chain = walkParentChain(from: candidate.pid, processTable: processTable)
             found.append(Session(
                 id: candidate.pid,
                 pid: candidate.pid,
@@ -313,6 +375,7 @@ final class SessionStore: ObservableObject {
                 tabName: nil,
                 claudeSessionID: sidecar?.sessionId,
                 liveTitle:      sidecar?.name,
+                liveTitleSource: sidecar?.nameSource,
                 liveStatus:    sidecar?.status,
                 lastActivityAt: sidecar?.updatedAt.map { Date(timeIntervalSince1970: $0 / 1000) }
             ))
@@ -341,12 +404,28 @@ final class SessionStore: ObservableObject {
         }
     }
 
-    private static func detectAgent(args: String) -> String? {
-        // First token of args is the executable path.
-        let firstToken = args.split(separator: " ", maxSplits: 1).first.map(String.init) ?? ""
-        let baseName = (firstToken as NSString).lastPathComponent
+    // Claude Code 2.1+ runs a process tree around each session, and every part
+    // of it is an executable called `claude`: one long-lived `claude daemon
+    // run` under launchd, plus per-session `bg-pty-host` / `bg-spare` hosts.
+    // None of them is a session the user can focus, and the daemon never
+    // exits, so left undetected they accumulated as permanent rows. The pty
+    // host is the nastiest: it inherits the project cwd, so it read as a real
+    // session in that project which had already ended.
+    private static let claudeInfraSubcommands: Set<String> = [
+        "daemon", "bg-pty-host", "bg-spare",
+    ]
+    private static let claudeInfraFlags: Set<String> = [
+        "--bg-pty-host", "--bg-spare",
+    ]
 
-        if baseName == "claude" { return "claude" }
+    static func detectAgent(args: String) -> String? {
+        let tokens = args.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
+        // First token of args is the executable path.
+        let baseName = ((tokens.first ?? "") as NSString).lastPathComponent
+
+        if baseName == "claude" {
+            return isClaudeInfrastructure(tokens: tokens) ? nil : "claude"
+        }
         if baseName == "gemini" { return "gemini" }
         if baseName == "codex"  { return "codex"  }
         if baseName == "agy"    { return "agy"    }
@@ -364,6 +443,19 @@ final class SessionStore: ObservableObject {
             }
         }
         return nil
+    }
+
+    // True for the helper processes above. Scans past leading flags to the
+    // first positional argument, which is the subcommand; anything after that
+    // belongs to the subcommand, so a session resumed as
+    // `claude --resume <uuid>` can't be mistaken for one.
+    private static func isClaudeInfrastructure(tokens: [String]) -> Bool {
+        for token in tokens.dropFirst() {
+            if claudeInfraFlags.contains(token) { return true }
+            if token.hasPrefix("-") { continue }
+            return claudeInfraSubcommands.contains(token)
+        }
+        return false
     }
 
     // Walk ~/.claude/sessions/ and recycle any <pid>.json whose PID is no
@@ -506,8 +598,16 @@ final class SessionStore: ObservableObject {
         // plumbing lives in one place — keeps stderr-swallow + failure
         // semantics consistent across SessionStore and the terminal
         // integrations.
-        ProcessOutput.read(path, args)
+        //
+        // Time-bounded: scan() latches `isScanning` for the duration and only
+        // clears it in the completion, so a single subprocess that never
+        // returns (lsof on an unresponsive network mount is the realistic
+        // one) froze the pane permanently — no new sessions, and no pruning
+        // of the ones that ended. A timeout turns that into one skipped scan.
+        ProcessOutput.read(path, args, timeout: subprocessTimeout) ?? ""
     }
+
+    private static let subprocessTimeout: TimeInterval = 2.0
 }
 
 private extension Session {
@@ -532,6 +632,7 @@ private extension Session {
             // from the previous poll.
             claudeSessionID: self.claudeSessionID,
             liveTitle:      self.liveTitle,
+            liveTitleSource: self.liveTitleSource,
             liveStatus:    self.liveStatus,
             lastActivityAt: self.lastActivityAt
         )

--- a/panel/Sessions.swift
+++ b/panel/Sessions.swift
@@ -227,7 +227,10 @@ private struct SessionRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(rowBackground)
         .padding(.horizontal, 6)
-        .opacity(isActive ? 1.0 : 0.6)
+        // Dormant sessions get the same recede as finished ones: the process
+        // is still there to focus or kill, but it hasn't done anything for a
+        // day, so it shouldn't read as live work.
+        .opacity(isActive && !session.isDormant() ? 1.0 : 0.6)
     }
 
     // Background composes the selection tint with a 3pt accent bar in the
@@ -395,15 +398,7 @@ private struct SessionRow: View {
     private var isActive: Bool { session.status == .active }
 
     private var displayName: String {
-        if let custom = session.customName, !custom.isEmpty { return custom }
-        // Prefer a user-set Claude session name when it's not the default
-        // ("main-agent" is what Claude Code assigns by default; treat it
-        // as not meaningful and fall through to project name).
-        if let liveTitle = session.liveTitle,
-           !liveTitle.isEmpty, liveTitle != "main-agent" {
-            return liveTitle
-        }
-        return session.projectName ?? "(no project)"
+        SessionLabel.displayName(for: session, fallback: "(no project)")
     }
 
     // Full cwd with $HOME replaced by ~ for compactness. Falls back to
@@ -415,7 +410,7 @@ private struct SessionRow: View {
 
     private var glyph: String {
         switch session.status {
-        case .active:   return "circle.fill"
+        case .active:   return session.isDormant() ? "circle.dotted" : "circle.fill"
         case .finished: return "circle"
         }
     }
@@ -423,6 +418,7 @@ private struct SessionRow: View {
     private var glyphColor: Color {
         switch session.status {
         case .finished: return .secondary
+        case .active where session.isDormant(): return .secondary
         case .active:
             // For claude sessions we get a live busy/idle signal from the
             // ~/.claude/sessions/<pid>.json sidecar; reflect it in the dot
@@ -444,11 +440,13 @@ private struct SessionRow: View {
     private var statusLabel: String {
         switch session.status {
         case .active:
-            // Lead with claude's live status (busy / idle). Append "last
+            // Lead with claude's live status (busy / idle), or "dormant" once
+            // there's been no activity for a day — at that point "idle" reads
+            // as "waiting on me right now", which it isn't. Append "last
             // activity Nm ago" from the sidecar's updatedAt when available
             // — more useful than process elapsed time, which only tells
             // you how long ago the process was spawned.
-            let head = session.liveStatus ?? "active"
+            let head = session.isDormant() ? "dormant" : (session.liveStatus ?? "active")
             if let updated = session.lastActivityAt {
                 return "\(head) · \(RelativeTime.string(updated))"
             }


### PR DESCRIPTION
Two reported bugs in the Sessions pane: stale and closed sessions never getting pruned, and a renamed session's name not reaching the event notification.

## Stale rows were agent infrastructure, not stale state

The finished-session prune was working. The rows that never went away were never sessions. `detectAgent` matched on the executable basename alone, and Claude Code 2.1 runs a process tree where every part is an executable called `claude`:

| process | why it showed up | why it never left |
|---|---|---|
| `claude daemon run` | basename match | parented to launchd, lives for weeks |
| `claude bg-pty-host` | basename match | outlives the session it hosts |
| `claude bg-spare` | basename match | pooled, not tied to a session |
| `ClaudeCode.app/…/claude --bg-pty-host` | basename match | inherits the project cwd, so it read as a real session in that project that had already ended |

Fixed two ways: a subcommand/flag denylist for the ones we know by name, and a version-proof backstop that drops a `claude` process with neither a controlling terminal nor a session sidecar. Replayed over a live process table: 4 ghost rows dropped, all 14 real sessions kept.

Also added a dormant tier. A session with no sidecar activity for 24h dims, reads "dormant", sorts below live sessions, and drops out of the tab badge and the pill's rotation. It is never hidden: the process is still there to focus or kill. On the machine this was found on, 6 of 14 sessions qualified at 92h to 239h idle, so the badge went from 14 to 8.

While in here: `SessionStore.runProcess` is now time-bounded. `scan()` latches `isScanning` and only clears it in the completion, so one hung `lsof` froze the pane permanently, adding nothing and pruning nothing. Now it costs one skipped scan.

Putting a deadline on that call exposed a bug in `ProcessOutput.read(_:_:timeout:)`: it waited for the child to exit *before* draining stdout. `ps -axo pid=,etime=,tty=,args=` is over 250KB on a busy machine against a ~64KB pipe buffer, so `ps` blocked on write, never exited, and the deadline fired on a command that was working perfectly, emptying the pane completely. It now drains stdout concurrently with the wait, and uses `nullDevice` for stderr instead of a `Pipe` nobody reads, which was the same latent hang. Measured through the fixed path: `ps` returns 257KB in 79ms and `lsof` in 36ms, against a 2s deadline that still fires for a child that genuinely never returns.

## Session names were resolved three different ways

Each surface answered "what is this session called" differently, and they disagreed:

- the **Sessions row** read the process list
- the **nudge row** read only the on-disk name store, so it never saw a name set inside the agent
- the **banner** joined events to sessions on Claude's session UUID alone, so a renamed Codex/Gemini/Antigravity session was always announced by its folder name
- the **spoken nudge** resolved nothing: the hook substituted the cwd basename into the phrase before the app ever saw it

New `SessionLabel` owns one cascade, ordered by provenance: pane rename, then a name the user set inside the agent, then the project folder. Event-to-session matching now goes through the same agent-PID match the Events tab already used, with the on-disk store as fallback for sessions whose process has exited.

Provenance matters because 2.1 auto-derives a name for *every* session and stamps `nameSource: "derived"`. The old code only filtered the literal `main-agent`, so banners had started reading `Claude Code — stackone-89` whether or not anything had been renamed, which looks exactly like a rename that didn't come through. Derived names are now ignored; a missing `nameSource` is still trusted, so older Claude Code keeps behaving as it did.

For speech, `notify.sh` now sends the phrase template with its `%s` intact alongside the substituted string, and the app fills in the resolved label with the same slug expansion (`stackone-cli` becomes "stack one C L I"). It falls back to the hook's own string when there's no name to say or when an older installed `notify.sh` sent no template.

## Terminal tab renames are deliberately not a rename source

Probed directly: `set name of session` writes the same iTerm `autoName` variable that OSC title escapes and the profile name write, so there is no user-intent signal to read back, and Claude Code rewrites the tab title every turn so a manual rename doesn't survive anyway. The tab name stays in the pane's meta row, where churn is harmless. It now reads `autoName` rather than the composed `name`, which drops the noisy ` (claude)` job suffix.

## Also

`make reload` and `make dev` were dead: the Makefile pointed at `stack-nudge.app` while `build.sh` emits `StackNudge.app`, so `reload` died on the `cp` under `set -e` and `dev` swallowed it with `|| true`. The watch loop had been silently reloading nothing.

## Testing

`SessionStoreTests` covers agent detection against arg strings copied verbatim from a real `ps` table, the full prune ladder (running, just-exited, pruned past retention, no resurrection, names surviving pid churn), the three-tier sort, and dormancy including the no-signal case. `SessionLabelTests` covers each rename source, derived-name rejection, non-Claude agents, the persistence fallback, and template substitution. `ProcessOutputTests` pins the drain-order bug above: large output must not read as a timeout, must come back complete rather than truncated at the buffer, the deadline must still fire on a hung child, and `nil` must stay distinguishable from empty-but-successful.

Assertions were also run locally through an in-module harness (this machine has Command Line Tools only, so no XCTest): 61/61. The wire change was probed end-to-end against a socket listener under a fake `HOME` for the stop, permission and welcome paths. Finally the whole thing was driven through a real `SessionStore` poll against a live process table: 12 sessions listed, 6 counted as live, 6 dormant, and every infrastructure process excluded.
