### PR TITLE
fix(panel): quota poll cadence, stale reset times, and unlabelled permission banners

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Bars are color-coded: green below 50%, yellow 50–80%, red 80%+. Reset times sh
 
 Numbers come straight from the `claude` CLI — stack-nudge shells out to `claude --print /usage` and parses the result. Because the CLI reads its *own* keychain grant, **stack-nudge never touches your keychain or calls the Anthropic API, so there's no password prompt**. If `claude` isn't on your `PATH` or you're signed out, the tab shows *"Claude usage unavailable — run `claude /usage` to check your session"* rather than falling back to any other source. (Codex and Antigravity usage are read from their own local files, unaffected.)
 
-Polls every 60 seconds while the panel is visible, or every 5 minutes by default in the background (configurable via Settings → Usage → "Poll frequency"). On the Usage tab: `r` triggers a manual sync, `p` pauses/resumes the poller.
+Polls every 60 seconds while the full panel is open, and otherwise every 5 minutes by default (configurable via Settings → Usage → "Poll frequency"). The collapsed widget counts as background, so it polls at your configured frequency rather than the faster open-panel rate. Opening the panel syncs immediately if the last one is over a minute old. On the Usage tab: `r` triggers a manual sync, `p` pauses/resumes the poller.
 
 #### Threshold-crossing notifications
 

--- a/Tests/StackNudgePanelCoreTests/ClaudeCliQuotaProbeTests.swift
+++ b/Tests/StackNudgePanelCoreTests/ClaudeCliQuotaProbeTests.swift
@@ -151,8 +151,13 @@ final class ClaudeCliQuotaProbeTests: XCTestCase {
     // MARK: - parseResetsAt
 
     func testParseResetsAtWithTimezone() {
-        // 6:50pm in Europe/London on a date in the current year.
-        let parsed = ClaudeCliQuotaProbe.parseResetsAt("Jun 30 at 6:50pm (Europe/London)")
+        // 6:50pm in Europe/London. `now` is pinned near the reset: these used to
+        // pass no clock and lean on the real date, which only worked because they
+        // assert components rather than the year — and stopped being safe once
+        // the parser started rejecting implausibly distant results.
+        let parsed = ClaudeCliQuotaProbe.parseResetsAt(
+            "Jun 30 at 6:50pm (Europe/London)",
+            now: Self.london(year: 2026, month: 6, day: 29, hour: 12))
         XCTAssertNotNil(parsed)
         var cal = Calendar(identifier: .gregorian)
         cal.timeZone = TimeZone(identifier: "Europe/London")!
@@ -165,7 +170,9 @@ final class ClaudeCliQuotaProbeTests: XCTestCase {
 
     func testParseResetsAtBareHour() {
         // "3am" — no minutes — uses the alternate format.
-        let parsed = ClaudeCliQuotaProbe.parseResetsAt("Jul 4 at 3am (Europe/London)")
+        let parsed = ClaudeCliQuotaProbe.parseResetsAt(
+            "Jul 4 at 3am (Europe/London)",
+            now: Self.london(year: 2026, month: 7, day: 2, hour: 12))
         XCTAssertNotNil(parsed)
         var cal = Calendar(identifier: .gregorian)
         cal.timeZone = TimeZone(identifier: "Europe/London")!
@@ -190,6 +197,42 @@ final class ClaudeCliQuotaProbeTests: XCTestCase {
         XCTAssertEqual(Self.londonCalendar.component(.year, from: parsed!), 2027)
         // And it must be ahead of now, not behind it.
         XCTAssertGreaterThan(parsed!, now)
+    }
+
+    // The mirror direction: a late-December deadline read just after midnight on
+    // Jan 1 must resolve to the year that just ended, not the one ahead. Without
+    // this the `year - 1` candidate is unpinned — deleting it from the search
+    // leaves every other test in this file green while a December reset reads a
+    // year into the future.
+    func testParseResetsAtRollsBackAYearJustAfterNewYear() {
+        let now = Self.london(year: 2027, month: 1, day: 1, hour: 0)
+        let parsed = ClaudeCliQuotaProbe.parseResetsAt("Dec 31 at 11pm (Europe/London)", now: now)
+        XCTAssertNotNil(parsed)
+        XCTAssertEqual(Self.londonCalendar.component(.year, from: parsed!), 2026)
+        XCTAssertLessThan(parsed!, now)
+    }
+
+    // "Nearest of the candidates that parsed" is only sound while the correct
+    // year parses. If it ever doesn't, a neighbour wins by ~365 days, and a
+    // future-dated wrong answer isn't caught by the past-guard downstream — the
+    // Usage tab would state "Resets in 12 months" as fact. Anything outside the
+    // plausible window is dropped instead.
+    func testParseResetsAtRejectsImplausiblyDistantResult() {
+        // A wall clock that exists in no year adjacent to `now` would be the real
+        // route in; simulate the outcome directly by reading a mid-year date from
+        // a `now` half a year away, so every candidate is months out.
+        let now = Self.london(year: 2026, month: 1, day: 15, hour: 12)
+        XCTAssertNil(ClaudeCliQuotaProbe.parseResetsAt("Jul 15 at 3am (Europe/London)", now: now))
+    }
+
+    // ...while a reset inside the plausible window still resolves, including one
+    // that has already passed (a held-over snapshot), which the display layer
+    // rather than the parser is responsible for hiding.
+    func testParseResetsAtKeepsRecentlyElapsedReset() {
+        let now = Self.london(year: 2026, month: 6, day: 10, hour: 12)
+        let parsed = ClaudeCliQuotaProbe.parseResetsAt("Jun 3 at 3am (Europe/London)", now: now)
+        XCTAssertNotNil(parsed)
+        XCTAssertLessThan(parsed!, now)
     }
 
     // The ordinary case must keep resolving to the year it's read in.

--- a/Tests/StackNudgePanelCoreTests/ClaudeCliQuotaProbeTests.swift
+++ b/Tests/StackNudgePanelCoreTests/ClaudeCliQuotaProbeTests.swift
@@ -151,10 +151,8 @@ final class ClaudeCliQuotaProbeTests: XCTestCase {
     // MARK: - parseResetsAt
 
     func testParseResetsAtWithTimezone() {
-        // 6:50pm in Europe/London. `now` is pinned near the reset: these used to
-        // pass no clock and lean on the real date, which only worked because they
-        // assert components rather than the year — and stopped being safe once
-        // the parser started rejecting implausibly distant results.
+        // `now` pinned near the reset: these used to lean on the real clock, which
+        // stopped being safe once the parser began rejecting distant results.
         let parsed = ClaudeCliQuotaProbe.parseResetsAt(
             "Jun 30 at 6:50pm (Europe/London)",
             now: Self.london(year: 2026, month: 6, day: 29, hour: 12))
@@ -199,10 +197,8 @@ final class ClaudeCliQuotaProbeTests: XCTestCase {
         XCTAssertGreaterThan(parsed!, now)
     }
 
-    // The mirror direction: a late-December deadline read just after midnight on
-    // Jan 1 must resolve to the year that just ended, not the one ahead. Without
-    // this the `year - 1` candidate is unpinned — deleting it from the search
-    // leaves every other test in this file green while a December reset reads a
+    // Mirror direction. Without this the `year - 1` candidate is unpinned:
+    // deleting it leaves every other test green while a December reset reads a
     // year into the future.
     func testParseResetsAtRollsBackAYearJustAfterNewYear() {
         let now = Self.london(year: 2027, month: 1, day: 1, hour: 0)
@@ -212,22 +208,17 @@ final class ClaudeCliQuotaProbeTests: XCTestCase {
         XCTAssertLessThan(parsed!, now)
     }
 
-    // "Nearest of the candidates that parsed" is only sound while the correct
-    // year parses. If it ever doesn't, a neighbour wins by ~365 days, and a
-    // future-dated wrong answer isn't caught by the past-guard downstream — the
-    // Usage tab would state "Resets in 12 months" as fact. Anything outside the
-    // plausible window is dropped instead.
+    // A neighbour winning by ~365 days is future-dated, so the past-guard
+    // downstream never catches it — the Usage tab would state "Resets in 12
+    // months" as fact. Out-of-window results are dropped instead.
     func testParseResetsAtRejectsImplausiblyDistantResult() {
-        // A wall clock that exists in no year adjacent to `now` would be the real
-        // route in; simulate the outcome directly by reading a mid-year date from
-        // a `now` half a year away, so every candidate is months out.
+        // Every candidate is months out from this `now`.
         let now = Self.london(year: 2026, month: 1, day: 15, hour: 12)
         XCTAssertNil(ClaudeCliQuotaProbe.parseResetsAt("Jul 15 at 3am (Europe/London)", now: now))
     }
 
-    // ...while a reset inside the plausible window still resolves, including one
-    // that has already passed (a held-over snapshot), which the display layer
-    // rather than the parser is responsible for hiding.
+    // An elapsed reset inside the window still parses — hiding it is the display
+    // layer's job, not the parser's.
     func testParseResetsAtKeepsRecentlyElapsedReset() {
         let now = Self.london(year: 2026, month: 6, day: 10, hour: 12)
         let parsed = ClaudeCliQuotaProbe.parseResetsAt("Jun 3 at 3am (Europe/London)", now: now)

--- a/Tests/StackNudgePanelCoreTests/ClaudeCliQuotaProbeTests.swift
+++ b/Tests/StackNudgePanelCoreTests/ClaudeCliQuotaProbeTests.swift
@@ -181,6 +181,38 @@ final class ClaudeCliQuotaProbeTests: XCTestCase {
         XCTAssertNil(ClaudeCliQuotaProbe.parseResetsAt(""))
     }
 
+    // The CLI omits the year, so a January reset read on New Year's Eve used to
+    // splice in the *current* year and land ~12 months in the past.
+    func testParseResetsAtRollsIntoNextYearAcrossNewYear() {
+        let now = Self.london(year: 2026, month: 12, day: 31, hour: 23)
+        let parsed = ClaudeCliQuotaProbe.parseResetsAt("Jan 1 at 3am (Europe/London)", now: now)
+        XCTAssertNotNil(parsed)
+        XCTAssertEqual(Self.londonCalendar.component(.year, from: parsed!), 2027)
+        // And it must be ahead of now, not behind it.
+        XCTAssertGreaterThan(parsed!, now)
+    }
+
+    // The ordinary case must keep resolving to the year it's read in.
+    func testParseResetsAtKeepsCurrentYearMidYear() {
+        let now = Self.london(year: 2026, month: 6, day: 1, hour: 12)
+        let parsed = ClaudeCliQuotaProbe.parseResetsAt("Jun 3 at 3am (Europe/London)", now: now)
+        XCTAssertNotNil(parsed)
+        XCTAssertEqual(Self.londonCalendar.component(.year, from: parsed!), 2026)
+        XCTAssertGreaterThan(parsed!, now)
+    }
+
+    private static let londonCalendar: Calendar = {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "Europe/London")!
+        return cal
+    }()
+
+    private static func london(year: Int, month: Int, day: Int, hour: Int) -> Date {
+        var comps = DateComponents()
+        comps.year = year; comps.month = month; comps.day = day; comps.hour = hour
+        return londonCalendar.date(from: comps)!
+    }
+
     // MARK: - Session cleanup
 
     func testExtractSessionId() {

--- a/Tests/StackNudgePanelCoreTests/QuotaPollIntervalTests.swift
+++ b/Tests/StackNudgePanelCoreTests/QuotaPollIntervalTests.swift
@@ -2,11 +2,9 @@ import XCTest
 
 @testable import StackNudgePanelCore
 
-// The poll cadence used to key off `panel.isVisible` alone. In compact mode the
-// widget pill IS the panel window and is never ordered out, so that stayed true
-// forever: every widget user polled the `claude` CLI every 60 seconds and
-// Settings → Poll frequency did nothing. These pin the collapsed-widget case,
-// which is the one that regressed.
+// Cadence used to key off `panel.isVisible` alone, but the widget pill IS the
+// panel window and is never ordered out — so every widget user polled every 60s
+// and Settings → Poll frequency did nothing. The collapsed case is the regression.
 final class QuotaPollIntervalTests: XCTestCase {
 
     private let hidden: TimeInterval = 300  // 5 min, the shipped default

--- a/Tests/StackNudgePanelCoreTests/QuotaPollIntervalTests.swift
+++ b/Tests/StackNudgePanelCoreTests/QuotaPollIntervalTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// The poll cadence used to key off `panel.isVisible` alone. In compact mode the
+// widget pill IS the panel window and is never ordered out, so that stayed true
+// forever: every widget user polled the `claude` CLI every 60 seconds and
+// Settings → Poll frequency did nothing. These pin the collapsed-widget case,
+// which is the one that regressed.
+final class QuotaPollIntervalTests: XCTestCase {
+
+    private let hidden: TimeInterval = 300  // 5 min, the shipped default
+    private let visible: TimeInterval = 60
+
+    // The regression: pill on screen, collapsed, so the user's setting applies.
+    func testCollapsedWidgetUsesConfiguredInterval() {
+        XCTAssertEqual(
+            PanelController.quotaPollInterval(visible: true,
+                                              compactMode: true,
+                                              compactExpanded: false,
+                                              hiddenInterval: hidden),
+            hidden)
+    }
+
+    // Expanded out of the pill, the Usage tab is reachable, so poll fast.
+    func testExpandedWidgetUsesVisibleInterval() {
+        XCTAssertEqual(
+            PanelController.quotaPollInterval(visible: true,
+                                              compactMode: true,
+                                              compactExpanded: true,
+                                              hiddenInterval: hidden),
+            visible)
+    }
+
+    func testFullPanelOpenUsesVisibleInterval() {
+        XCTAssertEqual(
+            PanelController.quotaPollInterval(visible: true,
+                                              compactMode: false,
+                                              compactExpanded: false,
+                                              hiddenInterval: hidden),
+            visible)
+    }
+
+    func testHiddenPanelUsesConfiguredInterval() {
+        XCTAssertEqual(
+            PanelController.quotaPollInterval(visible: false,
+                                              compactMode: false,
+                                              compactExpanded: false,
+                                              hiddenInterval: hidden),
+            hidden)
+    }
+
+    // A window that isn't on screen can't be showing usage, whatever the compact
+    // flags say.
+    func testNotVisibleWinsOverExpandedFlag() {
+        XCTAssertEqual(
+            PanelController.quotaPollInterval(visible: false,
+                                              compactMode: true,
+                                              compactExpanded: true,
+                                              hiddenInterval: hidden),
+            hidden)
+    }
+}

--- a/Tests/StackNudgePanelCoreTests/QuotaResetTests.swift
+++ b/Tests/StackNudgePanelCoreTests/QuotaResetTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// QuotaReset is the single place that decides how long is left on a quota tier.
+// The behaviour that matters most is the boundary: a deadline that has already
+// passed must read as "unknown" on every surface, because the only way to see one
+// is a snapshot the probe couldn't refresh. The widget's old formatter floored at
+// "1m", so a held-over snapshot showed a live one-minute countdown indefinitely.
+final class QuotaResetTests: XCTestCase {
+
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func ahead(_ seconds: TimeInterval) -> Date {
+        now.addingTimeInterval(seconds)
+    }
+
+    // MARK: - shortLabel
+
+    func testShortLabelHoursAndMinutes() {
+        XCTAssertEqual(QuotaReset.shortLabel(until: ahead(2 * 3600 + 24 * 60), now: now), "2h24m")
+    }
+
+    func testShortLabelDropsZeroMinutes() {
+        XCTAssertEqual(QuotaReset.shortLabel(until: ahead(2 * 3600), now: now), "2h")
+    }
+
+    func testShortLabelUnderAnHour() {
+        XCTAssertEqual(QuotaReset.shortLabel(until: ahead(14 * 60), now: now), "14m")
+    }
+
+    // Under a minute still rounds up to "1m" — it really is about to reset, which
+    // is the one case the old floor got right.
+    func testShortLabelSubMinuteRoundsUp() {
+        XCTAssertEqual(QuotaReset.shortLabel(until: ahead(20), now: now), "1m")
+    }
+
+    func testShortLabelIsNilOnceElapsed() {
+        XCTAssertNil(QuotaReset.shortLabel(until: now, now: now))
+        XCTAssertNil(QuotaReset.shortLabel(until: ahead(-1), now: now))
+        // The shape the year-splice bug produced: a deadline ~12 months back.
+        XCTAssertNil(QuotaReset.shortLabel(until: ahead(-365 * 24 * 3600), now: now))
+    }
+
+    // MARK: - relativeLabel
+
+    func testRelativeLabelPresentWhileFuture() {
+        XCTAssertNotNil(QuotaReset.relativeLabel(until: ahead(2 * 3600), now: now))
+    }
+
+    func testRelativeLabelIsNilOnceElapsed() {
+        XCTAssertNil(QuotaReset.relativeLabel(until: ahead(-2 * 3600), now: now))
+    }
+
+    // MARK: - remaining
+
+    func testRemainingIsNilAtAndAfterTheDeadline() {
+        XCTAssertEqual(QuotaReset.remaining(until: ahead(60), now: now), 60)
+        XCTAssertNil(QuotaReset.remaining(until: now, now: now))
+        XCTAssertNil(QuotaReset.remaining(until: ahead(-60), now: now))
+    }
+}

--- a/Tests/StackNudgePanelCoreTests/QuotaResetTests.swift
+++ b/Tests/StackNudgePanelCoreTests/QuotaResetTests.swift
@@ -2,11 +2,9 @@ import XCTest
 
 @testable import StackNudgePanelCore
 
-// QuotaReset is the single place that decides how long is left on a quota tier.
-// The behaviour that matters most is the boundary: a deadline that has already
-// passed must read as "unknown" on every surface, because the only way to see one
-// is a snapshot the probe couldn't refresh. The widget's old formatter floored at
-// "1m", so a held-over snapshot showed a live one-minute countdown indefinitely.
+// The boundary is what matters: a deadline that has passed must read as unknown
+// on every surface. The widget's old formatter floored at "1m", so a held-over
+// snapshot showed a live one-minute countdown indefinitely.
 final class QuotaResetTests: XCTestCase {
 
     private let now = Date(timeIntervalSince1970: 1_700_000_000)
@@ -29,8 +27,7 @@ final class QuotaResetTests: XCTestCase {
         XCTAssertEqual(QuotaReset.shortLabel(until: ahead(14 * 60), now: now), "14m")
     }
 
-    // Under a minute still rounds up to "1m" — it really is about to reset, which
-    // is the one case the old floor got right.
+    // Sub-minute rounds up to "1m" — it really is about to reset.
     func testShortLabelSubMinuteRoundsUp() {
         XCTAssertEqual(QuotaReset.shortLabel(until: ahead(20), now: now), "1m")
     }

--- a/notify.sh
+++ b/notify.sh
@@ -58,12 +58,10 @@ permission_context() {
   [[ -z "$tool_name" ]] && return
   case "$tool_name" in
     Bash)
-      # Truncation happens in jq, which counts characters. `cut -c` counts bytes
-      # under a non-UTF-8 locale (and hooks inherit whatever environment spawned
-      # them — this script never forces one), so it could slice a multibyte
-      # character in half. The stray byte survives python3's surrogateescape into
-      # the socket JSON, and EventListener then fails to decode the line and drops
-      # the whole event silently: no banner, no panel row, no log.
+      # Truncate in jq (characters), not `cut -c` (bytes under a non-UTF-8 locale,
+      # which hooks can inherit). A half-sliced multibyte character survives
+      # python3's surrogateescape into the socket JSON, where EventListener fails
+      # to decode the line and drops the whole event silently.
       printf '%s' "$HOOK_JSON" | jq -r '(.tool_input.command // empty) | .[0:60]' 2>/dev/null \
         | head -1
       ;;
@@ -85,12 +83,8 @@ permission_context() {
       if [[ -n "$file" ]]; then echo "apply_patch: ${file}"; else echo "apply_patch"; fi
       ;;
     AskUserQuestion)
-      # The agent is asking the user something directly. Without this case the
-      # banner body read a bare "AskUserQuestion" — the tool name and nothing
-      # else. Surface the first question instead, trimmed like the Bash case.
-      # Truncated in jq (character-wise) rather than `cut -c` (byte-wise under a
-      # non-UTF-8 locale) — see the Bash case above for why a split multibyte
-      # character costs the entire notification.
+      # Without this the body read a bare "AskUserQuestion". Same jq truncation as
+      # the Bash case above.
       local question
       question=$(printf '%s' "$HOOK_JSON" \
         | jq -r '(.tool_input.questions[0].question // empty) | .[0:60]' 2>/dev/null | head -1)

--- a/notify.sh
+++ b/notify.sh
@@ -58,8 +58,14 @@ permission_context() {
   [[ -z "$tool_name" ]] && return
   case "$tool_name" in
     Bash)
-      printf '%s' "$HOOK_JSON" | jq -r '.tool_input.command // empty' 2>/dev/null \
-        | head -1 | cut -c1-60
+      # Truncation happens in jq, which counts characters. `cut -c` counts bytes
+      # under a non-UTF-8 locale (and hooks inherit whatever environment spawned
+      # them — this script never forces one), so it could slice a multibyte
+      # character in half. The stray byte survives python3's surrogateescape into
+      # the socket JSON, and EventListener then fails to decode the line and drops
+      # the whole event silently: no banner, no panel row, no log.
+      printf '%s' "$HOOK_JSON" | jq -r '(.tool_input.command // empty) | .[0:60]' 2>/dev/null \
+        | head -1
       ;;
     Write|Edit|MultiEdit)
       local file
@@ -82,9 +88,12 @@ permission_context() {
       # The agent is asking the user something directly. Without this case the
       # banner body read a bare "AskUserQuestion" — the tool name and nothing
       # else. Surface the first question instead, trimmed like the Bash case.
+      # Truncated in jq (character-wise) rather than `cut -c` (byte-wise under a
+      # non-UTF-8 locale) — see the Bash case above for why a split multibyte
+      # character costs the entire notification.
       local question
       question=$(printf '%s' "$HOOK_JSON" \
-        | jq -r '.tool_input.questions[0].question // empty' 2>/dev/null | head -1 | cut -c1-60)
+        | jq -r '(.tool_input.questions[0].question // empty) | .[0:60]' 2>/dev/null | head -1)
       if [[ -n "$question" ]]; then echo "$question"; else echo "Needs your input"; fi
       ;;
     *)

--- a/notify.sh
+++ b/notify.sh
@@ -78,6 +78,15 @@ permission_context() {
         | sed -E 's/^.*File: //; s|.*/||')
       if [[ -n "$file" ]]; then echo "apply_patch: ${file}"; else echo "apply_patch"; fi
       ;;
+    AskUserQuestion)
+      # The agent is asking the user something directly. Without this case the
+      # banner body read a bare "AskUserQuestion" — the tool name and nothing
+      # else. Surface the first question instead, trimmed like the Bash case.
+      local question
+      question=$(printf '%s' "$HOOK_JSON" \
+        | jq -r '.tool_input.questions[0].question // empty' 2>/dev/null | head -1 | cut -c1-60)
+      if [[ -n "$question" ]]; then echo "$question"; else echo "Needs your input"; fi
+      ;;
     *)
       echo "$tool_name"
       ;;
@@ -110,6 +119,14 @@ voice_permission_context() {
         | grep -m1 -oE '^\*\*\* (Add|Update|Delete) File: .+' \
         | sed -E 's/^.*File: //; s|.*/||')
       if [[ -n "$file" ]]; then echo "apply_patch: ${file}"; else echo "Edit needs approval"; fi
+      ;;
+    AskUserQuestion)
+      # Speak the short header ("Widget cadence") rather than the full question,
+      # which runs to a paragraph and doesn't read aloud well.
+      local header
+      header=$(printf '%s' "$HOOK_JSON" \
+        | jq -r '.tool_input.questions[0].header // empty' 2>/dev/null | head -1)
+      if [[ -n "$header" ]]; then echo "${header} needs your answer"; else echo "A question needs your answer"; fi
       ;;
     *)
       echo "$tool_name"

--- a/panel/ClaudeCliQuotaProbe.swift
+++ b/panel/ClaudeCliQuotaProbe.swift
@@ -198,11 +198,14 @@ final class ClaudeCliQuotaProbe {
     }
 
     // Best-effort: "Jun 30 at 6:50pm (Europe/London)" → Date.
-    // The CLI omits the year, so we splice in the current one. If the deadline
-    // is "Jan 2 at 1am" rendered on Dec 31, the parsed date will be ~12 months
-    // in the past — accept the rare wraparound, the UI just shows nil when
-    // resetsAt is in the past (RelativeTime treats negative deltas gracefully).
-    static func parseResetsAt(_ raw: String) -> Date? {
+    //
+    // The CLI omits the year. Splicing in the current one alone broke across New
+    // Year: "Jan 2 at 1am" rendered on Dec 31 parsed ~12 months in the past, and
+    // both surfaces then rendered that as fact — "Resets 11 months ago" in the
+    // Usage tab, a stuck "1m" on the widget. So try the neighbouring years too
+    // and keep whichever candidate lands nearest `now`, which handles the Dec→Jan
+    // and Jan→Dec directions without special-casing either.
+    static func parseResetsAt(_ raw: String, now: Date = Date()) -> Date? {
         let trimmed = raw.trimmingCharacters(in: .whitespaces)
         var dateTimeStr = trimmed
         var tz: TimeZone?
@@ -216,13 +219,24 @@ final class ClaudeCliQuotaProbe {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         if let tz { formatter.timeZone = tz }
-        let year = Calendar(identifier: .gregorian).component(.year, from: Date())
-        let withYear = "\(dateTimeStr) \(year)"
-        // "h:mma" matches "6:50pm"; "ha" matches "3am".
-        for fmt in ["MMM d 'at' h:mma yyyy", "MMM d 'at' ha yyyy"] {
-            formatter.dateFormat = fmt
-            if let d = formatter.date(from: withYear) { return d }
+        var calendar = Calendar(identifier: .gregorian)
+        if let tz { calendar.timeZone = tz }
+        let year = calendar.component(.year, from: now)
+
+        var best: Date?
+        for candidateYear in [year - 1, year, year + 1] {
+            let withYear = "\(dateTimeStr) \(candidateYear)"
+            // "h:mma" matches "6:50pm"; "ha" matches "3am".
+            for fmt in ["MMM d 'at' h:mma yyyy", "MMM d 'at' ha yyyy"] {
+                formatter.dateFormat = fmt
+                guard let candidate = formatter.date(from: withYear) else { continue }
+                let closer = best.map {
+                    abs(candidate.timeIntervalSince(now)) < abs($0.timeIntervalSince(now))
+                } ?? true
+                if closer { best = candidate }
+                break
+            }
         }
-        return nil
+        return best
     }
 }

--- a/panel/ClaudeCliQuotaProbe.swift
+++ b/panel/ClaudeCliQuotaProbe.swift
@@ -199,21 +199,15 @@ final class ClaudeCliQuotaProbe {
 
     // Best-effort: "Jun 30 at 6:50pm (Europe/London)" → Date.
     //
-    // The CLI omits the year. Splicing in the current one alone broke across New
-    // Year: "Jan 2 at 1am" rendered on Dec 31 parsed ~12 months in the past, and
-    // both surfaces then rendered that as fact — "Resets 11 months ago" in the
-    // Usage tab, a stuck "1m" on the widget. So try the neighbouring years too
-    // and keep whichever candidate lands nearest `now`, which handles the Dec→Jan
-    // and Jan→Dec directions without special-casing either.
+    // The CLI omits the year, so try the neighbouring ones and keep whichever
+    // lands nearest `now` — splicing in the current year alone put "Jan 2 at 1am"
+    // read on Dec 31 twelve months in the past.
     //
-    // The candidate is then range-checked, because "nearest of the ones that
-    // parsed" is only sound while the correct year actually parses. If it ever
-    // doesn't, a neighbouring year wins by default and lands ~365 days out — and
-    // a future-dated wrong answer isn't caught by the past-guard downstream, so
-    // the Usage tab would state "Resets in 12 months" with total confidence. The
-    // widest real window is 7 days, so anything beyond `plausibleWindow` means we
-    // guessed wrong and nil (no reset line) is the honest answer.
-    static let plausibleWindow: TimeInterval = 60 * 24 * 3600  // 60 days
+    // Then range-check it: "nearest of the ones that parsed" is only sound while
+    // the correct year parses, and a future-dated wrong answer is ~365 days out
+    // and passes the past-guard downstream. Real windows are 7 days at most, so
+    // 60 leaves room for a future monthly tier while still catching a year.
+    static let plausibleWindow: TimeInterval = 60 * 24 * 3600
 
     static func parseResetsAt(_ raw: String, now: Date = Date()) -> Date? {
         let trimmed = raw.trimmingCharacters(in: .whitespaces)

--- a/panel/ClaudeCliQuotaProbe.swift
+++ b/panel/ClaudeCliQuotaProbe.swift
@@ -205,6 +205,16 @@ final class ClaudeCliQuotaProbe {
     // Usage tab, a stuck "1m" on the widget. So try the neighbouring years too
     // and keep whichever candidate lands nearest `now`, which handles the Dec→Jan
     // and Jan→Dec directions without special-casing either.
+    //
+    // The candidate is then range-checked, because "nearest of the ones that
+    // parsed" is only sound while the correct year actually parses. If it ever
+    // doesn't, a neighbouring year wins by default and lands ~365 days out — and
+    // a future-dated wrong answer isn't caught by the past-guard downstream, so
+    // the Usage tab would state "Resets in 12 months" with total confidence. The
+    // widest real window is 7 days, so anything beyond `plausibleWindow` means we
+    // guessed wrong and nil (no reset line) is the honest answer.
+    static let plausibleWindow: TimeInterval = 60 * 24 * 3600  // 60 days
+
     static func parseResetsAt(_ raw: String, now: Date = Date()) -> Date? {
         let trimmed = raw.trimmingCharacters(in: .whitespaces)
         var dateTimeStr = trimmed
@@ -237,6 +247,7 @@ final class ClaudeCliQuotaProbe {
                 break
             }
         }
+        guard let best, abs(best.timeIntervalSince(now)) <= plausibleWindow else { return nil }
         return best
     }
 }

--- a/panel/CompactView.swift
+++ b/panel/CompactView.swift
@@ -182,8 +182,9 @@ struct CompactView: View {
                 .frame(width: 0, height: 0)
             if show {
                 hoverLegend
-            } else if let reset = nav.quota?.fiveHour?.resetsAt {
-                Text(Self.shortDuration(until: reset))
+            } else if let reset = nav.quota?.fiveHour?.resetsAt,
+                      let countdown = QuotaReset.shortLabel(until: reset) {
+                Text(countdown)
                     .font(.system(size: 9, weight: .medium).monospacedDigit())
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
@@ -201,8 +202,8 @@ struct CompactView: View {
         .animation(.easeInOut(duration: 0.18), value: show)
     }
 
-    // Worst-case countdown footprint. shortDuration emits "Xh", "XhYm", or
-    // "Ym"; the 5h quota window caps the leading digit, so "0h00m" covers
+    // Worst-case countdown footprint. QuotaReset.shortLabel emits "Xh", "XhYm",
+    // or "Ym"; the 5h quota window caps the leading digit, so "0h00m" covers
     // every shape (digits are monospaced; 'h'/'m' are the widest letters).
     private var countdownSizer: some View {
         Text("0h00m")
@@ -478,16 +479,6 @@ struct CompactView: View {
         case .stop:       return "checkmark.circle.fill"
         case .other:      return "bell.fill"
         }
-    }
-
-    private static func shortDuration(until date: Date) -> String {
-        let s = max(0, Int(date.timeIntervalSinceNow))
-        if s >= 3600 {
-            let h = s / 3600
-            let m = (s % 3600) / 60
-            return m > 0 ? "\(h)h\(m)m" : "\(h)h"
-        }
-        return "\(max(1, s / 60))m"
     }
 }
 

--- a/panel/CompactView.swift
+++ b/panel/CompactView.swift
@@ -202,9 +202,8 @@ struct CompactView: View {
         .animation(.easeInOut(duration: 0.18), value: show)
     }
 
-    // Worst-case countdown footprint. QuotaReset.shortLabel emits "Xh", "XhYm",
-    // or "Ym"; the 5h quota window caps the leading digit, so "0h00m" covers
-    // every shape (digits are monospaced; 'h'/'m' are the widest letters).
+    // Worst-case countdown footprint: shortLabel emits "Xh"/"XhYm"/"Ym" and the
+    // 5h window caps the leading digit, so "0h00m" covers every shape.
     private var countdownSizer: some View {
         Text("0h00m")
             .font(.system(size: 9, weight: .medium).monospacedDigit())

--- a/panel/Formatting.swift
+++ b/panel/Formatting.swift
@@ -63,7 +63,7 @@ enum QuotaReset {
     // Prose form for the Usage tab and banners: "in 2 hours".
     static func relativeLabel(until date: Date, now: Date = Date()) -> String? {
         guard remaining(until: date, now: now) != nil else { return nil }
-        return RelativeTime.string(date, style: .full)
+        return RelativeTime.string(date, style: .full, relativeTo: now)
     }
 }
 
@@ -81,14 +81,18 @@ enum RelativeTime {
         return formatter
     }
 
+    // `relativeTo` defaults to now; callers that inject a clock (QuotaReset, and
+    // tests through it) pass their own so the rendered string agrees with the
+    // decision that produced it.
     static func string(_ date: Date,
-                       style: RelativeDateTimeFormatter.UnitsStyle = .abbreviated) -> String {
+                       style: RelativeDateTimeFormatter.UnitsStyle = .abbreviated,
+                       relativeTo reference: Date = Date()) -> String {
         let formatter: RelativeDateTimeFormatter
         switch style {
         case .short: formatter = shortStyle
         case .full:  formatter = full
         default:     formatter = abbreviated
         }
-        return formatter.localizedString(for: date, relativeTo: Date())
+        return formatter.localizedString(for: date, relativeTo: reference)
     }
 }

--- a/panel/Formatting.swift
+++ b/panel/Formatting.swift
@@ -26,27 +26,19 @@ enum ModelName {
     }
 }
 
-// How long until a quota tier resets, rendered for whichever surface is asking.
+// How long until a quota tier resets.
 //
-// Every accessor returns nil once the deadline has passed. That guard lives here
-// rather than at each call site because it used to live at none of them: the
-// widget's countdown floored at "1m" (`max(1, seconds / 60)`), so an expired or
-// held-over snapshot read as a live one-minute countdown forever, and the Usage
-// tab rendered "Resets 11 months ago" verbatim. A past reset means the snapshot
-// is stale, not that the reset is imminent, so the honest answer is "we don't
-// know" and callers fall back to their own empty state.
-//
-// `now` is injected so the boundary behaviour is testable without freezing the
-// clock.
+// Every accessor returns nil once the deadline has passed. A past reset means the
+// snapshot is stale, not that the reset is imminent — the widget's old formatter
+// floored at "1m" and showed a held-over snapshot as a live countdown forever.
 enum QuotaReset {
 
-    // Seconds remaining, or nil once the deadline has passed.
     static func remaining(until date: Date, now: Date = Date()) -> TimeInterval? {
         let seconds = date.timeIntervalSince(now)
         return seconds > 0 ? seconds : nil
     }
 
-    // Compact countdown for the widget pill: "2h24m", "2h", "14m".
+    // Widget pill: "2h24m", "2h", "14m".
     static func shortLabel(until date: Date, now: Date = Date()) -> String? {
         guard let remaining = remaining(until: date, now: now) else { return nil }
         let seconds = Int(remaining)
@@ -55,12 +47,10 @@ enum QuotaReset {
             let minutes = (seconds % 3600) / 60
             return minutes > 0 ? "\(hours)h\(minutes)m" : "\(hours)h"
         }
-        // Anything under a minute still reads as "1m" rather than "0m" — it is
-        // genuinely about to reset, which is the one case the old floor got right.
-        return "\(max(1, seconds / 60))m"
+        return "\(max(1, seconds / 60))m"  // sub-minute is genuinely about to reset
     }
 
-    // Prose form for the Usage tab and banners: "in 2 hours".
+    // Usage tab and banners: "in 2 hours".
     static func relativeLabel(until date: Date, now: Date = Date()) -> String? {
         guard remaining(until: date, now: now) != nil else { return nil }
         return RelativeTime.string(date, style: .full, relativeTo: now)
@@ -81,9 +71,8 @@ enum RelativeTime {
         return formatter
     }
 
-    // `relativeTo` defaults to now; callers that inject a clock (QuotaReset, and
-    // tests through it) pass their own so the rendered string agrees with the
-    // decision that produced it.
+    // Callers that inject a clock pass `relativeTo` so the rendered string agrees
+    // with the decision that produced it.
     static func string(_ date: Date,
                        style: RelativeDateTimeFormatter.UnitsStyle = .abbreviated,
                        relativeTo reference: Date = Date()) -> String {

--- a/panel/Formatting.swift
+++ b/panel/Formatting.swift
@@ -26,6 +26,47 @@ enum ModelName {
     }
 }
 
+// How long until a quota tier resets, rendered for whichever surface is asking.
+//
+// Every accessor returns nil once the deadline has passed. That guard lives here
+// rather than at each call site because it used to live at none of them: the
+// widget's countdown floored at "1m" (`max(1, seconds / 60)`), so an expired or
+// held-over snapshot read as a live one-minute countdown forever, and the Usage
+// tab rendered "Resets 11 months ago" verbatim. A past reset means the snapshot
+// is stale, not that the reset is imminent, so the honest answer is "we don't
+// know" and callers fall back to their own empty state.
+//
+// `now` is injected so the boundary behaviour is testable without freezing the
+// clock.
+enum QuotaReset {
+
+    // Seconds remaining, or nil once the deadline has passed.
+    static func remaining(until date: Date, now: Date = Date()) -> TimeInterval? {
+        let seconds = date.timeIntervalSince(now)
+        return seconds > 0 ? seconds : nil
+    }
+
+    // Compact countdown for the widget pill: "2h24m", "2h", "14m".
+    static func shortLabel(until date: Date, now: Date = Date()) -> String? {
+        guard let remaining = remaining(until: date, now: now) else { return nil }
+        let seconds = Int(remaining)
+        if seconds >= 3600 {
+            let hours = seconds / 3600
+            let minutes = (seconds % 3600) / 60
+            return minutes > 0 ? "\(hours)h\(minutes)m" : "\(hours)h"
+        }
+        // Anything under a minute still reads as "1m" rather than "0m" — it is
+        // genuinely about to reset, which is the one case the old floor got right.
+        return "\(max(1, seconds / 60))m"
+    }
+
+    // Prose form for the Usage tab and banners: "in 2 hours".
+    static func relativeLabel(until date: Date, now: Date = Date()) -> String? {
+        guard remaining(until: date, now: now) != nil else { return nil }
+        return RelativeTime.string(date, style: .full)
+    }
+}
+
 // Shared relative-time strings ("5m ago", "in 3 days") with per-style cached
 // formatters (these were re-created in CompactView / Sessions / SessionUsage /
 // Panel). Formatters are reused on the main thread, matching prior usage.

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -819,6 +819,19 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
             .removeDuplicates()
             .sink { [weak self] _ in self?.applyCompactLayout() }
             .store(in: &cancellables)
+        // Poll cadence follows the usage surface wherever it changes, not only at
+        // the call sites that remember to say so. Settings → "Pin panel" expands
+        // the pill straight from PanelNav, and the hotkey collapse and focus-loss
+        // collapse both flip these flags without going through showPanel/
+        // hidePanel — each of those otherwise left the poller on the wrong
+        // cadence, and the pin case reproduced the original stale-on-open bug via
+        // a different door. Deferred one turn so the @Published value has settled
+        // before usageSurfaceDidChange reads it back.
+        Publishers.Merge(nav.$compactMode.dropFirst(), nav.$compactExpanded.dropFirst())
+            .sink { [weak self] _ in
+                DispatchQueue.main.async { self?.usageSurfaceDidChange() }
+            }
+            .store(in: &cancellables)
         nav.$compactCorner
             .removeDuplicates()
             .dropFirst()
@@ -1078,10 +1091,11 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     // applies layout synchronously (so the panel is resized before SwiftUI
     // re-renders the full content into the still-compact frame), then
     // brings the window forward.
+    // No usageSurfaceDidChange() here — the $compactExpanded subscription covers
+    // every flip of this flag, including the ones PanelNav makes directly.
     private func expandFromCompact() {
         nav.compactExpanded = true
         applyCompactLayout()
-        usageSurfaceDidChange()
     }
 
     // Applies the user-configured widget opacity to the window. Only takes
@@ -1327,8 +1341,11 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         // `quotaSyncing` guards the case where two entry points fire in the same
         // run loop pass: the probe is async, so quotaLastUpdated hasn't moved yet
         // and both would see the same stale timestamp.
+        // Claude's own timestamp, not the shared one: Codex and Antigravity are
+        // local reads that succeed every tick and would otherwise mask a stale or
+        // failing Claude probe behind a fresh-looking `quotaLastUpdated`.
         if showingUsage, !nav.quotaSyncing {
-            let age = nav.quotaLastUpdated.map { Date().timeIntervalSince($0) }
+            let age = nav.quotaClaudeLastUpdated.map { Date().timeIntervalSince($0) }
             if age == nil || age! >= Self.quotaPollVisibleInterval {
                 runQuotaProbe()
             }
@@ -1352,6 +1369,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                 self.nav.quota = snapshot
                 self.nav.quotaError = nil
                 self.nav.quotaLastUpdated = Date()
+                self.nav.quotaClaudeLastUpdated = Date()
                 self.evaluateQuotaThresholds(snapshot)
             } else if self.claudeCliQuotaProbe.isRateLimited {
                 // Soft-fail: hold any prior snapshot. On a cold first probe
@@ -1367,6 +1385,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                 // state instead of rendering old bars as if they were current.
                 self.nav.quota = nil
                 self.nav.quotaLastUpdated = nil
+                self.nav.quotaClaudeLastUpdated = nil
                 self.nav.quotaError = "Claude usage unavailable — run `claude /usage` to check your session."
             }
         }
@@ -3175,13 +3194,14 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         if nav.compactMode {
             if nav.compactExpanded {
                 nav.compactExpanded = false
-                applyCompactLayout()
-                usageSurfaceDidChange()
+                applyCompactLayout()  // cadence follows via the $compactExpanded sink
             }
             return
         }
         panel.orderOut(nil)
         NSApp.hide(nil)
+        // Explicit here: the non-compact path changes visibility without touching
+        // the compact flags, so no subscription fires.
         usageSurfaceDidChange()
     }
 

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -819,17 +819,14 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
             .removeDuplicates()
             .sink { [weak self] _ in self?.applyCompactLayout() }
             .store(in: &cancellables)
-        // Poll cadence follows the usage surface wherever it changes, not only at
-        // the call sites that remember to say so. Settings → "Pin panel" expands
-        // the pill straight from PanelNav, and the hotkey collapse and focus-loss
-        // collapse both flip these flags without going through showPanel/
-        // hidePanel — each of those otherwise left the poller on the wrong
-        // cadence, and the pin case reproduced the original stale-on-open bug via
-        // a different door. Deferred one turn so the @Published value has settled
-        // before usageSurfaceDidChange reads it back.
+        // Cadence follows these flags wherever they flip, not just at the call
+        // sites that remember to say so — Settings → "Pin panel" expands the pill
+        // straight from PanelNav, and the hotkey and focus-loss collapses go
+        // through neither showPanel nor hidePanel. Deferred a turn so the
+        // @Published value has settled before usageSurfaceDidChange reads it back.
         Publishers.Merge(nav.$compactMode.dropFirst(), nav.$compactExpanded.dropFirst())
-            .sink { [weak self] _ in
-                DispatchQueue.main.async { self?.usageSurfaceDidChange() }
+            .sink { _ in
+                DispatchQueue.main.async { [weak self] in self?.usageSurfaceDidChange() }
             }
             .store(in: &cancellables)
         nav.$compactCorner
@@ -1091,8 +1088,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     // applies layout synchronously (so the panel is resized before SwiftUI
     // re-renders the full content into the still-compact frame), then
     // brings the window forward.
-    // No usageSurfaceDidChange() here — the $compactExpanded subscription covers
-    // every flip of this flag, including the ones PanelNav makes directly.
+    // Cadence follows via the $compactExpanded subscription.
     private func expandFromCompact() {
         nav.compactExpanded = true
         applyCompactLayout()
@@ -1299,17 +1295,10 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         scheduleNextQuotaPoll()
     }
 
-    // In compact mode the widget pill IS the panel window: applyCompactLayout()
-    // ends with orderFront and hidePanel() only collapses it, so panel.isVisible
-    // never goes false. Keying the cadence off that alone pinned every widget
-    // user to the 60s visible interval and made Settings → Poll frequency a
-    // no-op — ~1,440 `claude --print /usage` spawns a day against 288 at the
-    // default, which is enough to earn the CLI's own rate limiting. A collapsed
-    // pill is a background surface; its countdown re-renders off other published
-    // state, so a slower probe doesn't freeze it.
-    //
-    // Static and parameterised because PanelController is AppKit-bound and can't
-    // be reached from the test target.
+    // In compact mode the pill IS the panel window and is never ordered out, so
+    // `panel.isVisible` alone pinned every widget user to the 60s interval and
+    // made Settings → Poll frequency a no-op. A collapsed pill counts as
+    // background. Static so the test target can reach it.
     static func quotaPollInterval(visible: Bool,
                                   compactMode: Bool,
                                   compactExpanded: Bool,
@@ -1333,17 +1322,15 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         }
     }
 
-    // Called whenever the usage surface is shown or hidden. Without this the
-    // cadence only changed on the *next* tick, so summoning the panel could show
-    // data a full hidden interval old and leave it that way for another one.
+    // Re-times the poller when the usage surface appears or goes away, and syncs
+    // on open. Without it the cadence only changed on the next tick, so summoning
+    // the panel could show data a full hidden interval old.
     private func usageSurfaceDidChange() {
         let showingUsage = panel.isVisible && (!nav.compactMode || nav.compactExpanded)
-        // `quotaSyncing` guards the case where two entry points fire in the same
-        // run loop pass: the probe is async, so quotaLastUpdated hasn't moved yet
-        // and both would see the same stale timestamp.
-        // Claude's own timestamp, not the shared one: Codex and Antigravity are
-        // local reads that succeed every tick and would otherwise mask a stale or
-        // failing Claude probe behind a fresh-looking `quotaLastUpdated`.
+        // Claude's own timestamp, not the shared one — Codex and Antigravity are
+        // local reads that succeed every tick and would mask a failing probe.
+        // `quotaSyncing` covers two entry points firing in the same run loop pass,
+        // before an in-flight probe has moved the timestamp.
         if showingUsage, !nav.quotaSyncing {
             let age = nav.quotaClaudeLastUpdated.map { Date().timeIntervalSince($0) }
             if age == nil || age! >= Self.quotaPollVisibleInterval {
@@ -2187,19 +2174,11 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     // for the initial fire and by the snooze timer for re-fires. Request
     // identifier is a fresh UUID each time (macOS replaces by identifier);
     // event.id stays in userInfo so click handlers can find the source.
-    // Banner title with the session label appended: a chosen name when one
-    // exists, else the project folder.
-    //
-    // Two prior rounds of this were too narrow. It first joined event to session
-    // on Claude's session UUID alone, so a rename never reached the banner for any
-    // other agent, and it accepted Claude Code's auto-derived name — which 2.1+
-    // gives every session, so every banner read "Claude Code — stackone-89"
-    // whether or not anything had been renamed. Routing through SessionLabel fixed
-    // both, but via `chosenName`, which is nil unless a human renamed the session
-    // — so the common case (nobody renamed anything) posted a bare "Claude Code"
-    // with no clue which project was asking. The banner is the one surface read
-    // with no surrounding context, so it takes `displayName`, the same label the
-    // Events row shows.
+    // Chosen name when one exists, else the project folder. Was `chosenName`,
+    // which is nil unless a human renamed the session — so the common case posted
+    // a bare "Claude Code" with no clue which project was asking. The banner is
+    // read with no surrounding context, so it takes the same label as the Events
+    // row.
     private func bannerTitle(for event: NudgeEvent) -> String {
         guard let label = SessionLabel.displayName(for: event,
                                                    in: sessions.sessions,
@@ -3200,8 +3179,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         }
         panel.orderOut(nil)
         NSApp.hide(nil)
-        // Explicit here: the non-compact path changes visibility without touching
-        // the compact flags, so no subscription fires.
+        // Explicit: this path changes visibility without touching the flags.
         usageSurfaceDidChange()
     }
 

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -1081,6 +1081,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     private func expandFromCompact() {
         nav.compactExpanded = true
         applyCompactLayout()
+        usageSurfaceDidChange()
     }
 
     // Applies the user-configured widget opacity to the window. Only takes
@@ -1284,16 +1285,55 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         scheduleNextQuotaPoll()
     }
 
+    // In compact mode the widget pill IS the panel window: applyCompactLayout()
+    // ends with orderFront and hidePanel() only collapses it, so panel.isVisible
+    // never goes false. Keying the cadence off that alone pinned every widget
+    // user to the 60s visible interval and made Settings → Poll frequency a
+    // no-op — ~1,440 `claude --print /usage` spawns a day against 288 at the
+    // default, which is enough to earn the CLI's own rate limiting. A collapsed
+    // pill is a background surface; its countdown re-renders off other published
+    // state, so a slower probe doesn't freeze it.
+    //
+    // Static and parameterised because PanelController is AppKit-bound and can't
+    // be reached from the test target.
+    static func quotaPollInterval(visible: Bool,
+                                  compactMode: Bool,
+                                  compactExpanded: Bool,
+                                  hiddenInterval: TimeInterval) -> TimeInterval {
+        let showingUsage = visible && (!compactMode || compactExpanded)
+        return showingUsage ? quotaPollVisibleInterval : hiddenInterval
+    }
+
     private func scheduleNextQuotaPoll() {
         quotaTimer?.invalidate()
         // Schedule unconditionally so a re-enable from Settings picks up
         // again on the next tick without needing an explicit start call.
         // The probe itself bails when tracking is off.
-        let interval = panel.isVisible ? Self.quotaPollVisibleInterval : quotaPollHiddenInterval
+        let interval = Self.quotaPollInterval(visible: panel.isVisible,
+                                              compactMode: nav.compactMode,
+                                              compactExpanded: nav.compactExpanded,
+                                              hiddenInterval: quotaPollHiddenInterval)
         quotaTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: false) { [weak self] _ in
             self?.runQuotaProbe()
             self?.scheduleNextQuotaPoll()
         }
+    }
+
+    // Called whenever the usage surface is shown or hidden. Without this the
+    // cadence only changed on the *next* tick, so summoning the panel could show
+    // data a full hidden interval old and leave it that way for another one.
+    private func usageSurfaceDidChange() {
+        let showingUsage = panel.isVisible && (!nav.compactMode || nav.compactExpanded)
+        // `quotaSyncing` guards the case where two entry points fire in the same
+        // run loop pass: the probe is async, so quotaLastUpdated hasn't moved yet
+        // and both would see the same stale timestamp.
+        if showingUsage, !nav.quotaSyncing {
+            let age = nav.quotaLastUpdated.map { Date().timeIntervalSince($0) }
+            if age == nil || age! >= Self.quotaPollVisibleInterval {
+                runQuotaProbe()
+            }
+        }
+        scheduleNextQuotaPoll()
     }
 
     private func runQuotaProbe() {
@@ -1488,8 +1528,8 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
 
     private func postQuotaBanner(label: String, percent: Int, resetsAt: Date?) {
         let body: String
-        if let resetsAt {
-            body = "\(percent)% used. Resets \(RelativeTime.string(resetsAt, style: .full))."
+        if let resetsAt, let resetLabel = QuotaReset.relativeLabel(until: resetsAt) {
+            body = "\(percent)% used. Resets \(resetLabel)."
         } else {
             body = "\(percent)% used."
         }
@@ -2128,17 +2168,24 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     // for the initial fire and by the snooze timer for re-fires. Request
     // identifier is a fresh UUID each time (macOS replaces by identifier);
     // event.id stays in userInfo so click handlers can find the source.
-    // Banner title with session label appended when we can resolve one.
-    // Default project name is suppressed (already implied by the title); only
-    // a name someone actually chose is shown.
+    // Banner title with the session label appended: a chosen name when one
+    // exists, else the project folder.
     //
-    // This used to join event to session on Claude's session UUID alone, so a
-    // rename never reached the banner for any other agent, and it accepted
-    // Claude Code's auto-derived name — which 2.1+ gives every session, so
-    // every banner read "Claude Code — stackone-89" whether or not anything
-    // had been renamed. SessionLabel handles both.
+    // Two prior rounds of this were too narrow. It first joined event to session
+    // on Claude's session UUID alone, so a rename never reached the banner for any
+    // other agent, and it accepted Claude Code's auto-derived name — which 2.1+
+    // gives every session, so every banner read "Claude Code — stackone-89"
+    // whether or not anything had been renamed. Routing through SessionLabel fixed
+    // both, but via `chosenName`, which is nil unless a human renamed the session
+    // — so the common case (nobody renamed anything) posted a bare "Claude Code"
+    // with no clue which project was asking. The banner is the one surface read
+    // with no surrounding context, so it takes `displayName`, the same label the
+    // Events row shows.
     private func bannerTitle(for event: NudgeEvent) -> String {
-        guard let label = sessionLabel(for: event) else { return event.title }
+        guard let label = SessionLabel.displayName(for: event,
+                                                   in: sessions.sessions,
+                                                   persistence: SessionPersistence.shared)
+        else { return event.title }
         return "\(event.title) — \(label)"
     }
 
@@ -3116,6 +3163,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         positionPanel()  // re-resolve in case the user moved to a different display
         NSApp.activate(ignoringOtherApps: true)
         panel.makeKeyAndOrderFront(nil)
+        usageSurfaceDidChange()
     }
 
     // NSApp.hide hides all our windows AND deactivates the app, so the system
@@ -3128,11 +3176,13 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
             if nav.compactExpanded {
                 nav.compactExpanded = false
                 applyCompactLayout()
+                usageSurfaceDidChange()
             }
             return
         }
         panel.orderOut(nil)
         NSApp.hide(nil)
+        usageSurfaceDidChange()
     }
 
     // MARK: - Setup helpers

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -268,16 +268,12 @@ final class PanelNav: ObservableObject {
     // poller in PanelController. nil before the first probe completes, or
     // when the probe failed (no `claude` on PATH, not signed in, parse error).
     @Published var quota:            QuotaSnapshot?
-    // Freshness of *any* client's quota — Claude, Codex and Antigravity all
-    // stamp it — so the Usage tab's "Updated Xm ago" describes the pane as a
-    // whole.
+    // Any client's quota — all three stamp it — so "Updated Xm ago" describes the
+    // pane as a whole.
     @Published var quotaLastUpdated: Date?
-    // Freshness of the Claude probe alone. Separate because Codex and
-    // Antigravity are cheap local reads that succeed on every tick, so they keep
-    // `quotaLastUpdated` looking fresh even while the `claude` shell-out is
-    // failing or rate-limited. Gating the sync-on-open check on the shared
-    // timestamp let a Codex user open the panel to stale Claude bars and get no
-    // re-probe — the exact refresh that check exists to guarantee.
+    // The Claude probe alone. Codex and Antigravity are local reads that succeed
+    // on every tick, so they keep the shared timestamp looking fresh while the
+    // `claude` shell-out is failing; the sync-on-open check needs this one.
     @Published var quotaClaudeLastUpdated: Date?
     // True while a probe is in-flight. Set by PanelController around the
     // fetch call so the UI can swap the footer status to "Syncing…".

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -268,7 +268,17 @@ final class PanelNav: ObservableObject {
     // poller in PanelController. nil before the first probe completes, or
     // when the probe failed (no `claude` on PATH, not signed in, parse error).
     @Published var quota:            QuotaSnapshot?
+    // Freshness of *any* client's quota — Claude, Codex and Antigravity all
+    // stamp it — so the Usage tab's "Updated Xm ago" describes the pane as a
+    // whole.
     @Published var quotaLastUpdated: Date?
+    // Freshness of the Claude probe alone. Separate because Codex and
+    // Antigravity are cheap local reads that succeed on every tick, so they keep
+    // `quotaLastUpdated` looking fresh even while the `claude` shell-out is
+    // failing or rate-limited. Gating the sync-on-open check on the shared
+    // timestamp let a Codex user open the panel to stale Claude bars and get no
+    // re-probe — the exact refresh that check exists to guarantee.
+    @Published var quotaClaudeLastUpdated: Date?
     // True while a probe is in-flight. Set by PanelController around the
     // fetch call so the UI can swap the footer status to "Syncing…".
     @Published var quotaSyncing:     Bool = false
@@ -1221,6 +1231,7 @@ final class PanelNav: ObservableObject {
         if !quotaTrackingEnabled {
             quota = nil
             quotaLastUpdated = nil
+            quotaClaudeLastUpdated = nil
             quotaError = nil
         }
     }

--- a/panel/SessionLabel.swift
+++ b/panel/SessionLabel.swift
@@ -16,11 +16,9 @@ import Foundation
 //   3. the cwd basename, which nobody chose, so callers that need a name
 //      rather than a label ask for `chosenName` and get nil here.
 //
-// Which to call: anything the user reads on screen — the Events row, the
-// Sessions row, the banner title — wants `displayName`, because a banner that
-// omits the project tells you nothing about which session is asking. Only speech
-// wants `chosenName`: the hook already baked the cwd into its phrase, so nil
-// there means "nothing better to say" rather than "no label".
+// Which to call: on-screen surfaces (Events row, Sessions row, banner title) want
+// `displayName`. Only speech wants `chosenName` — the hook already baked the cwd
+// into its phrase, so nil there means "nothing better to say", not "no label".
 //
 // Deliberately excluded: the terminal tab name. On iTerm2 a manual rename,
 // an OSC title escape and the profile name all write the same `autoName`

--- a/panel/SessionLabel.swift
+++ b/panel/SessionLabel.swift
@@ -16,6 +16,12 @@ import Foundation
 //   3. the cwd basename, which nobody chose, so callers that need a name
 //      rather than a label ask for `chosenName` and get nil here.
 //
+// Which to call: anything the user reads on screen — the Events row, the
+// Sessions row, the banner title — wants `displayName`, because a banner that
+// omits the project tells you nothing about which session is asking. Only speech
+// wants `chosenName`: the hook already baked the cwd into its phrase, so nil
+// there means "nothing better to say" rather than "no label".
+//
 // Deliberately excluded: the terminal tab name. On iTerm2 a manual rename,
 // an OSC title escape and the profile name all write the same `autoName`
 // variable, so there is no way to read "the user chose this" back out — and

--- a/panel/SessionUsage.swift
+++ b/panel/SessionUsage.swift
@@ -478,8 +478,11 @@ struct UsageView: View {
             }
             ProgressView(value: min(tier.utilization, 100), total: 100)
                 .tint(barColor(tier.utilization))
-            if let resets = tier.resetsAt {
-                Text("Resets \(RelativeTime.string(resets, style: .full))")
+            // Hidden rather than rendered as "Resets 11 months ago" when the
+            // deadline has passed — that only happens on a stale snapshot, and a
+            // silent row beats a confidently wrong one.
+            if let resets = tier.resetsAt, let label = QuotaReset.relativeLabel(until: resets) {
+                Text("Resets \(label)")
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
             }

--- a/panel/SessionUsage.swift
+++ b/panel/SessionUsage.swift
@@ -478,9 +478,7 @@ struct UsageView: View {
             }
             ProgressView(value: min(tier.utilization, 100), total: 100)
                 .tint(barColor(tier.utilization))
-            // Hidden rather than rendered as "Resets 11 months ago" when the
-            // deadline has passed — that only happens on a stale snapshot, and a
-            // silent row beats a confidently wrong one.
+            // Hidden rather than "Resets 11 months ago" on a stale snapshot.
             if let resets = tier.resetsAt, let label = QuotaReset.relativeLabel(until: resets) {
                 Text("Resets \(label)")
                     .font(.caption2)


### PR DESCRIPTION
## Why

The Usage tab and the compact widget could freeze: percentages and the "resets in…" countdown stopped moving while the footer's "Updated Xm ago" kept climbing.

The root cause is the poll cadence. The interval was chosen from `panel.isVisible`, but in compact mode the pill **is** the panel window — `applyCompactLayout()` ends with `orderFront` and `hidePanel()` only collapses it — so that flag never went false. Every widget user polled at the 60s "visible" rate and **Settings → Poll frequency was silently a no-op**: ~1,440 `claude --print /usage` spawns a day against 288 at the default, which is enough to earn the CLI's own rate limiting. A rate-limited probe soft-fails and holds the prior snapshot by design — that's the freeze. Two display bugs then made a held-over snapshot look permanently wrong rather than briefly stale.

## What changed

| # | Fix |
|---|-----|
| 1 | Poll interval comes from a pure, testable `PanelController.quotaPollInterval`. A collapsed pill counts as a background surface, so the configured frequency applies. |
| 2 | Showing/hiding the usage surface re-times the poller immediately and syncs on open when the last snapshot is over a minute old. Previously the cadence only changed on the *next* tick, so opening the panel could show data a full hidden interval old and leave it that way for another one. |
| 3 | New shared `QuotaReset` (in `Formatting.swift`, beside `TokenFormat`/`RelativeTime`) returns nil once a deadline has passed, so no surface renders a stale one. The widget's formatter floored at `max(1, s / 60)`, so an expired reset read as a live **"1m"** forever; the Usage tab printed "Resets 11 months ago" verbatim. |
| 4 | `parseResetsAt` tries the neighbouring years and keeps whichever lands nearest `now`. Splicing in the current year alone put "Jan 1 at 3am" read on Dec 31 twelve months in the past. |
| 5 | README: state the widget's cadence. |
| 6 | `bannerTitle` asked `SessionLabel.chosenName`, nil unless a human renamed the session — so the common case posted a bare "Claude Code" with no clue which project was asking. Now uses `displayName`, the label the Events row already shows. |
| 7 | `notify.sh` had no `AskUserQuestion` case, so the banner body fell through to the bare tool name. It now surfaces the question; speech gets the shorter header. |

6 and 7 are the "Claude Code / AskUserQuestion" banner with no project and no question — two unrelated causes, folded in here rather than split across PRs.

## Testing

- `QuotaResetTests` — boundary behaviour of `shortLabel` / `relativeLabel` / `remaining`, including the past-deadline shape the year-splice bug produced.
- `QuotaPollIntervalTests` — pins the collapsed-widget case that regressed, plus expanded / full-panel / hidden.
- `ClaudeCliQuotaProbeTests` — New Year rollover, and that an ordinary mid-year reset is unchanged.
- The date logic was also exercised standalone against NYE, leap day, and a weekly window crossing New Year.
- `make build` and `make typecheck-tests` pass locally (`swift test` needs full Xcode; CI runs the assertions).

6 and 7 have no unit-test surface — `bannerTitle` is private on the AppKit controller and `notify.sh` has no shell harness — so they need the manual check below. The `jq` paths were verified against a real `AskUserQuestion` payload, including the degenerate no-questions case.

## Manual verification

1. Poll frequency → 1 min, widget on, collapsed: probe fires on the configured cadence, not every 60s.
2. Leave the panel hidden past one interval, then summon it: the Usage tab syncs on open.
3. Widget shows "—" rather than a stuck "1m" when no live reset is known.
4. Trigger an `AskUserQuestion` prompt: the banner reads "Claude Code — <repo>" with the question as the body.

## Out of scope

The quota alert gate (`evaluateQuotaThresholds`) can skip a warning after a partial decay — fire at 90%, decay to 65% (under the 30pp re-arm threshold), climb back to 85% → no banner. Lower confidence and the 30pp constant wants its own tuning, so it gets a separate issue.