### PR TITLE
feat(widget): free placement for the compact widget

### DIFF
--- a/Tests/StackNudgePanelCoreTests/CompactPlacementTests.swift
+++ b/Tests/StackNudgePanelCoreTests/CompactPlacementTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+import CoreGraphics
+
+@testable import StackNudgePanelCore
+
+final class CompactPlacementTests: XCTestCase {
+
+    // A 1000x1000 frame at origin (0,0); midpoint is (500, 500).
+    private let frame = CGRect(x: 0, y: 0, width: 1000, height: 1000)
+
+    // MARK: - nearestCorner (AppKit coords: y grows upward)
+
+    func test_nearestCorner_quadrants() {
+        // Below-mid Y = bottom; left/right by X.
+        XCTAssertEqual(CompactPlacement.nearestCorner(toCenter: CGPoint(x: 100, y: 100), in: frame), .bottomLeft)
+        XCTAssertEqual(CompactPlacement.nearestCorner(toCenter: CGPoint(x: 900, y: 100), in: frame), .bottomRight)
+        XCTAssertEqual(CompactPlacement.nearestCorner(toCenter: CGPoint(x: 100, y: 900), in: frame), .topLeft)
+        XCTAssertEqual(CompactPlacement.nearestCorner(toCenter: CGPoint(x: 900, y: 900), in: frame), .topRight)
+    }
+
+    func test_nearestCorner_respectsFrameOrigin() {
+        // Frame shifted to a second display; midpoint is (2500, 500).
+        let shifted = CGRect(x: 2000, y: 0, width: 1000, height: 1000)
+        XCTAssertEqual(CompactPlacement.nearestCorner(toCenter: CGPoint(x: 2100, y: 900), in: shifted), .topLeft)
+        XCTAssertEqual(CompactPlacement.nearestCorner(toCenter: CGPoint(x: 2900, y: 100), in: shifted), .bottomRight)
+    }
+
+    // MARK: - clamp
+
+    func test_clamp_insideFrame_isUnchanged() {
+        let p = CompactPlacement.clamp(origin: CGPoint(x: 400, y: 400),
+                                       size: CGSize(width: 100, height: 50),
+                                       into: frame, inset: 14)
+        XCTAssertEqual(p, CGPoint(x: 400, y: 400))
+    }
+
+    func test_clamp_pullsBackWithinInsetOnAllSides() {
+        let size = CGSize(width: 100, height: 50)
+        // Off the bottom-left.
+        XCTAssertEqual(CompactPlacement.clamp(origin: CGPoint(x: -50, y: -50),
+                                              size: size, into: frame, inset: 14),
+                       CGPoint(x: 14, y: 14))
+        // Off the top-right (maxX = 1000-100-14 = 886, maxY = 1000-50-14 = 936).
+        XCTAssertEqual(CompactPlacement.clamp(origin: CGPoint(x: 5000, y: 5000),
+                                              size: size, into: frame, inset: 14),
+                       CGPoint(x: 886, y: 936))
+    }
+
+    func test_clamp_degenerateFrameSmallerThanPill_pinsToMinInset() {
+        // Frame narrower/shorter than pill+insets: pin to min inset, no NaN/flip.
+        let tiny = CGRect(x: 0, y: 0, width: 80, height: 40)
+        let p = CompactPlacement.clamp(origin: CGPoint(x: 999, y: 999),
+                                       size: CGSize(width: 100, height: 50),
+                                       into: tiny, inset: 14)
+        XCTAssertEqual(p, CGPoint(x: 14, y: 14))
+    }
+
+    // MARK: - parse / format
+
+    func test_parsePosition_roundTrip() {
+        let p = CGPoint(x: 123, y: 456)
+        XCTAssertEqual(CompactPlacement.parsePosition(CompactPlacement.formatPosition(p)), p)
+    }
+
+    func test_parsePosition_toleratesWhitespace() {
+        XCTAssertEqual(CompactPlacement.parsePosition(" 12 , 34 "), CGPoint(x: 12, y: 34))
+    }
+
+    func test_parsePosition_rejectsMalformedAndNil() {
+        XCTAssertNil(CompactPlacement.parsePosition(nil))
+        XCTAssertNil(CompactPlacement.parsePosition(""))
+        XCTAssertNil(CompactPlacement.parsePosition("123"))
+        XCTAssertNil(CompactPlacement.parsePosition("a,b"))
+        XCTAssertNil(CompactPlacement.parsePosition("1,2,3"))
+    }
+
+    func test_formatPosition_roundsToIntegers() {
+        XCTAssertEqual(CompactPlacement.formatPosition(CGPoint(x: 12.6, y: 34.2)), "13,34")
+    }
+}

--- a/Tests/StackNudgePanelCoreTests/CompactPlacementTests.swift
+++ b/Tests/StackNudgePanelCoreTests/CompactPlacementTests.swift
@@ -99,4 +99,17 @@ final class CompactPlacementTests: XCTestCase {
     func test_formatPosition_roundsToIntegers() {
         XCTAssertEqual(CompactPlacement.formatPosition(CGPoint(x: 12.6, y: 34.2)), "13,34")
     }
+
+    // MARK: - placementBounds (free placement: Dock free at bottom, menu bar capped at top)
+
+    func test_placementBounds_bottomIsPhysical_topIsBelowMenuBar() {
+        // Full screen 1000 tall; 60pt Dock at the bottom, 25pt menu bar at the top.
+        let physical = CGRect(x: 0, y: 0, width: 1000, height: 1000)
+        let visible  = CGRect(x: 0, y: 60, width: 1000, height: 915) // maxY = 975
+        let b = CompactPlacement.placementBounds(frame: physical, visibleFrame: visible)
+        XCTAssertEqual(b.minY, 0)      // reaches the physical bottom (over the Dock)
+        XCTAssertEqual(b.maxY, 975)    // capped at the menu-bar underside
+        XCTAssertEqual(b.minX, 0)      // full width
+        XCTAssertEqual(b.maxX, 1000)
+    }
 }

--- a/Tests/StackNudgePanelCoreTests/CompactPlacementTests.swift
+++ b/Tests/StackNudgePanelCoreTests/CompactPlacementTests.swift
@@ -16,6 +16,8 @@ final class CompactPlacementTests: XCTestCase {
         XCTAssertEqual(CompactPlacement.nearestCorner(toCenter: CGPoint(x: 900, y: 100), in: frame), .bottomRight)
         XCTAssertEqual(CompactPlacement.nearestCorner(toCenter: CGPoint(x: 100, y: 900), in: frame), .topLeft)
         XCTAssertEqual(CompactPlacement.nearestCorner(toCenter: CGPoint(x: 900, y: 900), in: frame), .topRight)
+        // Exactly on both midpoints ties to top-right (`<` is false on each axis).
+        XCTAssertEqual(CompactPlacement.nearestCorner(toCenter: CGPoint(x: 500, y: 500), in: frame), .topRight)
     }
 
     func test_nearestCorner_respectsFrameOrigin() {
@@ -94,6 +96,11 @@ final class CompactPlacementTests: XCTestCase {
         XCTAssertNil(CompactPlacement.parsePosition("123"))
         XCTAssertNil(CompactPlacement.parsePosition("a,b"))
         XCTAssertNil(CompactPlacement.parsePosition("1,2,3"))
+        // Non-finite values parse as Double but must be rejected — a hand-edited
+        // config must never feed NaN/Inf through clamp into setFrame.
+        XCTAssertNil(CompactPlacement.parsePosition("nan,0"))
+        XCTAssertNil(CompactPlacement.parsePosition("0,inf"))
+        XCTAssertNil(CompactPlacement.parsePosition("-inf,10"))
     }
 
     func test_formatPosition_roundsToIntegers() {
@@ -110,6 +117,17 @@ final class CompactPlacementTests: XCTestCase {
         XCTAssertEqual(b.minY, 0)      // reaches the physical bottom (over the Dock)
         XCTAssertEqual(b.maxY, 975)    // capped at the menu-bar underside
         XCTAssertEqual(b.minX, 0)      // full width
+        XCTAssertEqual(b.maxX, 1000)
+    }
+
+    func test_placementBounds_displayBelowMain_negativeOrigin() {
+        // A display arranged below the main one: frame.minY is negative.
+        let physical = CGRect(x: 0, y: -1000, width: 1000, height: 1000)
+        let visible  = CGRect(x: 0, y: -940, width: 1000, height: 915)  // maxY = -25
+        let b = CompactPlacement.placementBounds(frame: physical, visibleFrame: visible)
+        XCTAssertEqual(b.minY, -1000)  // physical bottom of the lower display
+        XCTAssertEqual(b.maxY, -25)    // menu-bar underside (visibleFrame.maxY)
+        XCTAssertEqual(b.minX, 0)
         XCTAssertEqual(b.maxX, 1000)
     }
 }

--- a/Tests/StackNudgePanelCoreTests/CompactPlacementTests.swift
+++ b/Tests/StackNudgePanelCoreTests/CompactPlacementTests.swift
@@ -25,6 +25,28 @@ final class CompactPlacementTests: XCTestCase {
         XCTAssertEqual(CompactPlacement.nearestCorner(toCenter: CGPoint(x: 2900, y: 100), in: shifted), .bottomRight)
     }
 
+    // MARK: - frameIndex(containing:in:)
+
+    func test_frameIndex_findsContainingFrame() {
+        let frames = [CGRect(x: 0, y: 0, width: 100, height: 100),
+                      CGRect(x: 200, y: 0, width: 100, height: 100)]
+        XCTAssertEqual(CompactPlacement.frameIndex(containing: CGPoint(x: 50, y: 50), in: frames), 0)
+        XCTAssertEqual(CompactPlacement.frameIndex(containing: CGPoint(x: 250, y: 50), in: frames), 1)
+    }
+
+    func test_frameIndex_nilWhenPointOnNoFrame() {
+        let frames = [CGRect(x: 0, y: 0, width: 100, height: 100)]
+        XCTAssertNil(CompactPlacement.frameIndex(containing: CGPoint(x: 500, y: 500), in: frames))
+        XCTAssertNil(CompactPlacement.frameIndex(containing: CGPoint(x: 50, y: 50), in: []))
+    }
+
+    func test_frameIndex_returnsFirstMatchWhenFramesOverlap() {
+        let frames = [CGRect(x: 0, y: 0, width: 100, height: 100),
+                      CGRect(x: 50, y: 50, width: 100, height: 100)]
+        // (60,60) is inside both; expect the first.
+        XCTAssertEqual(CompactPlacement.frameIndex(containing: CGPoint(x: 60, y: 60), in: frames), 0)
+    }
+
     // MARK: - clamp
 
     func test_clamp_insideFrame_isUnchanged() {

--- a/Tests/StackNudgePanelCoreTests/SettingsRowTests.swift
+++ b/Tests/StackNudgePanelCoreTests/SettingsRowTests.swift
@@ -145,4 +145,16 @@ final class SettingsRowTests: XCTestCase {
             XCTAssertEqual(nav.selectedRow, row)
         }
     }
+
+    func test_snapToCorners_defaultsOn() {
+        XCTAssertTrue(PanelNav().compactSnap)
+    }
+
+    func test_snapToCorners_sitsRightAfterWidget() {
+        let rows = PanelNav().settingsRows
+        let widget = rows.firstIndex(of: .widget)
+        XCTAssertNotNil(widget)
+        XCTAssertEqual(rows[widget! + 1], .snapToCorners)
+        XCTAssertEqual(rows[widget! + 2], .widgetCorner)
+    }
 }

--- a/panel/CompactPlacement.swift
+++ b/panel/CompactPlacement.swift
@@ -1,0 +1,54 @@
+import CoreGraphics
+import Foundation
+
+// Pure geometry + persistence helpers for the compact widget's position.
+// No AppKit window/screen access lives here so the math is unit-testable in
+// isolation; PanelController supplies the concrete screen frame and window
+// size at call time.
+enum CompactPlacement {
+
+    // Which corner a pill centred at `center` is closest to, within
+    // `visibleFrame`. AppKit coordinates: y grows upward, so a center below
+    // the vertical midpoint is a *bottom* corner.
+    static func nearestCorner(toCenter center: CGPoint,
+                              in visibleFrame: CGRect) -> CompactCorner {
+        switch (center.x < visibleFrame.midX, center.y < visibleFrame.midY) {
+        case (true,  false): return .topLeft
+        case (false, false): return .topRight
+        case (true,  true):  return .bottomLeft
+        case (false, true):  return .bottomRight
+        }
+    }
+
+    // Clamp a pill of `size` positioned at `origin` so it stays fully inside
+    // `visibleFrame`, keeping `inset` clearance from every edge. If the frame
+    // is smaller than the pill plus insets (maxN < minN), pin to the min inset
+    // rather than producing an inverted range.
+    static func clamp(origin: CGPoint, size: CGSize,
+                      into visibleFrame: CGRect, inset: CGFloat) -> CGPoint {
+        let minX = visibleFrame.minX + inset
+        let maxX = visibleFrame.maxX - size.width - inset
+        let minY = visibleFrame.minY + inset
+        let maxY = visibleFrame.maxY - size.height - inset
+        let x = maxX >= minX ? min(max(origin.x, minX), maxX) : minX
+        let y = maxY >= minY ? min(max(origin.y, minY), maxY) : minY
+        return CGPoint(x: x, y: y)
+    }
+
+    // Parse a persisted "x,y" string into a point. Returns nil for missing or
+    // malformed input so callers can fall back to a corner origin.
+    static func parsePosition(_ raw: String?) -> CGPoint? {
+        guard let raw else { return nil }
+        let parts = raw.split(separator: ",", omittingEmptySubsequences: false)
+        guard parts.count == 2,
+              let x = Double(parts[0].trimmingCharacters(in: .whitespaces)),
+              let y = Double(parts[1].trimmingCharacters(in: .whitespaces))
+        else { return nil }
+        return CGPoint(x: x, y: y)
+    }
+
+    // Format a point for persistence as integer "x,y".
+    static func formatPosition(_ p: CGPoint) -> String {
+        "\(Int(p.x.rounded())),\(Int(p.y.rounded()))"
+    }
+}

--- a/panel/CompactPlacement.swift
+++ b/panel/CompactPlacement.swift
@@ -9,7 +9,8 @@ enum CompactPlacement {
 
     // Which corner a pill centred at `center` is closest to, within
     // `visibleFrame`. AppKit coordinates: y grows upward, so a center below
-    // the vertical midpoint is a *bottom* corner.
+    // the vertical midpoint is a *bottom* corner. A center exactly on midX/midY
+    // ties to the right/top (the `<` comparisons are false).
     static func nearestCorner(toCenter center: CGPoint,
                               in visibleFrame: CGRect) -> CompactCorner {
         switch (center.x < visibleFrame.midX, center.y < visibleFrame.midY) {
@@ -58,8 +59,8 @@ enum CompactPlacement {
         guard let raw else { return nil }
         let parts = raw.split(separator: ",", omittingEmptySubsequences: false)
         guard parts.count == 2,
-              let x = Double(parts[0].trimmingCharacters(in: .whitespaces)),
-              let y = Double(parts[1].trimmingCharacters(in: .whitespaces))
+              let x = Double(parts[0].trimmingCharacters(in: .whitespaces)), x.isFinite,
+              let y = Double(parts[1].trimmingCharacters(in: .whitespaces)), y.isFinite
         else { return nil }
         return CGPoint(x: x, y: y)
     }

--- a/panel/CompactPlacement.swift
+++ b/panel/CompactPlacement.swift
@@ -35,6 +35,12 @@ enum CompactPlacement {
         return CGPoint(x: x, y: y)
     }
 
+    // Index of the first frame that contains `point`, or nil if the point is
+    // on no frame. Used to find which screen a free-placed pill lives on.
+    static func frameIndex(containing point: CGPoint, in frames: [CGRect]) -> Int? {
+        frames.firstIndex { $0.contains(point) }
+    }
+
     // Parse a persisted "x,y" string into a point. Returns nil for missing or
     // malformed input so callers can fall back to a corner origin.
     static func parsePosition(_ raw: String?) -> CGPoint? {

--- a/panel/CompactPlacement.swift
+++ b/panel/CompactPlacement.swift
@@ -41,6 +41,17 @@ enum CompactPlacement {
         frames.firstIndex { $0.contains(point) }
     }
 
+    // The region a free-placed pill may occupy on a screen: full width and down
+    // to the physical bottom of `frame` (so it can sit over the Dock), but
+    // capped at the top of `visibleFrame` (just under the menu bar). Clamping a
+    // pill into this keeps it fully on-screen while allowing Dock-level
+    // placement. AppKit coords (y up): the menu bar is at the top, so
+    // visibleFrame.maxY is the underside of the menu bar.
+    static func placementBounds(frame: CGRect, visibleFrame: CGRect) -> CGRect {
+        CGRect(x: frame.minX, y: frame.minY,
+               width: frame.width, height: visibleFrame.maxY - frame.minY)
+    }
+
     // Parse a persisted "x,y" string into a point. Returns nil for missing or
     // malformed input so callers can fall back to a corner origin.
     static func parsePosition(_ raw: String?) -> CGPoint? {

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -1030,7 +1030,12 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     // Apply window size + origin appropriate to the current compact-mode
     // state. Called whenever nav.compactMode or nav.compactExpanded changes
     // and once at launch to handle config-restored state.
-    private func applyCompactLayout() {
+    //
+    // `snap` overrides nav.compactSnap for callers that run inside its
+    // @Published willSet (the $compactSnap sink), where the property still
+    // holds the pre-change value. Everyone else passes nil and reads the
+    // settled property.
+    private func applyCompactLayout(snap: Bool? = nil) {
         if nav.compactMode, !nav.compactExpanded {
             // Widget: shrink + pin to the chosen corner, float above
             // everything, follow the user across spaces. Transparent
@@ -1042,7 +1047,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
             panel.contentMinSize = size
             var frame = panel.frame
             frame.size = size
-            frame.origin = nav.compactSnap
+            frame.origin = (snap ?? nav.compactSnap)
                 ? compactCornerOrigin(for: size)
                 : resolvedFreeOrigin(for: size)
             ignoringProgrammaticMove = true
@@ -1229,9 +1234,14 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                                  value: corner.rawValue)
             }
         } else {
-            nav.setCompactFreeOrigin(cornerOrigin(for: size, corner: nav.compactCorner))
+            // Seed the free origin from the pill's current resting corner so it
+            // stays put. Resolve against the panel's own screen, not the cursor's
+            // (Settings is keyboard-driven, so on multi-monitor the cursor may be
+            // on a different display than the widget).
+            nav.setCompactFreeOrigin(
+                cornerOrigin(for: size, corner: nav.compactCorner, on: panel.screen))
         }
-        applyCompactLayout()
+        applyCompactLayout(snap: snap)
     }
 
     // The region a free-placed pill may occupy on `screen`: full width, down to
@@ -1274,8 +1284,9 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                                       inset: Self.compactWidgetInset)
     }
 
-    private func cornerOrigin(for size: NSSize, corner: CompactCorner) -> NSPoint {
-        let visible = activeScreen().visibleFrame
+    private func cornerOrigin(for size: NSSize, corner: CompactCorner,
+                              on screen: NSScreen? = nil) -> NSPoint {
+        let visible = (screen ?? activeScreen()).visibleFrame
         let inset = Self.compactWidgetInset
         switch corner {
         case .topLeft:

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -1044,7 +1044,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
             frame.size = size
             frame.origin = nav.compactSnap
                 ? compactCornerOrigin(for: size)
-                : compactFreeOrigin(for: size)
+                : resolvedFreeOrigin(for: size)
             ignoringProgrammaticMove = true
             panel.setFrame(frame, display: true, animate: false)
             ignoringProgrammaticMove = false
@@ -1191,7 +1191,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     // animation — the pill stays where the user let go.
     private func persistCompactFreePosition() {
         guard nav.compactMode, !nav.compactExpanded else { return }
-        let visible = activeScreen().visibleFrame
+        let visible = screenForFreeOrigin(panel.frame.origin, size: panel.frame.size).visibleFrame
         let clamped = CompactPlacement.clamp(origin: panel.frame.origin,
                                              size: panel.frame.size,
                                              into: visible,
@@ -1205,18 +1205,18 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         nav.setCompactFreeOrigin(clamped)
     }
 
-    // Re-enabling snap: pick the corner nearest the pill's last floating spot
-    // (its saved free origin, since the panel is expanded in Settings when the
-    // toggle flips and its live frame isn't the pill's), persist that corner,
-    // then re-lay-out so the pill lands there when it next collapses. Turning
-    // snap off does nothing visible — the pill keeps its current spot until the
-    // next drag.
+    // Snap toggled. On ENABLE: pick the corner nearest the pill's last floating
+    // spot (its saved free origin — the panel is expanded in Settings when the
+    // toggle flips, so its live frame isn't the pill's) and persist it, so the
+    // pill lands there on next collapse. On DISABLE: pin the free origin to the
+    // pill's current resting corner so it stays put instead of jumping to a
+    // stale free spot. Either way, re-lay-out.
     private func handleSnapModeChange(_ snap: Bool) {
+        let size = compactWidgetSizeForMode
         if snap {
-            let size = compactWidgetSizeForMode
-            let visible = activeScreen().visibleFrame
             let origin = nav.compactFreeOrigin
                 ?? cornerOrigin(for: size, corner: nav.compactCorner)
+            let visible = screenForFreeOrigin(origin, size: size).visibleFrame
             let center = NSPoint(x: origin.x + size.width / 2,
                                  y: origin.y + size.height / 2)
             let corner = CompactPlacement.nearestCorner(toCenter: center, in: visible)
@@ -1225,8 +1225,24 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                 ConfigFile.write(key: "STACKNUDGE_COMPACT_CORNER",
                                  value: corner.rawValue)
             }
+        } else {
+            nav.setCompactFreeOrigin(cornerOrigin(for: size, corner: nav.compactCorner))
         }
         applyCompactLayout()
+    }
+
+    // The screen a free-placed pill at `origin` lives on — the one containing
+    // the pill's centre — so it stays on its own display regardless of where
+    // the cursor is. Falls back to the cursor's screen when the centre is on
+    // no connected screen (e.g. a monitor was unplugged).
+    private func screenForFreeOrigin(_ origin: NSPoint, size: NSSize) -> NSScreen {
+        let center = NSPoint(x: origin.x + size.width / 2,
+                             y: origin.y + size.height / 2)
+        if let idx = CompactPlacement.frameIndex(containing: center,
+                                                 in: NSScreen.screens.map(\.frame)) {
+            return NSScreen.screens[idx]
+        }
+        return activeScreen()
     }
 
     private func compactCornerOrigin(for size: NSSize) -> NSPoint {
@@ -1234,12 +1250,13 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     }
 
     // Origin for free-placement mode: the saved free position clamped into the
-    // active screen (so a display change can't strand the pill), falling back
-    // to the current corner the first time free mode is entered.
-    private func compactFreeOrigin(for size: NSSize) -> NSPoint {
-        let visible = activeScreen().visibleFrame
+    // screen that contains it (so it stays on its own display, and a resolution
+    // change can't strand it), falling back to the current corner the first
+    // time free mode is entered.
+    private func resolvedFreeOrigin(for size: NSSize) -> NSPoint {
         let saved = nav.compactFreeOrigin
             ?? cornerOrigin(for: size, corner: nav.compactCorner)
+        let visible = screenForFreeOrigin(saved, size: size).visibleFrame
         return CompactPlacement.clamp(origin: saved, size: size,
                                       into: visible,
                                       inset: Self.compactWidgetInset)
@@ -3312,11 +3329,10 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
             queue: .main
         ) { [weak self] _ in
             guard let self, let panel = self.panel as NSWindow? else { return }
-            // Compact widget: don't persist the moved origin (the corner
-            // is the source of truth). The actual snap fires from the
-            // mouse-up event monitor. Here we just record that movement
-            // happened during the current mouse-down so the monitor
-            // knows whether to snap.
+            // Compact widget: don't persist the moved origin here. Persistence
+            // happens on mouse-up — the corner (snap on) or the free origin
+            // (snap off). Here we just record that movement happened during the
+            // current mouse-down so the mouse-up monitor knows whether to act.
             if self.ignoringProgrammaticMove { return }
             if self.nav.compactMode, !self.nav.compactExpanded {
                 self.compactMovedSinceMouseDown = true

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -1186,15 +1186,18 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         }
     }
 
-    // Free-placement drop: clamp the released origin into the active screen,
-    // settle the window there if the clamp moved it, and persist. No snap
-    // animation — the pill stays where the user let go.
+    // Free-placement drop: clamp the released origin into the free-placement
+    // bounds (full width, down to the Dock at the bottom, capped below the menu
+    // bar at the top) so nothing hangs off-screen but the pill can rest at Dock
+    // level. Settle the window there if the clamp moved it, then persist. No
+    // snap animation — the pill stays where the user let go.
     private func persistCompactFreePosition() {
         guard nav.compactMode, !nav.compactExpanded else { return }
-        let visible = screenForFreeOrigin(panel.frame.origin, size: panel.frame.size).visibleFrame
+        let bounds = freePlacementBounds(on: screenForFreeOrigin(panel.frame.origin,
+                                                                 size: panel.frame.size))
         let clamped = CompactPlacement.clamp(origin: panel.frame.origin,
                                              size: panel.frame.size,
-                                             into: visible,
+                                             into: bounds,
                                              inset: Self.compactWidgetInset)
         if clamped != panel.frame.origin {
             ignoringProgrammaticMove = true
@@ -1231,6 +1234,13 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         applyCompactLayout()
     }
 
+    // The region a free-placed pill may occupy on `screen`: full width, down to
+    // the physical bottom (Dock level) but capped just below the menu bar.
+    private func freePlacementBounds(on screen: NSScreen) -> NSRect {
+        CompactPlacement.placementBounds(frame: screen.frame,
+                                         visibleFrame: screen.visibleFrame)
+    }
+
     // The screen a free-placed pill at `origin` lives on — the one containing
     // the pill's centre — so it stays on its own display regardless of where
     // the cursor is. Falls back to the cursor's screen when the centre is on
@@ -1249,16 +1259,18 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         cornerOrigin(for: size, corner: nav.compactCorner)
     }
 
-    // Origin for free-placement mode: the saved free position clamped into the
-    // screen that contains it (so it stays on its own display, and a resolution
-    // change can't strand it), falling back to the current corner the first
-    // time free mode is entered.
+    // Origin for free-placement mode: the saved free position, clamped into the
+    // free-placement bounds of the screen that contains it (full width, down to
+    // the Dock at the bottom, capped below the menu bar at the top). So it can
+    // rest at Dock level but nothing hangs off-screen; a resolution change or
+    // unplugged monitor still pulls it back on-screen. Falls back to the current
+    // corner the first time free mode is entered.
     private func resolvedFreeOrigin(for size: NSSize) -> NSPoint {
         let saved = nav.compactFreeOrigin
             ?? cornerOrigin(for: size, corner: nav.compactCorner)
-        let visible = screenForFreeOrigin(saved, size: size).visibleFrame
+        let bounds = freePlacementBounds(on: screenForFreeOrigin(saved, size: size))
         return CompactPlacement.clamp(origin: saved, size: size,
-                                      into: visible,
+                                      into: bounds,
                                       inset: Self.compactWidgetInset)
     }
 

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -834,6 +834,11 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
             .dropFirst()
             .sink { [weak self] _ in self?.applyCompactLayout() }
             .store(in: &cancellables)
+        nav.$compactSnap
+            .removeDuplicates()
+            .dropFirst()
+            .sink { [weak self] snap in self?.handleSnapModeChange(snap) }
+            .store(in: &cancellables)
         nav.$compactAlpha
             .removeDuplicates()
             .sink { [weak self] _ in self?.applyCompactAlpha() }
@@ -908,7 +913,11 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                 self.nav.compactDragging = false
                 if self.compactMovedSinceMouseDown {
                     self.compactMovedSinceMouseDown = false
-                    self.snapCompactToNearestCorner()
+                    if self.nav.compactSnap {
+                        self.snapCompactToNearestCorner()
+                    } else {
+                        self.persistCompactFreePosition()
+                    }
                 }
             default: break
             }
@@ -1033,7 +1042,9 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
             panel.contentMinSize = size
             var frame = panel.frame
             frame.size = size
-            frame.origin = compactCornerOrigin(for: size)
+            frame.origin = nav.compactSnap
+                ? compactCornerOrigin(for: size)
+                : compactFreeOrigin(for: size)
             ignoringProgrammaticMove = true
             panel.setFrame(frame, display: true, animate: false)
             ignoringProgrammaticMove = false
@@ -1147,13 +1158,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         let visible = activeScreen().visibleFrame
         let size = panel.frame.size
         let center = NSPoint(x: panel.frame.midX, y: panel.frame.midY)
-        let corner: CompactCorner
-        switch (center.x < visible.midX, center.y < visible.midY) {
-        case (true,  false): corner = .topLeft
-        case (false, false): corner = .topRight
-        case (true,  true):  corner = .bottomLeft
-        case (false, true):  corner = .bottomRight
-        }
+        let corner = CompactPlacement.nearestCorner(toCenter: center, in: visible)
         // Animate from the released position to the target corner FIRST.
         // Persist the corner only after the animation finishes — otherwise
         // updating nav.compactCorner mid-animation fires the Combine sink,
@@ -1181,8 +1186,63 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         }
     }
 
+    // Free-placement drop: clamp the released origin into the active screen,
+    // settle the window there if the clamp moved it, and persist. No snap
+    // animation — the pill stays where the user let go.
+    private func persistCompactFreePosition() {
+        guard nav.compactMode, !nav.compactExpanded else { return }
+        let visible = activeScreen().visibleFrame
+        let clamped = CompactPlacement.clamp(origin: panel.frame.origin,
+                                             size: panel.frame.size,
+                                             into: visible,
+                                             inset: Self.compactWidgetInset)
+        if clamped != panel.frame.origin {
+            ignoringProgrammaticMove = true
+            panel.setFrame(NSRect(origin: clamped, size: panel.frame.size),
+                           display: true, animate: false)
+            ignoringProgrammaticMove = false
+        }
+        nav.setCompactFreeOrigin(clamped)
+    }
+
+    // Re-enabling snap: pick the corner nearest the pill's last floating spot
+    // (its saved free origin, since the panel is expanded in Settings when the
+    // toggle flips and its live frame isn't the pill's), persist that corner,
+    // then re-lay-out so the pill lands there when it next collapses. Turning
+    // snap off does nothing visible — the pill keeps its current spot until the
+    // next drag.
+    private func handleSnapModeChange(_ snap: Bool) {
+        if snap {
+            let size = compactWidgetSizeForMode
+            let visible = activeScreen().visibleFrame
+            let origin = nav.compactFreeOrigin
+                ?? cornerOrigin(for: size, corner: nav.compactCorner)
+            let center = NSPoint(x: origin.x + size.width / 2,
+                                 y: origin.y + size.height / 2)
+            let corner = CompactPlacement.nearestCorner(toCenter: center, in: visible)
+            if nav.compactCorner != corner {
+                nav.compactCorner = corner
+                ConfigFile.write(key: "STACKNUDGE_COMPACT_CORNER",
+                                 value: corner.rawValue)
+            }
+        }
+        applyCompactLayout()
+    }
+
     private func compactCornerOrigin(for size: NSSize) -> NSPoint {
         cornerOrigin(for: size, corner: nav.compactCorner)
+    }
+
+    // Origin for free-placement mode: the saved free position clamped into the
+    // active screen (so a display change can't strand the pill), falling back
+    // to the current corner the first time free mode is entered.
+    private func compactFreeOrigin(for size: NSSize) -> NSPoint {
+        let visible = activeScreen().visibleFrame
+        let saved = nav.compactFreeOrigin
+            ?? cornerOrigin(for: size, corner: nav.compactCorner)
+        return CompactPlacement.clamp(origin: saved, size: size,
+                                      into: visible,
+                                      inset: Self.compactWidgetInset)
     }
 
     private func cornerOrigin(for size: NSSize, corner: CompactCorner) -> NSPoint {

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -146,7 +146,7 @@ enum SettingsRow: Hashable {
     case wireAgents, dismissAgents
     case permissions, update, hotkey
     case banner, muteWhenFocused, mute, muteDuration, pinPanel, keepOpenWhenEmpty, launchAtLogin
-    case widget, widgetCorner, widgetOpacity, widgetContent, mascot, theme
+    case widget, snapToCorners, widgetCorner, widgetOpacity, widgetContent, mascot, theme
     case soundEnabled, agentDoneSound, permissionSound
     case voiceEnabled, voice, voiceSpeed, speakHotkey, downloadVoiceModel
     case quotaTracking, quotaAlerts, alertThreshold, pollFrequency, contextAlert, showRemaining
@@ -736,6 +736,16 @@ final class PanelNav: ObservableObject {
     // the controller's compact-aware code; just don't expose a toggle.
     @Published var compactMode:   Bool = true
     @Published var compactCorner: CompactCorner = .topRight
+    // When true (default), releasing a drag snaps the pill to the nearest
+    // screen corner (STACKNUDGE_COMPACT_CORNER is the source of truth). When
+    // false, the pill stays where it is dropped and its absolute origin is
+    // persisted in STACKNUDGE_COMPACT_POS.
+    @Published var compactSnap: Bool = true
+    // The pill's last free-placement origin (absolute screen coords). Only
+    // meaningful while compactSnap is false; nil until the user first drops
+    // the pill in free mode. Written through setCompactFreeOrigin so the
+    // config key stays in sync.
+    @Published private(set) var compactFreeOrigin: CGPoint?
     @Published var compactContent: CompactContent = .sessions
     @Published var mascot:        MascotKind = .robot
     @Published var theme:         AccentTheme = .cyan
@@ -845,7 +855,7 @@ final class PanelNav: ObservableObject {
         if updateAvailable != nil { rows.append(.update) }
         rows += [.hotkey,
                  .banner, .muteWhenFocused, .mute, .muteDuration, .pinPanel, .keepOpenWhenEmpty, .launchAtLogin,
-                 .widget, .widgetCorner, .widgetOpacity, .widgetContent, .mascot, .theme,
+                 .widget, .snapToCorners, .widgetCorner, .widgetOpacity, .widgetContent, .mascot, .theme,
                  .soundEnabled, .agentDoneSound, .permissionSound,
                  .voiceEnabled, .speakHotkey]
         rows += voiceModelCached ? [.voice, .voiceSpeed] : [.downloadVoiceModel]
@@ -927,6 +937,8 @@ final class PanelNav: ObservableObject {
         compactMode   = ConfigFile.bool(config, "STACKNUDGE_COMPACT_MODE", default: true)
         compactCorner = CompactCorner(rawValue: config["STACKNUDGE_COMPACT_CORNER"] ?? "")
             ?? .topRight
+        compactSnap   = ConfigFile.bool(config, "STACKNUDGE_COMPACT_SNAP", default: true)
+        compactFreeOrigin = CompactPlacement.parsePosition(config["STACKNUDGE_COMPACT_POS"])
         compactContent = CompactContent(rawValue: config["STACKNUDGE_COMPACT_CONTENT"] ?? "")
             ?? .sessions
         mascot        = MascotKind(rawValue: config["STACKNUDGE_MASCOT"] ?? "") ?? .robot
@@ -1238,6 +1250,14 @@ final class PanelNav: ObservableObject {
                          value: keepOpenWhenEmpty ? "true" : "false")
     }
 
+    // Persist a new free-placement origin for the pill. Called by
+    // PanelController after a free-mode drop (already clamped to screen).
+    func setCompactFreeOrigin(_ p: CGPoint) {
+        compactFreeOrigin = p
+        ConfigFile.write(key: "STACKNUDGE_COMPACT_POS",
+                         value: CompactPlacement.formatPosition(p))
+    }
+
     // Settings "GitHub PR links" toggle. Persists STACKNUDGE_GITHUB; on enable
     // kicks an immediate PR fetch so chips appear without waiting for the next
     // tab visit, on disable drops cached PR state so chips revert to the local
@@ -1317,6 +1337,10 @@ final class PanelNav: ObservableObject {
             ConfigFile.write(key: "STACKNUDGE_COMPACT_MODE",
                              value: compactMode ? "true" : "false")
             compactExpanded = compactMode
+        case .snapToCorners:
+            compactSnap.toggle()
+            ConfigFile.write(key: "STACKNUDGE_COMPACT_SNAP",
+                             value: compactSnap ? "true" : "false")
         case .widgetCorner:
             let list = CompactCorner.allCases
             let idx = list.firstIndex(of: compactCorner) ?? 0

--- a/panel/PanelNav.swift
+++ b/panel/PanelNav.swift
@@ -1216,7 +1216,7 @@ final class PanelNav: ObservableObject {
         case .permissions, .update, .hotkey, .speakHotkey,
              .banner, .muteWhenFocused, .mute, .muteDuration, .pinPanel,
              .keepOpenWhenEmpty, .launchAtLogin,
-             .widget, .widgetCorner, .widgetOpacity, .widgetContent, .mascot, .theme,
+             .widget, .snapToCorners, .widgetCorner, .widgetOpacity, .widgetContent, .mascot, .theme,
              .soundEnabled, .agentDoneSound, .permissionSound,
              .voiceEnabled, .voice, .voiceSpeed, .downloadVoiceModel,
              .quotaTracking, .quotaAlerts, .alertThreshold, .pollFrequency,

--- a/panel/Settings.swift
+++ b/panel/Settings.swift
@@ -80,13 +80,13 @@ struct SettingsView: View {
                         }
 
                         section("Widget") {
-                            row(.widget,        label: "Widget",         kind: .toggle, value: nav.compactMode ? "On" : "Off")
-                            row(.snapToCorners, label: "Snap to corners", kind: .toggle, value: nav.compactSnap ? "On" : "Off", enabled: nav.compactMode)
-                            row(.widgetCorner,  label: "Widget corner",   kind: .cycle,  value: nav.compactCorner.label,          enabled: nav.compactMode && nav.compactSnap)
-                            row(.widgetOpacity, label: "Widget opacity", kind: .cycle, value: "\(Int(nav.compactAlpha * 100))%",  enabled: nav.compactMode)
-                            row(.widgetContent, label: "Widget type",   kind: .cycle,  value: nav.compactContent.label,           enabled: nav.compactMode)
-                            row(.mascot,        label: "Mascot",        kind: .cycle,  value: nav.mascot.label,                   enabled: nav.compactMode)
-                            row(.theme,         label: "Accent color",  kind: .cycle,  value: nav.theme.label,                    enabled: nav.compactMode)
+                            row(.widget,        label: "Widget",          kind: .toggle, value: nav.compactMode ? "On" : "Off")
+                            row(.snapToCorners, label: "Snap to corners", kind: .toggle, value: nav.compactSnap ? "On" : "Off",   enabled: nav.compactMode)
+                            row(.widgetCorner,  label: "Widget corner",   kind: .cycle,  value: nav.compactCorner.label,           enabled: nav.compactMode && nav.compactSnap)
+                            row(.widgetOpacity, label: "Widget opacity",  kind: .cycle,  value: "\(Int(nav.compactAlpha * 100))%", enabled: nav.compactMode)
+                            row(.widgetContent, label: "Widget type",     kind: .cycle,  value: nav.compactContent.label,          enabled: nav.compactMode)
+                            row(.mascot,        label: "Mascot",          kind: .cycle,  value: nav.mascot.label,                  enabled: nav.compactMode)
+                            row(.theme,         label: "Accent color",    kind: .cycle,  value: nav.theme.label,                   enabled: nav.compactMode)
                         }
 
                         section("Sounds") {

--- a/panel/Settings.swift
+++ b/panel/Settings.swift
@@ -80,8 +80,9 @@ struct SettingsView: View {
                         }
 
                         section("Widget") {
-                            row(.widget,        label: "Widget",        kind: .toggle, value: nav.compactMode ? "On" : "Off")
-                            row(.widgetCorner,  label: "Widget corner", kind: .cycle,  value: nav.compactCorner.label,            enabled: nav.compactMode)
+                            row(.widget,        label: "Widget",         kind: .toggle, value: nav.compactMode ? "On" : "Off")
+                            row(.snapToCorners, label: "Snap to corners", kind: .toggle, value: nav.compactSnap ? "On" : "Off", enabled: nav.compactMode)
+                            row(.widgetCorner,  label: "Widget corner",   kind: .cycle,  value: nav.compactCorner.label,          enabled: nav.compactMode && nav.compactSnap)
                             row(.widgetOpacity, label: "Widget opacity", kind: .cycle, value: "\(Int(nav.compactAlpha * 100))%",  enabled: nav.compactMode)
                             row(.widgetContent, label: "Widget type",   kind: .cycle,  value: nav.compactContent.label,           enabled: nav.compactMode)
                             row(.mascot,        label: "Mascot",        kind: .cycle,  value: nav.mascot.label,                   enabled: nav.compactMode)


### PR DESCRIPTION
## What

Adds an opt-in "free placement" mode for the compact widget (the always-on pill), which until now could only sit at one of four screen corners.

A new **Snap to corners** toggle in Settings → Widget drives it. It defaults to **On**, so existing users see no change. Turn it off and the pill stays wherever you drop it.

## Behaviour

- **Snap on (default):** unchanged. Releasing a drag animates the pill to the nearest corner and persists that corner.
- **Snap off:** the pill stays where you drop it. Its position is saved and restored across relaunches.
- **Own display:** a free-placed pill stays on the screen you left it on, not whichever screen the cursor happens to be on.
- **Dock level:** the pill clamps into the screen's full frame rather than the Dock-excluded area, so it can rest down at Dock level. The top stays capped just below the menu bar, and nothing hangs off the physical screen.
- **Re-enabling snap** sends the pill to the corner nearest its last free spot. **Toggling snap off** leaves it where it currently rests.

## Settings

New **Snap to corners** toggle. The existing **Widget corner** row dims while snap is off, since it has no effect in free mode.

## Config

- `STACKNUDGE_COMPACT_SNAP` (`true`/`false`, default `true`)
- `STACKNUDGE_COMPACT_POS` (`x,y`, the saved free origin)

`STACKNUDGE_COMPACT_CORNER` is unchanged and remains the source of truth while snap is on.

## Scope

The pill widget only. Notification banners are macOS notifications positioned by the system, and the full expanded panel keeps its own position handling. Neither is touched.

## Testing

- Unit tests for the new geometry and persistence helpers (`CompactPlacement`): nearest-corner selection, clamping, screen selection, placement bounds, and position parse/format.
- Full `swift test` suite passes.
- Built and exercised in the live app: drag to free-place, Dock-level placement, snap on/off transitions, and multi-monitor placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)