### PR TITLE
feat(panel): capture codex sessions in the outcomes tab

### DIFF
--- a/Tests/StackNudgePanelCoreTests/BootstrapTests.swift
+++ b/Tests/StackNudgePanelCoreTests/BootstrapTests.swift
@@ -158,6 +158,50 @@ final class BootstrapTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: path))
     }
 
+    // A stamp-only version bump (which release-please does on every release) must
+    // NOT rewrite the script: rewriting would reset Codex's hook-trust hash and
+    // silently disable codex capture until the user re-trusts via /hooks.
+    func test_refreshNotifyScript_skipsAStampOnlyBump() throws {
+        let dir = try temporaryDirectory()
+        let path = dir.appendingPathComponent("notify.sh").path
+        let installed = "#!/usr/bin/env bash\n# stack-nudge-version: 1.26.0\necho same\n"
+        try installed.write(toFile: path, atomically: true, encoding: .utf8)
+        let bundled = "#!/usr/bin/env bash\n# stack-nudge-version: 1.27.0\necho same\n"
+
+        XCTAssertNil(Bootstrap.refreshNotifyScript(bundled: bundled, installedPath: path))
+        XCTAssertEqual(try String(contentsOfFile: path, encoding: .utf8), installed)
+    }
+
+    func test_refreshNotifyScript_rewritesOnALogicChange() throws {
+        let dir = try temporaryDirectory()
+        let path = dir.appendingPathComponent("notify.sh").path
+        try "#!/usr/bin/env bash\n# stack-nudge-version: 1.26.0\necho old\n"
+            .write(toFile: path, atomically: true, encoding: .utf8)
+        let bundled = "#!/usr/bin/env bash\n# stack-nudge-version: 1.27.0\necho new\n"
+
+        XCTAssertEqual(Bootstrap.refreshNotifyScript(bundled: bundled, installedPath: path), "1.27.0")
+        XCTAssertEqual(try String(contentsOfFile: path, encoding: .utf8), bundled)
+    }
+
+    func test_notifyScriptOutdated_falseForAStampOnlyDifference_trueForALogicChange() throws {
+        let dir = try temporaryDirectory()
+        let path = dir.appendingPathComponent("notify.sh").path
+        try "#!/usr/bin/env bash\n# stack-nudge-version: 1.26.0\necho same\n"
+            .write(toFile: path, atomically: true, encoding: .utf8)
+        XCTAssertFalse(Bootstrap.notifyScriptOutdated(
+            bundled: "#!/usr/bin/env bash\n# stack-nudge-version: 1.27.0\necho same\n", installedPath: path))
+        XCTAssertTrue(Bootstrap.notifyScriptOutdated(
+            bundled: "#!/usr/bin/env bash\n# stack-nudge-version: 1.27.0\necho changed\n", installedPath: path))
+    }
+
+    func test_functionalContent_neutralisesTheVersionStamp() {
+        let v1 = "#!/usr/bin/env bash\n# stack-nudge-version: 1.26.0 # x-release-please-version\necho hi\n"
+        let v2 = "#!/usr/bin/env bash\n# stack-nudge-version: 9.9.9 # x-release-please-version\necho hi\n"
+        XCTAssertEqual(Bootstrap.functionalContent(v1), Bootstrap.functionalContent(v2))
+        let changed = "#!/usr/bin/env bash\n# stack-nudge-version: 1.26.0\necho DIFFERENT\n"
+        XCTAssertNotEqual(Bootstrap.functionalContent(v1), Bootstrap.functionalContent(changed))
+    }
+
     // MARK: - Helpers
 
     private func temporaryDirectory() throws -> URL {

--- a/Tests/StackNudgePanelCoreTests/CodexTranscriptReaderTests.swift
+++ b/Tests/StackNudgePanelCoreTests/CodexTranscriptReaderTests.swift
@@ -20,6 +20,41 @@ final class CodexTranscriptReaderTests: XCTestCase {
         return path
     }
 
+    // Build a fake ~/.codex/sessions tree with one rollout for `sessionID` under
+    // YYYY/MM/DD, returning the root to pass to rolloutPath(forSessionID:root:).
+    private func writeSessionsTree(sessionID: String, day: String = "2026/08/10") -> (root: String, path: String) {
+        let root = NSTemporaryDirectory() + "codex-sessions-\(UUID().uuidString)"
+        let dayDir = "\(root)/\(day)"
+        try? FileManager.default.createDirectory(atPath: dayDir, withIntermediateDirectories: true)
+        let path = "\(dayDir)/rollout-2026-08-10T12-05-45-\(sessionID).jsonl"
+        try? "{}\n".write(toFile: path, atomically: true, encoding: .utf8)
+        return (root, path)
+    }
+
+    func test_rolloutPath_findsRolloutBySessionIdSuffix() {
+        let sid = "019feb59-9aec-7480-b180-7e8b1cb64117"
+        let tree = writeSessionsTree(sessionID: sid)
+        XCTAssertEqual(CodexTranscriptReader.rolloutPath(forSessionID: sid, root: tree.root), tree.path)
+    }
+
+    func test_rolloutPath_nilWhenNoMatchOrEmptyId() {
+        let tree = writeSessionsTree(sessionID: "aaaa")
+        XCTAssertNil(CodexTranscriptReader.rolloutPath(forSessionID: "bbbb", root: tree.root))
+        XCTAssertNil(CodexTranscriptReader.rolloutPath(forSessionID: "", root: tree.root))
+    }
+
+    func test_rolloutPath_walksNewestDayFirst() {
+        let sid = "dup"
+        let root = NSTemporaryDirectory() + "codex-sessions-\(UUID().uuidString)"
+        for day in ["2026/08/09", "2026/08/10"] {
+            let dayDir = "\(root)/\(day)"
+            try? FileManager.default.createDirectory(atPath: dayDir, withIntermediateDirectories: true)
+            try? "{}\n".write(toFile: "\(dayDir)/rollout-x-\(sid).jsonl", atomically: true, encoding: .utf8)
+        }
+        XCTAssertEqual(CodexTranscriptReader.rolloutPath(forSessionID: sid, root: root),
+                       "\(root)/2026/08/10/rollout-x-\(sid).jsonl")
+    }
+
     func test_read_usesContextOccupancyFromLatestTokenCount() {
         let path = writeRollout([
             #"{"type":"session_meta","payload":{"id":"s1","model":"gpt-5-codex"}}"#,

--- a/panel/Bootstrap.swift
+++ b/panel/Bootstrap.swift
@@ -172,13 +172,12 @@ enum Bootstrap {
     @discardableResult
     static func refreshNotifyScript(bundled bundledScript: String?,
                                     installedPath: String) -> String? {
-        guard FileManager.default.fileExists(atPath: installedPath),
-              let bundledScript
+        guard let bundledScript,
+              notifyScriptOutdated(bundled: bundledScript, installedPath: installedPath)
         else { return nil }
-        let bundled = notifyVersion(inScript: bundledScript)
         let installed = (try? String(contentsOfFile: installedPath, encoding: .utf8))
             .flatMap { notifyVersion(inScript: $0) }
-        guard needsNotifyRefresh(installed: installed, bundled: bundled) else { return nil }
+        let bundled = notifyVersion(inScript: bundledScript)
         do {
             try writeNotifyScript(bundledScript, to: installedPath)
             log("refreshed notify.sh: \(installed ?? "unstamped") -> \(bundled ?? "unstamped")")
@@ -187,6 +186,35 @@ enum Bootstrap {
             log("failed to refresh notify.sh: \(error.localizedDescription)")
             return nil
         }
+    }
+
+    // Whether the refresh above would actually rewrite the installed script.
+    // Two gates: the stamp must differ (a matching stamp means "same protocol,
+    // leave local tweaks alone"), AND the logic must have genuinely changed. The
+    // second gate is why a stamp-only release (release-please bumps the stamp on
+    // every version) does NOT rewrite: rewriting would reset Codex's hook-trust
+    // hash, silently disabling codex capture until the user re-trusts via /hooks.
+    // Shared with the Settings "hook script stale" footer so the two agree.
+    static func notifyScriptOutdated(bundled bundledScript: String?,
+                                     installedPath: String) -> Bool {
+        guard let bundledScript,
+              let installedScript = try? String(contentsOfFile: installedPath, encoding: .utf8)
+        else { return false }
+        guard needsNotifyRefresh(installed: notifyVersion(inScript: installedScript),
+                                 bundled: notifyVersion(inScript: bundledScript))
+        else { return false }
+        return functionalContent(bundledScript) != functionalContent(installedScript)
+    }
+
+    // notify.sh with the release-please version-stamp line neutralised and
+    // trailing newlines trimmed, so two copies that differ only by their version
+    // (or a stray trailing newline) compare equal.
+    static func functionalContent(_ script: String) -> String {
+        script
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { $0.contains("stack-nudge-version:") ? "" : String($0) }
+            .joined(separator: "\n")
+            .trimmingCharacters(in: .newlines)
     }
 
     // Write the hook script and make it executable, swapping it in atomically:

--- a/panel/CodexTranscriptStats.swift
+++ b/panel/CodexTranscriptStats.swift
@@ -61,6 +61,36 @@ enum CodexTranscriptReader {
         return TranscriptStats(tokens: tokens, model: model)
     }
 
+    // Locate the rollout file for a Codex session id. Codex's Stop hook may send
+    // `transcript_path: null`, but the rollout filename embeds the session id
+    // (`rollout-<timestamp>-<session_id>.jsonl` under
+    // ~/.codex/sessions/YYYY/MM/DD/), so we can derive the path and still read
+    // token/model stats. Walks the date tree newest-first (the just-stopped
+    // session's rollout is recent) and returns the first match. Disk I/O — call
+    // off the main thread.
+    static func rolloutPath(forSessionID sessionID: String,
+                            root: String = "\(NSHomeDirectory())/.codex/sessions") -> String? {
+        guard !sessionID.isEmpty else { return nil }
+        let fileManager = FileManager.default
+        let suffix = "-\(sessionID).jsonl"
+        func namesDescending(_ path: String) -> [String] {
+            ((try? fileManager.contentsOfDirectory(atPath: path)) ?? []).sorted(by: >)
+        }
+        for year in namesDescending(root) {
+            let yearPath = "\(root)/\(year)"
+            for month in namesDescending(yearPath) {
+                let monthPath = "\(yearPath)/\(month)"
+                for day in namesDescending(monthPath) {
+                    let dayPath = "\(monthPath)/\(day)"
+                    if let match = namesDescending(dayPath).first(where: { $0.hasSuffix(suffix) }) {
+                        return "\(dayPath)/\(match)"
+                    }
+                }
+            }
+        }
+        return nil
+    }
+
     // Codex stamps the active model on turn_context lines; session_meta carries
     // it for the session as a whole. Nesting has shifted across Codex versions,
     // so probe the few known shapes defensively and ignore anything else.

--- a/panel/InsightsView.swift
+++ b/panel/InsightsView.swift
@@ -13,6 +13,11 @@ import SwiftUI
 struct InsightsView: View {
     @ObservedObject var nav: PanelNav
 
+    // Whether Codex hooks are wired (stack-nudge wrote ~/.codex/hooks.json). Used
+    // only to hint, when Codex is present but absent from the rollup, that its
+    // hooks likely need trusting. Read once on appear (a single fileExists).
+    @State private var codexWired = false
+
     var body: some View {
         _ = nav.handoffsRevision   // re-run when a Stop adds a ledger row
         let summary = nav.insightsSummary()
@@ -35,6 +40,12 @@ struct InsightsView: View {
                         if !summary.topTickets.isEmpty { topTicketsSection(summary) }
                         if !summary.tokensByAgent.isEmpty { agentSection(summary) }
                         if !summary.tokensByModel.isEmpty { modelSection(summary.tokensByModel) }
+                        // Codex present on the machine but nothing captured ⇒ its
+                        // hooks probably aren't trusted (Codex skips untrusted
+                        // hooks and we can't trust them for you).
+                        if codexWired, summary.totalTokens > 0, summary.tokensByAgent["codex"] == nil {
+                            codexHint
+                        }
                     }
                 }
                 .padding(14)
@@ -52,11 +63,23 @@ struct InsightsView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .onAppear {
+            codexWired = FileManager.default.fileExists(
+                atPath: "\(NSHomeDirectory())/.codex/hooks.json")
             // Populate the outcome/PR maps the same way the Tickets tab does, so
             // opening Insights first (without Tickets) still resolves shipped state.
             nav.refreshOutcomes?()
             nav.refreshPullRequests?()
         }
+    }
+
+    private var codexHint: some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "info.circle").font(.caption2).foregroundStyle(.tertiary)
+            Text("Codex is set up but not captured. Trust its hooks with /hooks in Codex so its sessions land here.")
+                .font(.caption2).foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.top, 4)
     }
 
     // MARK: - Sections

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -1627,12 +1627,17 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
             return dropHandoff(.missingProjectPath, agent: event.agent)
         }
         let agent = Agent.canonical(event.agent)
-        let transcriptPath = event.transcriptPath
+        let providedTranscriptPath = event.transcriptPath
         DispatchQueue.global(qos: .utility).async { [weak self] in
             guard let repoRoot = Self.gitValue(cwd, ["rev-parse", "--show-toplevel"]) else {
                 DispatchQueue.main.async { self?.dropHandoff(.notAGitRepo, agent: agent) }
                 return
             }
+            // Codex's Stop hook may omit transcript_path; derive the rollout from
+            // the session id (its filename embeds it) so codex records carry
+            // token/model stats rather than landing token-less.
+            let transcriptPath = providedTranscriptPath
+                ?? (agent == "codex" ? CodexTranscriptReader.rolloutPath(forSessionID: sessionID) : nil)
             let branch = Self.gitValue(cwd, ["rev-parse", "--abbrev-ref", "HEAD"])
             // Only consider the subject of a commit *unique to this branch*
             // (base..HEAD). The absolute last commit may already be on main —

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -649,8 +649,16 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         // Updates swap the .app but never the installed hook script, so a
         // self-updating machine can run a current panel against a notify.sh from
         // any earlier release, one that omits payload fields we now depend on.
-        // Repair it here, while we know the bundle we shipped with.
-        Bootstrap.refreshNotifyScriptIfNeeded()
+        // Repair it here, while we know the bundle we shipped with. A rewrite
+        // resets Codex's hook-trust hash (Codex silently skips a changed hook
+        // until re-trusted, and there's no trust API for us to call), so when one
+        // happens and Codex is wired, nudge the user to re-trust via /hooks.
+        if Bootstrap.refreshNotifyScriptIfNeeded() != nil,
+           FileManager.default.fileExists(atPath: "\(NSHomeDirectory())/.codex/hooks.json") {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 4) { [weak self] in
+                self?.postCodexRetrustBanner()
+            }
+        }
 
         let size = Self.loadSavedPanelSize()
         let frame = NSRect(origin: .zero, size: size)
@@ -1959,6 +1967,18 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         guard let session = sessions.sessions.first(where: { $0.claudeSessionID == id })
         else { return "a session" }
         return SessionLabel.displayName(for: session, fallback: "a session")
+    }
+
+    // Fired once after a notify.sh rewrite when Codex is wired: the rewrite
+    // reset Codex's hook trust, so its sessions won't be captured until the user
+    // re-trusts. We can't do it for them (Codex has no trust API, only /hooks).
+    private func postCodexRetrustBanner() {
+        let content = UNMutableNotificationContent()
+        content.title = "Codex hooks need re-trusting"
+        content.body = "This update changed notify.sh. Run /hooks in Codex to re-trust its hooks, or Codex sessions won't be captured."
+        content.categoryIdentifier = "STOP"
+        let req = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
+        UNUserNotificationCenter.current().add(req, withCompletionHandler: nil)
     }
 
     private func postContextBanner(tokens: Int, model: String?, sessionLabel: String) {

--- a/panel/Settings.swift
+++ b/panel/Settings.swift
@@ -192,9 +192,9 @@ struct SettingsView: View {
             // returns to the panel.
             nav.refreshPermissions()
             installedHookVersion = Bootstrap.installedNotifyVersion()
-            hookScriptStale = Bootstrap.needsNotifyRefresh(
-                installed: installedHookVersion,
-                bundled: Bootstrap.bundledNotifyVersion())
+            hookScriptStale = Bootstrap.notifyScriptOutdated(
+                bundled: Bootstrap.bundledNotifyScript(),
+                installedPath: Bootstrap.notifyPath)
         }
     }
 


### PR DESCRIPTION
## What

Captures Codex sessions into the Outcomes ledger, so Codex work shows up in the Overview (agent/model mix, spend-to-outcome) and the Tickets list alongside Claude, and keeps that capture working across updates. Insights was already agent-agnostic; the gaps were upstream in capture and in hook trust.

## Why it wasn't landing

Codex's Stop hook does fire our `notify.sh`, but with two gaps:

1. Its Stop payload sends `transcript_path: null`, so `captureHandoff` recorded a codex row with no tokens/model.
2. Codex skips hooks whose trust hash it doesn't recognize, and there is no programmatic trust API, so the stack-nudge hooks have to be trusted once via `/hooks` in Codex. Worse, we were resetting that trust on essentially every release (see below).

## Changes

**Capture**

- **Rollout-path derivation.** `CodexTranscriptReader.rolloutPath(forSessionID:)` finds `~/.codex/sessions/…/rollout-<session_id>.jsonl` (the filename embeds the session id), and `captureHandoff` uses it for Codex when the hook omits `transcript_path`. `CodexTranscriptReader` already parses tokens + model from that file. Verified end-to-end: codex records now land with real tokens and model (`gpt-5.6-sol`), and get the same ticket / branch / outcome attribution as Claude (it's all agent-agnostic).

**Hook trust across updates**

- **Idempotent `notify.sh` refresh.** `refreshNotifyScript` used to rewrite the installed script whenever the version stamp differed, and release-please bumps that stamp on every release, so every update rewrote `notify.sh` and reset Codex's hook-trust hash (silently disabling capture). It now compares functional content (stamp line neutralised) and only rewrites on a genuine logic change. A stamp-only bump leaves the file byte-stable, so Codex trust survives. The Settings "hook script stale" footer uses the same predicate, so it no longer false-warns on stamp-only bumps.
- **Re-trust nudge.** When a real `notify.sh` change does land and Codex is wired, a one-time banner points the user at `/hooks` to re-trust (we can't do it for them). Plus the passive Overview hint when Codex is wired but absent from the rollup.

Antigravity is intentionally left out: its transcript carries no per-session token data, so it would only ever record token-less rows.

## Testing

- `CodexTranscriptReaderTests` for `rolloutPath` (suffix match, no-match / empty id, newest-day-first walk).
- `BootstrapTests` for the idempotent refresh (stamp-only bump is a no-op and leaves the file untouched; a logic change still rewrites) and `functionalContent` stamp neutralisation.
- `scripts/typecheck-tests.sh` green; assertions verified locally via an in-module harness (`swift test` needs Xcode, so CI runs the real suite).
