### PR TITLE
feat(panel): add insights overview to the outcomes tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,11 @@ Add that to your shell profile.
 
 ### Keyboard-native panel (macOS)
 
-If you'd rather not click banners with the mouse, stack-nudge runs a small floating panel that you summon with a hotkey. It has five tabs — **Events**, **Sessions**, **Usage**, **Tickets**, and **Settings** — and is fully keyboard-driven.
+If you'd rather not click banners with the mouse, stack-nudge runs a small floating panel that you summon with a hotkey. It has five tabs (**Events**, **Sessions**, **Usage**, **Outcomes**, and **Settings**) and is fully keyboard-driven.
 
 The panel is installed and registered as a launchd agent by `./install.sh` — no opt-in needed. To run quietly without macOS banners, toggle **Settings → Banner notifications** off (panel-only mode).
 
-Default hotkey is `cmd+opt+n`. Hit it from anywhere to summon the panel; hit it again while focused to hide. Switch tabs with `Cmd+1` (Events), `Cmd+2` (Sessions), `Cmd+3` (Usage), `Cmd+4` (Tickets), `Cmd+5` (Settings) — or click them. Banner and panel can run together, alone, or both off — the sound and voice still fire as passive signals.
+Default hotkey is `cmd+opt+n`. Hit it from anywhere to summon the panel; hit it again while focused to hide. Switch tabs with `Cmd+1` (Events), `Cmd+2` (Sessions), `Cmd+3` (Usage), `Cmd+4` (Outcomes), `Cmd+5` (Settings), or click them. Banner and panel can run together, alone, or both off; the sound and voice still fire as passive signals.
 
 #### Events tab
 
@@ -220,9 +220,26 @@ The hotkey row records live: press `⏎` on it, press the new combo, and stack-n
 
 All Settings choices persist to `~/.stack-nudge/config` (a `KEY=value` text file). You don't need to edit it directly — Settings is the source of truth — but it's there for backup/sync or scripted setup.
 
-### Tickets (usage → outcomes)
+### Outcomes (usage → shipped)
 
-The **Tickets** tab (`⌘4`) rolls every captured agent session up **by ticket** — derived from your branch naming (`eng-123/…` → `ENG-123`), falling back to the branch when there's no ticket — and shows the tokens spent, files changed, and the live git outcome: *needs-review → committed → pushed → merged*. Select rows with `↑ ↓`, open the ticket or PR with `⏎`, dismiss one with `⌫`.
+The **Outcomes** tab (`⌘4`) is two views of one dataset. It opens on the **Overview** (the aggregate); press `→` to carousel into the per-ticket **Tickets** list, `←` to step back.
+
+#### Overview
+
+The spend-to-outcome picture over a trailing window, so you see not just *what* your agents did but *what share of it shipped*.
+
+- **Shipped share**: the headline. Of the effort spent in the window, how much sits on work that merged or pushed, versus in-flight, versus **abandoned** (committed / needs-review work that's gone quiet for over 14 days).
+- **Spend bar**: one bar partitioning tokens across those three buckets, coloured shipped (green) / in-flight (blue) / abandoned (orange).
+- **Top tickets by spend**: the heaviest tickets (or unticketed repos) in the window, each with its dominant outcome. Click a row to open the ticket (when `STACKNUDGE_TICKET_URL` is set) or its PR.
+- **Agents**: the token mix per agent alongside each agent's **shipped share**, so you can see whose work actually merges. Plus the model mix.
+
+The Overview is a scroll page: `↑ ↓` scroll, `⌘↑ ⌘↓` jump to top/bottom, `W` cycles the trailing window (24h / 7d / 30d / 90d; 90d is the ledger's own retention ceiling). Because "abandoned" needs 14 days of quiet, it only appears on the 30d and 90d windows. It's token-only today; per-model dollar cost and reclaimed-time are planned follow-ups.
+
+#### Tickets
+
+Every captured agent session rolled up **by ticket**, derived from your branch naming (`eng-123/…` → `ENG-123`), falling back to the branch when there's no ticket. Shows the tokens spent, files changed, and the live git outcome: *needs-review → committed → pushed → merged*. `↑ ↓` select rows, `⏎` opens the ticket or PR, `⌫` dismisses one, `←` steps back to the Overview.
+
+The two panes agree by construction: both read the same per-branch outcome and PR state, so a squash-merged branch reads as shipped in each.
 
 Opt-in GitHub linking adds real **PR + CI status** (so even squash-merged work reads as *merged*). Turn it on in Settings → Tickets → **GitHub PR links**, then sign in via the in-panel device flow (no `gh` needed). Config keys (all optional; the toggles in Settings write the same file):
 
@@ -230,10 +247,10 @@ Opt-in GitHub linking adds real **PR + CI status** (so even squash-merged work r
 |-----|--------------|
 | `STACKNUDGE_GITHUB` | `true` to enable GitHub PR/CI linking (off by default) |
 | `STACKNUDGE_GITHUB_CLIENT_ID` | Override the embedded OAuth app Client ID (rarely needed) |
-| `STACKNUDGE_TICKET_URL` | Deep-link template for ticket rows, e.g. `https://linear.app/acme/issue/{key}` — `{key}` is replaced with the ticket |
-| `STACKNUDGE_HIDE_SHIPPED` | `true` to drop groups once their PR reads merged, keeping the tab on in-flight work |
+| `STACKNUDGE_TICKET_URL` | Deep-link template for ticket rows, e.g. `https://linear.app/acme/issue/{key}`; `{key}` is replaced with the ticket |
+| `STACKNUDGE_HIDE_SHIPPED` | `true` to drop groups once their PR reads merged, keeping the list on in-flight work |
 
-**Nothing showing up?** A session is recorded when an agent's turn ends *inside a git repo*, and only if the hook payload carries a session id. The tab's empty state names which of those failed; `~/.stack-nudge/app.log` has a line per dropped turn. The usual cause is an installed hook script older than the app, since updates swap the `.app` alone: the app repairs that on launch, and Settings warns in the footer if the rewrite couldn't be applied. To fix it by hand:
+**Nothing showing up?** A session is recorded when an agent's turn ends *inside a git repo*, and only if the hook payload carries a session id. The Tickets empty state names which of those failed; `~/.stack-nudge/app.log` has a line per dropped turn. The usual cause is an installed hook script older than the app, since updates swap the `.app` alone: the app repairs that on launch, and Settings warns in the footer if the rewrite couldn't be applied. To fix it by hand:
 
 ```bash
 grep -c stack-nudge-version ~/.stack-nudge/notify.sh   # 0 means the script predates v1.26

--- a/Tests/StackNudgePanelCoreTests/InsightsTests.swift
+++ b/Tests/StackNudgePanelCoreTests/InsightsTests.swift
@@ -1,0 +1,247 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// Insights.summarize is the pure spend-to-outcome rollup behind the Insights
+// tab. These pin the bucket partition (shipped / abandoned / in-flight), the
+// shipped-share math, the staleness cutoff that defines abandoned, PR state
+// superseding the local git heuristic, the agent/model mixes, and the trailing
+// window boundary.
+final class InsightsTests: XCTestCase {
+
+    private let day: TimeInterval = 86_400
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func key(_ repoRoot: String?, _ branch: String?) -> String {
+        PanelNav.outcomeKey(repoRoot, branch)
+    }
+
+    private func record(id: String,
+                        agent: String = "claude",
+                        repoRoot: String? = "/work/repo",
+                        branch: String? = "feat/x",
+                        ticket: String? = nil,
+                        model: String? = nil,
+                        tokens: Int? = 100,
+                        updated: Date) -> HandoffRecord {
+        HandoffRecord(
+            id: id, agent: agent, repoRoot: repoRoot, branch: branch, ticket: ticket,
+            model: model, contextTokens: tokens, headCommit: nil, filesChanged: nil,
+            insertions: nil, deletions: nil, createdAt: updated, updatedAt: updated)
+    }
+
+    private func pr(_ state: PRState) -> PullRequestInfo {
+        PullRequestInfo(number: 1, url: "https://example/pr/1", state: state, isDraft: false, ci: nil)
+    }
+
+    func test_partitionsTokensByBucket_shippedIsMergedPlusPushed() {
+        let yesterday = now.addingTimeInterval(-day)
+        let actual = Insights.summarize(
+            records: [
+                record(id: "a", branch: "b1", tokens: 100, updated: yesterday),
+                record(id: "b", branch: "b2", tokens: 200, updated: yesterday),
+                record(id: "c", branch: "b3", tokens: 50,  updated: yesterday),
+            ],
+            outcomeByBranch: [
+                key("/work/repo", "b1"): .merged,
+                key("/work/repo", "b2"): .pushed,
+                key("/work/repo", "b3"): .needsReview,
+            ],
+            pullRequestByBranch: [:],
+            now: now, window: 7 * day)
+
+        XCTAssertEqual(actual.totalTokens, 350)
+        XCTAssertEqual(actual.tokensByBucket[.shipped], 300)
+        XCTAssertEqual(actual.tokensByBucket[.inFlight], 50)   // recent needs-review, not abandoned
+        XCTAssertNil(actual.tokensByBucket[.abandoned])
+        XCTAssertEqual(actual.shippedShare, 300.0 / 350.0, accuracy: 0.0001)
+        XCTAssertEqual(actual.tokensByStatus[.merged], 100)
+        XCTAssertEqual(actual.tokensByStatus[.pushed], 200)
+        XCTAssertEqual(actual.tokensByStatus[.needsReview], 50)
+    }
+
+    func test_shippedShare_zeroWhenNothingShipped_oneWhenAllShipped() {
+        let yesterday = now.addingTimeInterval(-day)
+
+        let nothing = Insights.summarize(
+            records: [record(id: "a", branch: "b1", tokens: 100, updated: yesterday)],
+            outcomeByBranch: [key("/work/repo", "b1"): .needsReview],
+            pullRequestByBranch: [:], now: now, window: 7 * day)
+        XCTAssertEqual(nothing.shippedShare, 0)
+
+        let everything = Insights.summarize(
+            records: [record(id: "a", branch: "b1", tokens: 100, updated: yesterday)],
+            outcomeByBranch: [key("/work/repo", "b1"): .merged],
+            pullRequestByBranch: [:], now: now, window: 7 * day)
+        XCTAssertEqual(everything.shippedShare, 1)
+    }
+
+    func test_abandoned_onlyWhenUnshippedBranchGoneQuietPastCutoff() {
+        let quiet30d = now.addingTimeInterval(-30 * day)
+        let abandoned = Insights.summarize(
+            records: [record(id: "a", branch: "b1", tokens: 100, updated: quiet30d)],
+            outcomeByBranch: [key("/work/repo", "b1"): .committed],
+            pullRequestByBranch: [:], now: now, window: 90 * day)   // window wider than the 14d cutoff
+        XCTAssertEqual(abandoned.tokensByBucket[.abandoned], 100)
+        XCTAssertNil(abandoned.tokensByBucket[.inFlight])
+
+        let recent2d = now.addingTimeInterval(-2 * day)
+        let inFlight = Insights.summarize(
+            records: [record(id: "a", branch: "b1", tokens: 100, updated: recent2d)],
+            outcomeByBranch: [key("/work/repo", "b1"): .committed],
+            pullRequestByBranch: [:], now: now, window: 90 * day)
+        XCTAssertEqual(inFlight.tokensByBucket[.inFlight], 100)
+        XCTAssertNil(inFlight.tokensByBucket[.abandoned])
+    }
+
+    func test_prStateSupersedesLocal_squashMergeReadsAsShipped() {
+        let yesterday = now.addingTimeInterval(-day)
+        let actual = Insights.summarize(
+            records: [record(id: "a", branch: "b1", tokens: 100, updated: yesterday)],
+            outcomeByBranch: [key("/work/repo", "b1"): .committed],       // local: commits not on base
+            pullRequestByBranch: [key("/work/repo", "b1"): pr(.merged)],  // but the PR squash-merged
+            now: now, window: 7 * day)
+        XCTAssertEqual(actual.tokensByBucket[.shipped], 100)
+        XCTAssertEqual(actual.tokensByStatus[.merged], 100)
+        XCTAssertNil(actual.tokensByStatus[.committed])
+    }
+
+    func test_agentMix_canonicalized() {
+        let yesterday = now.addingTimeInterval(-day)
+        let actual = Insights.summarize(
+            records: [
+                record(id: "a", agent: "cursor", branch: "b1", tokens: 100, updated: yesterday),
+                record(id: "b", agent: "codex",  branch: "b2", tokens: 40,  updated: yesterday),
+            ],
+            outcomeByBranch: [:], pullRequestByBranch: [:], now: now, window: 7 * day)
+        XCTAssertEqual(actual.tokensByAgent["claude"], 100)   // cursor canonicalizes to claude
+        XCTAssertEqual(actual.tokensByAgent["codex"], 40)
+    }
+
+    func test_modelMix_keyedByRawId() {
+        let yesterday = now.addingTimeInterval(-day)
+        let actual = Insights.summarize(
+            records: [
+                record(id: "a", branch: "b1", model: "claude-opus-4-8", tokens: 100, updated: yesterday),
+                record(id: "b", branch: "b2", model: "claude-opus-4-8", tokens: 30,  updated: yesterday),
+                record(id: "c", branch: "b3", model: "gpt-5-codex",     tokens: 20,  updated: yesterday),
+            ],
+            outcomeByBranch: [:], pullRequestByBranch: [:], now: now, window: 7 * day)
+        XCTAssertEqual(actual.tokensByModel["claude-opus-4-8"], 130)
+        XCTAssertEqual(actual.tokensByModel["gpt-5-codex"], 20)
+    }
+
+    func test_window_excludesOlderThanWindow_includesEdge() {
+        let insideWindow = now.addingTimeInterval(-3 * day)
+        let onEdge       = now.addingTimeInterval(-7 * day)   // exactly at windowStart, inclusive
+        let outsideWindow = now.addingTimeInterval(-10 * day)
+        let actual = Insights.summarize(
+            records: [
+                record(id: "a", branch: "b1", tokens: 100, updated: insideWindow),
+                record(id: "b", branch: "b2", tokens: 10,  updated: onEdge),
+                record(id: "c", branch: "b3", tokens: 999, updated: outsideWindow),
+            ],
+            outcomeByBranch: [:], pullRequestByBranch: [:], now: now, window: 7 * day)
+        XCTAssertEqual(actual.totalTokens, 110)
+        XCTAssertEqual(actual.sessionCount, 2)
+    }
+
+    func test_emptyRecords_yieldsEmptySummary() {
+        let actual = Insights.summarize(
+            records: [], outcomeByBranch: [:], pullRequestByBranch: [:], now: now, window: 7 * day)
+        XCTAssertEqual(actual.totalTokens, 0)
+        XCTAssertEqual(actual.sessionCount, 0)
+        XCTAssertEqual(actual.ticketCount, 0)
+        XCTAssertEqual(actual.shippedShare, 0)
+        XCTAssertTrue(actual.tokensByBucket.isEmpty)
+    }
+
+    func test_nilTokens_countsSessionButZeroTokens() {
+        let yesterday = now.addingTimeInterval(-day)
+        let actual = Insights.summarize(
+            records: [record(id: "a", branch: "b1", tokens: nil, updated: yesterday)],
+            outcomeByBranch: [key("/work/repo", "b1"): .merged],
+            pullRequestByBranch: [:], now: now, window: 7 * day)
+        XCTAssertEqual(actual.sessionCount, 1)
+        XCTAssertEqual(actual.totalTokens, 0)
+    }
+
+    func test_topTickets_rankedByTokensWithDominantStatus() {
+        let yesterday = now.addingTimeInterval(-day)
+        let actual = Insights.summarize(
+            records: [
+                record(id: "a", branch: "b1", ticket: "ENG-1", tokens: 500, updated: yesterday),
+                record(id: "b", branch: "b2", ticket: "ENG-2", tokens: 100, updated: yesterday),
+            ],
+            outcomeByBranch: [
+                key("/work/repo", "b1"): .merged,
+                key("/work/repo", "b2"): .needsReview,
+            ],
+            pullRequestByBranch: [:], now: now, window: 7 * day)
+        XCTAssertEqual(actual.topTickets.map(\.label), ["ENG-1", "ENG-2"])
+        XCTAssertEqual(actual.topTickets.first?.status, .merged)
+        XCTAssertEqual(actual.topTickets.first?.bucket, .shipped)
+    }
+
+    func test_topTickets_dominantStatusPrefersMostShipped() {
+        let yesterday = now.addingTimeInterval(-day)
+        let actual = Insights.summarize(
+            records: [
+                record(id: "a", branch: "b1", ticket: "ENG-1", tokens: 100, updated: yesterday),
+                record(id: "b", branch: "b2", ticket: "ENG-1", tokens: 100, updated: yesterday),
+            ],
+            outcomeByBranch: [
+                key("/work/repo", "b1"): .needsReview,
+                key("/work/repo", "b2"): .merged,
+            ],
+            pullRequestByBranch: [:], now: now, window: 7 * day)
+        XCTAssertEqual(actual.topTickets.count, 1)
+        XCTAssertEqual(actual.topTickets.first?.tokens, 200)
+        XCTAssertEqual(actual.topTickets.first?.status, .merged)   // merged outranks needs-review
+    }
+
+    func test_topTickets_prSupersedesLocalAndCarriesURL() {
+        let yesterday = now.addingTimeInterval(-day)
+        let actual = Insights.summarize(
+            records: [record(id: "a", branch: "b1", ticket: "ENG-1", tokens: 100, updated: yesterday)],
+            outcomeByBranch: [key("/work/repo", "b1"): .committed],
+            pullRequestByBranch: [key("/work/repo", "b1"): pr(.merged)],
+            now: now, window: 7 * day)
+        XCTAssertEqual(actual.topTickets.first?.status, .merged)
+        XCTAssertEqual(actual.topTickets.first?.bucket, .shipped)
+        XCTAssertEqual(actual.topTickets.first?.prURL, "https://example/pr/1")
+    }
+
+    func test_shippedTokensByAgent_countsOnlyShippedBuckets() {
+        let yesterday = now.addingTimeInterval(-day)
+        let actual = Insights.summarize(
+            records: [
+                record(id: "a", agent: "claude", branch: "b1", tokens: 100, updated: yesterday),
+                record(id: "b", agent: "claude", branch: "b2", tokens: 100, updated: yesterday),
+                record(id: "c", agent: "codex",  branch: "b3", tokens: 50,  updated: yesterday),
+            ],
+            outcomeByBranch: [
+                key("/work/repo", "b1"): .merged,
+                key("/work/repo", "b2"): .needsReview,
+                key("/work/repo", "b3"): .pushed,
+            ],
+            pullRequestByBranch: [:], now: now, window: 7 * day)
+        XCTAssertEqual(actual.tokensByAgent["claude"], 200)
+        XCTAssertEqual(actual.shippedTokensByAgent["claude"], 100)   // only the merged branch
+        XCTAssertEqual(actual.tokensByAgent["codex"], 50)
+        XCTAssertEqual(actual.shippedTokensByAgent["codex"], 50)     // pushed counts as shipped
+    }
+
+    func test_ticketCount_distinctTicketsTouched() {
+        let yesterday = now.addingTimeInterval(-day)
+        let actual = Insights.summarize(
+            records: [
+                record(id: "a", branch: "b1", ticket: "ENG-1", tokens: 10, updated: yesterday),
+                record(id: "b", branch: "b2", ticket: "ENG-1", tokens: 10, updated: yesterday),
+                record(id: "c", branch: "b3", ticket: "ENG-2", tokens: 10, updated: yesterday),
+                record(id: "d", branch: "feat/x", ticket: nil, tokens: 10, updated: yesterday),
+            ],
+            outcomeByBranch: [:], pullRequestByBranch: [:], now: now, window: 7 * day)
+        XCTAssertEqual(actual.ticketCount, 2)
+    }
+}

--- a/panel/Components.swift
+++ b/panel/Components.swift
@@ -1,6 +1,46 @@
 import AppKit
 import SwiftUI
 
+// Left-to-right flow that wraps to the next row when it runs out of width, so a
+// row of variable-width pills stays tidy instead of overflowing or compressing
+// its children (which makes their text wrap mid-word). macOS 13+ `Layout`.
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 6
+    var rowSpacing: CGFloat = 6
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var rowWidth: CGFloat = 0, rowHeight: CGFloat = 0
+        var totalWidth: CGFloat = 0, totalHeight: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if rowWidth > 0, rowWidth + spacing + size.width > maxWidth {
+                totalWidth = max(totalWidth, rowWidth)
+                totalHeight += rowHeight + rowSpacing
+                rowWidth = 0; rowHeight = 0
+            }
+            rowWidth += (rowWidth > 0 ? spacing : 0) + size.width
+            rowHeight = max(rowHeight, size.height)
+        }
+        totalWidth = max(totalWidth, rowWidth)
+        totalHeight += rowHeight
+        return CGSize(width: min(totalWidth, maxWidth), height: totalHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var x = bounds.minX, y = bounds.minY, rowHeight: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x > bounds.minX, x + size.width > bounds.maxX {
+                x = bounds.minX; y += rowHeight + rowSpacing; rowHeight = 0
+            }
+            subview.place(at: CGPoint(x: x, y: y), anchor: .topLeading, proposal: ProposedViewSize(size))
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+}
+
 // MARK: - Footer hint pieces
 
 // A keycap-shaped pill — used for inline shortcut hints throughout the UI.

--- a/panel/Formatting.swift
+++ b/panel/Formatting.swift
@@ -11,6 +11,21 @@ enum TokenFormat {
     }
 }
 
+// Display form of a model id: drop the redundant "claude-" vendor prefix and any
+// trailing "-YYYYMMDD" date stamp. "claude-haiku-4-5-20251001" → "haiku-4-5",
+// "claude-opus-5" → "opus-5". A non-claude id (e.g. "gpt-5-codex") keeps its name,
+// minus a trailing date stamp.
+enum ModelName {
+    static func short(_ id: String) -> String {
+        var name = id.hasPrefix("claude-") ? String(id.dropFirst("claude-".count)) : id
+        if let dash = name.range(of: "-2", options: .backwards),
+           name[dash.lowerBound...].dropFirst().allSatisfy(\.isNumber) {
+            name = String(name[..<dash.lowerBound])
+        }
+        return name
+    }
+}
+
 // Shared relative-time strings ("5m ago", "in 3 days") with per-style cached
 // formatters (these were re-created in CompactView / Sessions / SessionUsage /
 // Panel). Formatters are reused on the main thread, matching prior usage.

--- a/panel/Insights.swift
+++ b/panel/Insights.swift
@@ -1,0 +1,265 @@
+import Foundation
+
+// Pure spend-to-outcome rollup behind the Insights tab. A function of the
+// handoff ledger plus the per-branch outcome + PR maps the Tickets tab already
+// computes (nav.outcomeByBranch / nav.pullRequestByBranch), so Insights agrees
+// with the Tickets tab by construction rather than re-deriving git state. No
+// I/O, no network; the same posture as OutcomesView.groups.
+//
+// Step 1 is token-only: `contextTokens` is the same cumulative-effort proxy the
+// Tickets tab sums, not output tokens or dollar cost. The dollar and cache
+// lenses (a real input/output/cache split) and reclaimed-time arrive with the
+// HandoffRecord fields added in later steps, and this type grows with them.
+
+// The five OutcomeStatus values collapse into three spend buckets for the
+// headline. Merged/pushed shipped; committed/needs-review that has gone quiet
+// past the staleness cutoff is abandoned; everything else (recent unshipped
+// work, and `clean`) is still in flight.
+enum SpendBucket: String, CaseIterable {
+    case shipped
+    case abandoned
+    case inFlight
+
+    // Headline label. `inFlight` reads "in flight" rather than the raw case name.
+    var label: String {
+        switch self {
+        case .shipped:   return "shipped"
+        case .abandoned: return "abandoned"
+        case .inFlight:  return "in flight"
+        }
+    }
+}
+
+// Trailing windows the Insights tab cycles through with `W`. All are trailing
+// (now - seconds), not calendar periods, so the labels say so. `abandoned` only
+// surfaces on windows wider than the 14-day staleness cutoff.
+enum InsightsWindow: CaseIterable {
+    case day
+    case week
+    case month
+    case quarter
+
+    var label: String {
+        switch self {
+        case .day:     return "Last 24h"
+        case .week:    return "Last 7 days"
+        case .month:   return "Last 30 days"
+        case .quarter: return "Last 90 days"
+        }
+    }
+
+    var seconds: TimeInterval {
+        switch self {
+        case .day:     return 86_400
+        case .week:    return 7 * 86_400
+        case .month:   return 30 * 86_400
+        case .quarter: return 90 * 86_400
+        }
+    }
+}
+
+// One row in the "top tickets by spend" list: a ticket (or unticketed repo)
+// group, its token spend, and its dominant outcome. `prURL` lets the row open
+// the PR when there's no ticket deep-link.
+struct TicketSpend: Identifiable, Equatable {
+    let id: String              // group dedup key ("t:<ticket>" / "r:<repoRoot>")
+    let label: String           // ticket key, or repo basename
+    let isTicket: Bool
+    let tokens: Int
+    let status: OutcomeStatus?  // dominant effective status across the group's branches
+    let bucket: SpendBucket
+    let prURL: String?
+}
+
+struct InsightsSummary: Equatable {
+    let window: DateInterval
+    let totalTokens: Int
+    let sessionCount: Int
+    let ticketCount: Int                        // distinct tickets touched in-window
+
+    // Headline: tokens by spend bucket.
+    let tokensByBucket: [SpendBucket: Int]
+
+    // Detail: the effective per-status split (PR state preferred), the agent
+    // mix, and the model mix. Model keys are the raw reported ids (e.g.
+    // "claude-opus-4-8", "gpt-5-codex"): distinct minor versions are genuinely
+    // different models, so the data layer keeps them apart and the view formats.
+    let tokensByStatus: [OutcomeStatus: Int]
+    let tokensByAgent: [String: Int]
+    let tokensByModel: [String: Int]
+
+    // Shipped (merged + pushed) tokens per agent, paired with tokensByAgent to
+    // give each agent's shipped share: which agent's work actually merges.
+    let shippedTokensByAgent: [String: Int]
+
+    // The heaviest-spend groups in the window, most tokens first, for the
+    // drill-down list. Bounded to Insights.maxTopTickets.
+    let topTickets: [TicketSpend]
+
+    // Shipped share of total effort. 0 when nothing ran, so the headline reads
+    // "0% shipped" on an empty window rather than dividing by zero.
+    var shippedShare: Double {
+        guard totalTokens > 0 else { return 0 }
+        return Double(tokensByBucket[.shipped] ?? 0) / Double(totalTokens)
+    }
+}
+
+enum Insights {
+
+    // A branch quiet for this long with unshipped work reads as abandoned. Only
+    // meaningful once the window is at least this wide: a 7-day window cannot
+    // contain a branch that has been quiet for 14 days, so its abandoned bucket
+    // is naturally empty. Overridable in summarize() for tests.
+    static let defaultStaleness: TimeInterval = 14 * 86_400
+
+    // How many rows the top-tickets drill-down shows.
+    static let maxTopTickets = 6
+
+    // Highest (most-shipped) status wins when a group spans branches at
+    // different stages: a ticket with one merged branch reads "merged".
+    private static let statusPrecedence: [OutcomeStatus] = [.merged, .pushed, .committed, .needsReview, .clean]
+
+    static func summarize(records: [HandoffRecord],
+                          outcomeByBranch: [String: OutcomeStatus],
+                          pullRequestByBranch: [String: PullRequestInfo],
+                          now: Date,
+                          window: TimeInterval,
+                          staleness: TimeInterval = defaultStaleness) -> InsightsSummary {
+        let windowStart = now.addingTimeInterval(-window)
+        let inWindow = records.filter { $0.updatedAt >= windowStart && $0.updatedAt <= now }
+
+        // Per-branch last activity, for the abandoned test. Max updatedAt over
+        // the branch's in-window records; a branch spans multiple session rows.
+        var lastActivityByBranch: [String: Date] = [:]
+        for record in inWindow {
+            let key = PanelNav.outcomeKey(record.repoRoot, record.branch)
+            if let seen = lastActivityByBranch[key], seen >= record.updatedAt { continue }
+            lastActivityByBranch[key] = record.updatedAt
+        }
+
+        var tokensByBucket: [SpendBucket: Int] = [:]
+        var tokensByStatus: [OutcomeStatus: Int] = [:]
+        var tokensByAgent: [String: Int] = [:]
+        var shippedTokensByAgent: [String: Int] = [:]
+        var tokensByModel: [String: Int] = [:]
+        var tickets = Set<String>()
+        var total = 0
+
+        for record in inWindow {
+            let tokens = record.contextTokens ?? 0
+            total += tokens
+
+            let key = PanelNav.outcomeKey(record.repoRoot, record.branch)
+            let status = OutcomeWatcher.effective(local: outcomeByBranch[key],
+                                                  pr: pullRequestByBranch[key])
+            if let status { tokensByStatus[status, default: 0] += tokens }
+
+            let bucket = spendBucket(status: status,
+                                     branchLastActivity: lastActivityByBranch[key],
+                                     now: now, staleness: staleness)
+            tokensByBucket[bucket, default: 0] += tokens
+
+            let agent = Agent.canonical(record.agent)
+            tokensByAgent[agent, default: 0] += tokens
+            if bucket == .shipped { shippedTokensByAgent[agent, default: 0] += tokens }
+            if let model = record.model { tokensByModel[model, default: 0] += tokens }
+
+            if let ticket = record.ticket ?? TicketAttribution.ticket(branch: record.branch) {
+                tickets.insert(ticket)
+            }
+        }
+
+        // Reuse the Tickets tab's grouping so the drill-down agrees with it, then
+        // classify each group and keep the heaviest.
+        let topTickets = OutcomesView.groups(from: inWindow)
+            .map { group -> TicketSpend in
+                let status = dominantStatus(branches: group.branches,
+                                            outcomeByBranch: outcomeByBranch,
+                                            pullRequestByBranch: pullRequestByBranch)
+                let lastActivity = groupLastActivity(branches: group.branches,
+                                                     lastActivityByBranch: lastActivityByBranch)
+                return TicketSpend(
+                    id: group.id, label: group.label, isTicket: group.isTicket,
+                    tokens: group.totalTokens, status: status,
+                    bucket: spendBucket(status: status, branchLastActivity: lastActivity,
+                                        now: now, staleness: staleness),
+                    prURL: groupPRURL(branches: group.branches, pullRequestByBranch: pullRequestByBranch))
+            }
+            .sorted { $0.tokens > $1.tokens }
+            .prefix(maxTopTickets)
+
+        return InsightsSummary(
+            window: DateInterval(start: windowStart, end: now),
+            totalTokens: total,
+            sessionCount: inWindow.count,
+            ticketCount: tickets.count,
+            tokensByBucket: tokensByBucket,
+            tokensByStatus: tokensByStatus,
+            tokensByAgent: tokensByAgent,
+            tokensByModel: tokensByModel,
+            shippedTokensByAgent: shippedTokensByAgent,
+            topTickets: Array(topTickets))
+    }
+
+    // Highest-precedence effective status across a group's branches, or nil when
+    // none has resolved yet.
+    static func dominantStatus(branches: [BranchBreakdown],
+                               outcomeByBranch: [String: OutcomeStatus],
+                               pullRequestByBranch: [String: PullRequestInfo]) -> OutcomeStatus? {
+        var best: OutcomeStatus?
+        for branch in branches {
+            let key = PanelNav.outcomeKey(branch.repoRoot, branch.branch)
+            guard let status = OutcomeWatcher.effective(local: outcomeByBranch[key],
+                                                        pr: pullRequestByBranch[key]),
+                  let rank = statusPrecedence.firstIndex(of: status) else { continue }
+            if best == nil || rank < (statusPrecedence.firstIndex(of: best!) ?? .max) {
+                best = status
+            }
+        }
+        return best
+    }
+
+    // A PR to open for the group: prefer a merged one, else the first present.
+    static func groupPRURL(branches: [BranchBreakdown],
+                           pullRequestByBranch: [String: PullRequestInfo]) -> String? {
+        var firstURL: String?
+        for branch in branches {
+            let key = PanelNav.outcomeKey(branch.repoRoot, branch.branch)
+            guard let pr = pullRequestByBranch[key] else { continue }
+            if pr.state == .merged { return pr.url }
+            if firstURL == nil { firstURL = pr.url }
+        }
+        return firstURL
+    }
+
+    private static func groupLastActivity(branches: [BranchBreakdown],
+                                          lastActivityByBranch: [String: Date]) -> Date? {
+        var latest: Date?
+        for branch in branches {
+            let key = PanelNav.outcomeKey(branch.repoRoot, branch.branch)
+            guard let activity = lastActivityByBranch[key] else { continue }
+            if latest == nil || activity > latest! { latest = activity }
+        }
+        return latest
+    }
+
+    // Collapse an effective status + branch recency into a spend bucket. Missing
+    // status (branch not yet resolved) and `clean` both read as in-flight: they
+    // are neither shipped nor demonstrably abandoned.
+    static func spendBucket(status: OutcomeStatus?,
+                            branchLastActivity: Date?,
+                            now: Date,
+                            staleness: TimeInterval) -> SpendBucket {
+        switch status {
+        case .merged, .pushed:
+            return .shipped
+        case .committed, .needsReview:
+            if let last = branchLastActivity, now.timeIntervalSince(last) > staleness {
+                return .abandoned
+            }
+            return .inFlight
+        case .clean, .none:
+            return .inFlight
+        }
+    }
+}

--- a/panel/InsightsView.swift
+++ b/panel/InsightsView.swift
@@ -1,0 +1,223 @@
+import SwiftUI
+
+// The Insights tab: a spend-to-outcome overview over the handoff ledger. Reads
+// the same per-branch outcome/PR maps the Tickets tab computes (nav.outcomeByBranch
+// / nav.pullRequestByBranch), so shipped vs in-flight vs abandoned agrees with
+// that tab. Step 1 is token-only (contextTokens, the effort proxy the Tickets tab
+// shows); dollar cost and reclaimed-time land in later steps.
+//
+// The rollup is recomputed in `body`: it's a cheap in-memory pass over the
+// bounded ledger, and reading nav's published maps + handoffsRevision means
+// SwiftUI re-runs it exactly when the inputs change, so no separate cache is
+// needed.
+struct InsightsView: View {
+    @ObservedObject var nav: PanelNav
+
+    var body: some View {
+        _ = nav.handoffsRevision   // re-run when a Stop adds a ledger row
+        let summary = nav.insightsSummary()
+        // Match the other tabs: content fills the pane with its own padding, and
+        // the key hints sit in a shared PageFooter (divider + subtle bar), not a
+        // bare row.
+        return VStack(alignment: .leading, spacing: 0) {
+            // Scroll the content so a tall window (many tickets/agents) can't push
+            // the header off the top or collide with the footer; the footer stays
+            // pinned outside the ScrollView. Matches the Sessions/Tickets tabs.
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    header
+                    if summary.sessionCount == 0 {
+                        emptyState
+                    } else {
+                        shippedHeadline(summary)
+                        spendBar(summary)
+                        bucketLegend(summary)
+                        if !summary.topTickets.isEmpty { topTicketsSection(summary) }
+                        if !summary.tokensByAgent.isEmpty { agentSection(summary) }
+                        if !summary.tokensByModel.isEmpty { modelSection(summary.tokensByModel) }
+                    }
+                }
+                .padding(14)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .background(ThinScrollers())
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            PageFooter {
+                FooterHint(label: "Scroll", keys: ["↑↓"])
+                FooterHint(label: "Window", keys: ["W"])
+                FooterHint(label: "Tickets", keys: ["→"])
+                FooterHint(label: "Hide", keys: ["Esc"])
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .onAppear {
+            // Populate the outcome/PR maps the same way the Tickets tab does, so
+            // opening Insights first (without Tickets) still resolves shipped state.
+            nav.refreshOutcomes?()
+            nav.refreshPullRequests?()
+        }
+    }
+
+    // MARK: - Sections
+
+    private var header: some View {
+        HStack {
+            Text("Insights").font(.system(size: 14, weight: .semibold))
+            Spacer()
+            Button { nav.cycleInsightsWindow() } label: {
+                Text(nav.insightsWindow.label)
+                    .font(.caption).fontWeight(.medium)
+                    .padding(.horizontal, 8).padding(.vertical, 3)
+                    .background(Capsule().fill(Color.accentColor.opacity(0.15)))
+                    .foregroundStyle(Color.accentColor)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private func shippedHeadline(_ summary: InsightsSummary) -> some View {
+        let pct = Int((summary.shippedShare * 100).rounded())
+        return VStack(alignment: .leading, spacing: 2) {
+            (Text("\(pct)% shipped").font(.system(size: 22, weight: .bold))
+             + Text("  ·  \(TokenFormat.short(summary.totalTokens)) tokens")
+                .font(.system(size: 13)).foregroundColor(.secondary))
+            Text("\(summary.sessionCount) sessions · \(summary.ticketCount) tickets")
+                .font(.caption).foregroundStyle(.secondary)
+        }
+    }
+
+    private func spendBar(_ summary: InsightsSummary) -> some View {
+        let segments = SpendBucket.allCases.compactMap { bucket -> (bucket: SpendBucket, tokens: Int)? in
+            let tokens = summary.tokensByBucket[bucket] ?? 0
+            return tokens > 0 ? (bucket, tokens) : nil
+        }
+        let total = max(1, segments.reduce(0) { $0 + $1.tokens })
+        return GeometryReader { geo in
+            HStack(spacing: 1) {
+                ForEach(segments, id: \.bucket) { segment in
+                    Rectangle()
+                        .fill(color(for: segment.bucket))
+                        .frame(width: geo.size.width * CGFloat(segment.tokens) / CGFloat(total))
+                }
+            }
+        }
+        .frame(height: 14)
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+    }
+
+    private func bucketLegend(_ summary: InsightsSummary) -> some View {
+        let total = max(1, summary.totalTokens)
+        return HStack(spacing: 14) {
+            ForEach(SpendBucket.allCases, id: \.self) { bucket in
+                let tokens = summary.tokensByBucket[bucket] ?? 0
+                if tokens > 0 {
+                    HStack(spacing: 5) {
+                        Circle().fill(color(for: bucket)).frame(width: 8, height: 8)
+                        Text(bucket.label).font(.caption)
+                        Text("\(TokenFormat.short(tokens)) · \(Int((Double(tokens) / Double(total) * 100).rounded()))%")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+
+    // Model mix as wrapping pills. Names are shortened (ModelName.short drops the
+    // redundant "claude-" prefix and any date stamp) and kept to one line, so a
+    // long id can't wrap mid-word; FlowLayout wraps whole pills to the next row.
+    private func modelSection(_ tokensByModel: [String: Int]) -> some View {
+        let items = tokensByModel.sorted { $0.value > $1.value }.prefix(6)
+        return VStack(alignment: .leading, spacing: 6) {
+            Text("Models").font(.caption).foregroundStyle(.secondary)
+            FlowLayout(spacing: 6, rowSpacing: 6) {
+                ForEach(Array(items), id: \.key) { item in
+                    HStack(spacing: 5) {
+                        Text(ModelName.short(item.key)).font(.caption).fontWeight(.medium)
+                        Text(TokenFormat.short(item.value)).font(.caption).foregroundStyle(.secondary)
+                    }
+                    .lineLimit(1)
+                    .fixedSize()
+                    .padding(.horizontal, 8).padding(.vertical, 4)
+                    .background(RoundedRectangle(cornerRadius: 6).fill(Color.secondary.opacity(0.12)))
+                }
+            }
+        }
+    }
+
+    // Heaviest-spend tickets/repos, with a bucket dot, dominant status, and token
+    // total. Click a row to open its ticket/PR.
+    private func topTicketsSection(_ summary: InsightsSummary) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text("Top tickets by spend").font(.caption).foregroundStyle(.secondary)
+            VStack(spacing: 2) {
+                ForEach(summary.topTickets) { ticket in
+                    topTicketRow(ticket)
+                }
+            }
+        }
+    }
+
+    private func topTicketRow(_ ticket: TicketSpend) -> some View {
+        HStack(spacing: 8) {
+            Circle().fill(color(for: ticket.bucket)).frame(width: 8, height: 8)
+            Text(ticket.label).font(.system(size: 12, weight: .medium)).lineLimit(1)
+            Spacer(minLength: 8)
+            if let status = ticket.status {
+                Text(statusLabel(status)).font(.caption2).foregroundStyle(.secondary)
+            }
+            Text(TokenFormat.short(ticket.tokens)).font(.caption).foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 8).padding(.vertical, 4)
+        .contentShape(Rectangle())
+        .onTapGesture { nav.openInsightTicket(ticket) }
+    }
+
+    // Agent mix with each agent's shipped share: which agent's work actually merges.
+    private func agentSection(_ summary: InsightsSummary) -> some View {
+        let agents = summary.tokensByAgent.sorted { $0.value > $1.value }
+        return VStack(alignment: .leading, spacing: 5) {
+            Text("Agents").font(.caption).foregroundStyle(.secondary)
+            VStack(spacing: 2) {
+                ForEach(agents, id: \.key) { agent, tokens in
+                    let shipped = summary.shippedTokensByAgent[agent] ?? 0
+                    let share = tokens > 0 ? Int((Double(shipped) / Double(tokens) * 100).rounded()) : 0
+                    HStack(spacing: 8) {
+                        Text(agent).font(.system(size: 12, weight: .medium))
+                        Spacer(minLength: 8)
+                        Text(TokenFormat.short(tokens)).font(.caption).foregroundStyle(.secondary)
+                        Text("\(share)% shipped").font(.caption2).foregroundStyle(.secondary)
+                    }
+                    .padding(.horizontal, 8).padding(.vertical, 3)
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("No sessions in this window.").font(.system(size: 13, weight: .medium))
+            Text("Finish an agent turn inside a git repo, or widen the window with W.")
+                .font(.caption).foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 8)
+    }
+
+    private func statusLabel(_ status: OutcomeStatus) -> String {
+        switch status {
+        case .merged:      return "merged"
+        case .pushed:      return "pushed"
+        case .committed:   return "committed"
+        case .needsReview: return "needs review"
+        case .clean:       return "clean"
+        }
+    }
+
+    private func color(for bucket: SpendBucket) -> Color {
+        switch bucket {
+        case .shipped:   return .green
+        case .inFlight:  return .blue
+        case .abandoned: return .orange
+        }
+    }
+}

--- a/panel/OutcomeWatcher.swift
+++ b/panel/OutcomeWatcher.swift
@@ -31,6 +31,21 @@ struct OutcomeInputs: Equatable {
 // needsReview > clean.
 enum OutcomeWatcher {
 
+    // The user-facing "did it ship?" status: a known PR state supersedes the
+    // local git heuristic, because a squash-merged branch only reads as `.merged`
+    // through its PR (its commits never land on the base by ancestry). Open means
+    // at least pushed; closed-not-merged falls back to the local truth. This is
+    // the single definition the Tickets tab (OutcomesView) and the Insights
+    // rollup both read, so the two cannot drift.
+    static func effective(local: OutcomeStatus?, pr: PullRequestInfo?) -> OutcomeStatus? {
+        guard let pr else { return local }
+        switch pr.state {
+        case .merged: return .merged
+        case .open:   return .pushed
+        case .closed: return local
+        }
+    }
+
     // Local default branch first — it's the one the user keeps pulled, and in a
     // fork workflow `origin/main` (the fork) can lag the real mainline. Falls
     // back to the fork's, then the upstream's, default branch.

--- a/panel/OutcomesView.swift
+++ b/panel/OutcomesView.swift
@@ -69,6 +69,25 @@ struct TicketGroup: Identifiable, Equatable {
 // for unticketed work), shows the branches beneath each group, and deep-links
 // each ticket row to its tracker when STACKNUDGE_TICKET_URL is
 // set. Pure read over data the ledger already holds; no capture, no network.
+
+// The Outcomes tab: a two-pane carousel over one dataset. Lands on the Insights
+// overview (the aggregate); → carousels into the per-ticket list, ← back (key
+// handling lives in PanelController.keyDown, mode == .outcomes). Resets to the
+// overview each time the tab opens.
+struct OutcomesTabView: View {
+    @ObservedObject var nav: PanelNav
+
+    var body: some View {
+        Group {
+            switch nav.outcomesPane {
+            case .overview: InsightsView(nav: nav)
+            case .tickets:  OutcomesView(nav: nav)
+            }
+        }
+        .onAppear { nav.outcomesPane = .overview }
+    }
+}
+
 struct OutcomesView: View {
 
     @ObservedObject var nav: PanelNav
@@ -88,6 +107,14 @@ struct OutcomesView: View {
             if groups.isEmpty {
                 emptyState
             } else {
+                // Count lives in the content (like the Overview pane), not the
+                // footer, so the footer stays within the panel width.
+                HStack {
+                    Text(countSummary(groups)).font(.caption).foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .padding(.horizontal, 14)
+                .padding(.top, 10)
                 ScrollViewReader { proxy in
                     ScrollView {
                         // Lazy, like the Sessions and Events lists. A plain VStack
@@ -138,13 +165,12 @@ struct OutcomesView: View {
             }
 
             PageFooter {
-                FooterHint(label: footerStatus(groups), keys: [])
                 if !groups.isEmpty {
                     FooterHint(label: "Select", keys: ["↑↓"])
-                    FooterHint(label: "Top/Bottom", keys: ["⌘↑↓"])
                     FooterHint(label: "Open", keys: ["↵"])
                     FooterHint(label: "Remove", keys: ["⌫"])
                 }
+                FooterHint(label: "Overview", keys: ["←"])
                 FooterHint(label: "Hide", keys: ["Esc"])
             }
         }
@@ -339,14 +365,7 @@ struct OutcomesView: View {
     // how a squash-merged branch finally reads as "merged". Open → at least
     // pushed; closed-not-merged falls back to the local truth.
     private func effectiveStatus(for branch: BranchBreakdown) -> OutcomeStatus? {
-        if let pr = prInfo(for: branch) {
-            switch pr.state {
-            case .merged: return .merged
-            case .open:   return .pushed
-            case .closed: return outcome(for: branch)
-            }
-        }
-        return outcome(for: branch)
+        OutcomeWatcher.effective(local: outcome(for: branch), pr: prInfo(for: branch))
     }
 
     // Counts of each non-clean status across the group's branches (PR state
@@ -596,7 +615,7 @@ struct OutcomesView: View {
 
     // MARK: - Footer + empty state
 
-    private func footerStatus(_ groups: [TicketGroup]) -> String {
+    private func countSummary(_ groups: [TicketGroup]) -> String {
         guard !groups.isEmpty else { return "No tracked sessions" }
         let sessions = groups.reduce(0) { $0 + $1.sessionCount }
         let groupWord = groups.count == 1 ? "group" : "groups"

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -133,7 +133,7 @@ struct PanelContentView: View {
                 case .events:   eventsBody
                 case .sessions: SessionsView(store: sessions, events: store, nav: nav)
                 case .usage:    UsageView(nav: nav)
-                case .outcomes: OutcomesView(nav: nav)
+                case .outcomes: OutcomesTabView(nav: nav)
                 case .settings: SettingsView(nav: nav)
                 case .phrases:  PhrasesView(model: phrases) { nav.mode = .settings }
                 case .updateConfirm:
@@ -175,7 +175,7 @@ struct PanelContentView: View {
             tab(.events,   label: "Events",   count: store.events.count)
             tab(.sessions, label: "Sessions", count: sessions.liveSessions.count)
             tab(.usage,    label: "Usage",    count: 0)
-            tab(.outcomes, label: "Tickets",  count: ticketGroupCount)
+            tab(.outcomes, label: "Outcomes", count: ticketGroupCount)
             tab(.settings, label: "Settings", count: 0,
                 dotColor: !nav.missingPermissions.isEmpty ? .orange
                         : nav.updateAvailable != nil ? .accentColor
@@ -2769,20 +2769,42 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
             return true
         }
 
-        // Tickets tab: ↑/↓ move the row selection, →/Enter open the selected
-        // row's ticket/PR link, Esc hides. Other keys are swallowed so they
-        // don't leak through to the events store.
+        // Outcomes tab: a two-pane carousel. The Overview pane (Insights) is a
+        // scroll page — ↑/↓ scroll, ⌘↑/↓ jump (see jumpToEdge), W cycles the
+        // window, → steps into the Tickets list, and ticket rows open on click.
+        // The Tickets pane is a list — ↑/↓ move the selection, ⏎ opens the row,
+        // ⌫ dismisses, ← steps back to the Overview. Other plain keys are
+        // swallowed so they don't leak through to the events store.
         if nav.mode == .outcomes {
             let plain = mods.intersection([.command, .control, .option, .shift]).isEmpty
             guard plain else { return false }
+            if nav.outcomesPane == .overview {
+                switch event.keyCode {
+                case KeyCode.escape:
+                    hidePanel()
+                case KeyCode.upArrow:
+                    scrollDetailBy(-40)
+                case KeyCode.downArrow:
+                    scrollDetailBy(40)
+                case KeyCode.rightArrow:
+                    nav.outcomesPane = .tickets
+                case KeyCode.wKey:
+                    nav.cycleInsightsWindow()
+                default:
+                    break
+                }
+                return true
+            }
             switch event.keyCode {
             case KeyCode.escape:
                 hidePanel()
+            case KeyCode.leftArrow:
+                nav.outcomesPane = .overview
             case KeyCode.upArrow:
                 nav.moveOutcomeSelection(-1)
             case KeyCode.downArrow:
                 nav.moveOutcomeSelection(1)
-            case KeyCode.rightArrow, KeyCode.returnKey, KeyCode.numpadEnter:
+            case KeyCode.returnKey, KeyCode.numpadEnter:
                 nav.activateSelectedOutcome()
             case KeyCode.delete, KeyCode.forwardDelete:
                 nav.dismissSelectedOutcome()
@@ -2959,7 +2981,9 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                 top ? nav.selectFirstUsageClient() : nav.selectLastUsageClient()
             }
         case .outcomes:
-            nav.jumpOutcomeSelection(toLast: !top)
+            // Overview pane scrolls; the tickets list jumps its selection.
+            if nav.outcomesPane == .overview { scrollDetailToEdge(top: top) }
+            else { nav.jumpOutcomeSelection(toLast: !top) }
         case .settings:
             top ? nav.selectFirstRow() : nav.selectLastRow()
         case .phrases:

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -28,6 +28,13 @@ enum PanelMode {
     case uninstall
 }
 
+// The two panes of the Outcomes tab, carousel-ordered: the Insights aggregate,
+// then the per-ticket list.
+enum OutcomesPane {
+    case overview
+    case tickets
+}
+
 // Action callbacks the controller wires into nav so settings rows like
 // "Check permissions" / "Open config" / "Quit" can fire effects without the
 // SwiftUI view needing to know about windows or app-level state.
@@ -296,6 +303,42 @@ final class PanelNav: ObservableObject {
     // in-memory HandoffLedger and reflect the new session live. The ledger
     // isn't itself observable; this is the single change-signal that drives it.
     @Published var handoffsRevision: Int = 0 { didSet { cachedOutcomeGroups = nil } }
+    // Trailing window the Insights tab summarises over. Cycled by `W`; the view
+    // recomputes the (cheap, in-memory) rollup whenever this or the outcome maps
+    // change, so no separate cache is needed.
+    // Which pane of the Outcomes tab is showing. The tab lands on .overview (the
+    // Insights aggregate); → carousels into .tickets (the per-ticket list), ←
+    // back. Reset to .overview each time the tab opens (see OutcomesTabView).
+    @Published var outcomesPane: OutcomesPane = .overview
+
+    @Published var insightsWindow: InsightsWindow = .week
+    func cycleInsightsWindow() {
+        let all = InsightsWindow.allCases
+        guard let idx = all.firstIndex(of: insightsWindow) else { return }
+        insightsWindow = all[(idx + 1) % all.count]
+    }
+    // The current Insights rollup. Computed here (not only in the view) so it's
+    // a single source the view reads.
+    func insightsSummary() -> InsightsSummary {
+        Insights.summarize(
+            records: HandoffLedger.shared.all(),
+            outcomeByBranch: outcomeByBranch,
+            pullRequestByBranch: pullRequestByBranch,
+            now: Date(),
+            window: insightsWindow.seconds)
+    }
+
+    // Open a top-ticket row (on click): its tracker link when it's a ticket and
+    // STACKNUDGE_TICKET_URL is set, else its PR. Mirrors activateSelectedOutcome.
+    func openInsightTicket(_ ticket: TicketSpend) {
+        if ticket.isTicket,
+           let template = ConfigFile.read()["STACKNUDGE_TICKET_URL"], template.contains("{key}"),
+           let url = URL(string: template.replacingOccurrences(of: "{key}", with: ticket.label)) {
+            NSWorkspace.shared.open(url)
+            return
+        }
+        if let prURL = ticket.prURL, let url = URL(string: prURL) { NSWorkspace.shared.open(url) }
+    }
     // Memoized grouping of the ledger (the expensive part: regex ticket
     // attribution + branch breakdown + sorts). Invalidated only when the ledger
     // changes (handoffsRevision) — NOT on selection moves, so holding ↑/↓ on the

--- a/panel/Sessions.swift
+++ b/panel/Sessions.swift
@@ -346,21 +346,9 @@ private struct SessionRow: View {
         // the model ID. Showing the model name keeps the row honest.
         let tokens = "\(TokenFormat.short(stats.tokens)) tokens"
         if let model = stats.model {
-            return "\(tokens) · \(Self.shortModel(model))"
+            return "\(tokens) · \(ModelName.short(model))"
         }
         return tokens
-    }
-
-    // Strip the date suffix Anthropic appends to model IDs
-    // (e.g. "claude-opus-4-7-20250606" → "opus-4-7") and the
-    // redundant "claude-" prefix.
-    private static func shortModel(_ id: String) -> String {
-        var s = id.hasPrefix("claude-") ? String(id.dropFirst("claude-".count)) : id
-        if let dash = s.range(of: "-2", options: .backwards),
-           s[dash.lowerBound...].dropFirst().allSatisfy(\.isNumber) {
-            s = String(s[..<dash.lowerBound])
-        }
-        return s
     }
 
 


### PR DESCRIPTION
## What

Adds an **Insights** overview and folds it in with the existing per-ticket view as one **Outcomes** tab (`⌘4`), so usage and outcomes live together. No new capture: it reads the same handoff ledger plus the per-branch outcome/PR state the ticket view already computes, so the two agree by construction.

## The Outcomes tab (two panes)

Lands on the **Overview** (the aggregate); `→` carousels into the **Tickets** list, `←` back (mirrors the Usage tab's pane carousel). Settings stays at `⌘5`.

**Overview** (a scroll page: `↑↓` scroll, `⌘↑↓` jump, `W` cycles the window):

- **Shipped share** headline: of the tokens spent in a trailing window (24h / 7d / 30d / 90d), how much sits on merged/pushed work versus in-flight versus abandoned (committed/needs-review gone quiet for over 14 days).
- **Spend bar** partitioning tokens across those three buckets.
- **Top tickets by spend**: the heaviest tickets/repos with their dominant outcome; click a row to open the ticket (`STACKNUDGE_TICKET_URL`) or its PR.
- **Agents**: the token mix plus each agent's shipped share (whose work actually merges), and a **Models** mix rendered as shortened, wrapping pills.

**Tickets**: the existing per-ticket rollup, unchanged, now reached with `→` / `←`.

## Design notes

- `Insights.summarize(...)` is pure (no I/O) and unit-tested; it rolls up over the ledger plus the outcome/PR maps.
- Extracted `OutcomeWatcher.effective(local:pr:)` so both panes share one "did it ship?" definition (a squash-merged branch reads shipped in each).
- Promoted the model-name shortener to a shared `ModelName.short` (used by Sessions and Insights) and added a small `FlowLayout` so the model pills wrap instead of compressing.
- Token-only for now (`contextTokens`, the same effort proxy the ticket view shows); per-model dollar cost and reclaimed-time are planned follow-ups.

## Testing

- `InsightsTests`: bucket math, shipped-share, the staleness cutoff, PR-supersedes-local, top-tickets ranking and dominant-status precedence, per-agent shipped share, window boundary, and empty/nil cases.
- `scripts/typecheck-tests.sh` is green; assertions were verified locally via an in-module harness (`swift test` needs Xcode, so CI runs the real suite).
