### PR TITLE
feat(agents): add pi coding-agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@
 | Codex | ✅ |
 | Gemini CLI | ✅ † |
 | Antigravity CLI | ✅ † |
+| pi | ✅ † |
 | Any hooks-capable agent | ✅ — point it at `notify.sh` |
 
-† Gemini CLI and Antigravity route tool-permission prompts through an observability-only hook — the banner shows the prompt, but the Allow / Deny click still has to happen in the agent's own terminal. Claude Code and Codex permission events can be approved from the panel directly.
+† Gemini CLI, Antigravity, and pi route their turn-end / permission signals through an observability-only hook — the banner shows the prompt, but the Allow / Deny click still has to happen in the agent's own terminal. Claude Code and Codex permission events can be approved from the panel directly. (pi has no native hook system; stack-nudge installs a pi extension that forwards its lifecycle events.)
 
 **Platforms:** macOS — full app with panel, click-to-focus banners, auto-update, quota tracking, voice. Linux (PulseAudio / ALSA / libnotify) and Windows (Git Bash / WSL) get audio + basic notifications via `notify.sh` only.
 
@@ -76,7 +77,7 @@ cd stack-nudge
 
 **Prerequisites:** Python ≥ 3.10 (the bundled voice engine [stackvox](https://github.com/StackOneHQ/stackvox) requires it).
 
-The installer auto-wires hooks for every detected agent — **Claude Code** (`~/.claude`), **Cursor** (`~/.cursor`), **Codex** (`~/.codex`), **Gemini CLI** (`~/.gemini`), and **Antigravity CLI** (`~/.gemini/antigravity-cli`). Any other hooks-capable agent can be wired by hand — see [Manual setup](#manual-setup) below.
+The installer auto-wires hooks for every detected agent — **Claude Code** (`~/.claude`), **Cursor** (`~/.cursor`), **Codex** (`~/.codex`), **Gemini CLI** (`~/.gemini`), **Antigravity CLI** (`~/.gemini/antigravity-cli`), and **pi** (`~/.pi/agent`, wired by installing a pi extension rather than a hook config). Any other hooks-capable agent can be wired by hand — see [Manual setup](#manual-setup) below.
 
 ### From source (macOS dev)
 
@@ -100,6 +101,7 @@ Each supported agent has a hooks system. `stack-nudge` registers these hooks:
 | Claude Code | `PermissionRequest` | Banner when Claude pauses for approval |
 | Cursor | `stop` | Banner when agent turn ends |
 | Gemini CLI | session end | Banner when agent finishes |
+| pi | `agent_settled` (via extension) | Banner when the turn settles |
 
 The hook calls `notify.sh <agent> <event>`, which plays a sound and shows a banner via:
 

--- a/Tests/StackNudgePanelCoreTests/PiTranscriptReaderTests.swift
+++ b/Tests/StackNudgePanelCoreTests/PiTranscriptReaderTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+// PiTranscriptReader parses @earendil-works/pi-coding-agent session JSONL into
+// the same TranscriptStats the Claude/Codex readers produce. The schema is
+// pinned against pi's own session format: the assistant turn is wrapped in a
+// `type == "message"` entry with the model turn under `.message`, usage keys are
+// camelCase, and `input` does NOT already include the cached portion (so
+// occupancy is input + cacheRead + cacheWrite, never a subtraction). locate()
+// binds a running pi process to its transcript by matching the cwd stamped in
+// the session header, which is what gives pi sessions stats with no hook event.
+final class PiTranscriptReaderTests: XCTestCase {
+
+    private func writeSession(_ lines: [String],
+                              dirName: String = "--Users-x-project--",
+                              name: String = "2026-09-01T00-00-00-000Z_session.jsonl",
+                              root: String) -> String {
+        let dir = "\(root)/\(dirName)"
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let path = "\(dir)/\(name)"
+        try? (lines.joined(separator: "\n") + "\n")
+            .write(toFile: path, atomically: true, encoding: .utf8)
+        return path
+    }
+
+    private func header(cwd: String, id: String = "01a05d37-018f-7429-b85d-7d6580040df0") -> String {
+        #"{"type":"session","version":1,"id":"\#(id)","timestamp":"2026-09-01T13:44:41.103Z","cwd":"\#(cwd)"}"#
+    }
+
+    private func assistantLine(input: Int, cacheRead: Int, cacheWrite: Int,
+                               output: Int = 27, reasoning: Int = 0,
+                               model: String = "qwen3.8:27b") -> String {
+        let total = input + output + cacheRead + cacheWrite + reasoning
+        return #"{"type":"message","id":"m1","parentId":"p1","timestamp":"2026-09-01T13:52:20.252Z","message":{"role":"assistant","model":"\#(model)","usage":{"input":\#(input),"output":\#(output),"cacheRead":\#(cacheRead),"cacheWrite":\#(cacheWrite),"reasoning":\#(reasoning),"totalTokens":\#(total)},"stopReason":"stop"}}"#
+    }
+
+    func test_read_sumsInputAndCacheTokens_excludingOutputAndReasoning() {
+        let root = NSTemporaryDirectory() + "pi-\(UUID().uuidString)"
+        let path = writeSession([
+            header(cwd: "/Users/x/project"),
+            #"{"type":"message","id":"u1","message":{"role":"user","content":[{"type":"text","text":"hey"}]}}"#,
+            assistantLine(input: 55_000, cacheRead: 3_000, cacheWrite: 2_000, output: 400, reasoning: 900),
+        ], root: root)
+
+        let actual = PiTranscriptReader.read(path: path)
+
+        XCTAssertEqual(actual?.tokens, 60_000)  // 55000 + 3000 + 2000; output/reasoning excluded
+        XCTAssertEqual(actual?.model, "qwen3.8:27b")
+    }
+
+    func test_read_usesLatestAssistantMessage() {
+        let root = NSTemporaryDirectory() + "pi-\(UUID().uuidString)"
+        let path = writeSession([
+            header(cwd: "/Users/x/project"),
+            assistantLine(input: 30_000, cacheRead: 0, cacheWrite: 0),
+            assistantLine(input: 90_000, cacheRead: 0, cacheWrite: 0),
+        ], root: root)
+
+        XCTAssertEqual(PiTranscriptReader.read(path: path)?.tokens, 90_000)
+    }
+
+    func test_read_returnsNilWhenNoAssistantUsage() {
+        let root = NSTemporaryDirectory() + "pi-\(UUID().uuidString)"
+        let path = writeSession([
+            header(cwd: "/Users/x/project"),
+            #"{"type":"message","id":"u1","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#,
+            #"{"type":"model_change","id":"c1","provider":"ollama","modelId":"qwen3.8:27b"}"#,
+        ], root: root)
+
+        XCTAssertNil(PiTranscriptReader.read(path: path))
+    }
+
+    func test_read_returnsNilForMissingFile() {
+        XCTAssertNil(PiTranscriptReader.read(path: "/nonexistent/pi/session.jsonl"))
+    }
+
+    func test_dispatch_routesPiPathToPiReader() {
+        // A pi-shaped assistant line under a /.pi/agent/sessions/ path. If the
+        // dispatcher fell through to the Claude reader it would find no
+        // top-level type=="assistant" and return nil; the pi reader parses the
+        // wrapped message and returns tokens. A non-nil result proves routing.
+        let root = NSTemporaryDirectory() + "some/.pi/agent/sessions"
+        let path = writeSession([
+            header(cwd: "/Users/x/project"),
+            assistantLine(input: 10, cacheRead: 0, cacheWrite: 0),
+        ], root: root)
+
+        XCTAssertEqual(TranscriptReader.read(path: path)?.tokens, 10)
+    }
+
+    func test_locate_matchesByHeaderCwd_newestWins() {
+        let root = NSTemporaryDirectory() + "pi-locate-\(UUID().uuidString)"
+        let target = "/Users/x/stackone"
+
+        // A session for a different cwd — must be ignored despite being present.
+        _ = writeSession([header(cwd: "/Users/x/other"), assistantLine(input: 5, cacheRead: 0, cacheWrite: 0)],
+                         dirName: "--Users-x-other--", root: root)
+
+        // Two sessions for the target cwd, in different dirs; the newer file wins.
+        let older = writeSession([header(cwd: target, id: "old"), assistantLine(input: 5, cacheRead: 0, cacheWrite: 0)],
+                                 dirName: "--Users-x-stackone--", name: "old.jsonl", root: root)
+        let newer = writeSession([header(cwd: target, id: "new"), assistantLine(input: 5, cacheRead: 0, cacheWrite: 0)],
+                                 dirName: "--Users-x-stackone-branch--", name: "new.jsonl", root: root)
+        // Force a deterministic mtime ordering (newer strictly after older).
+        let old = Date(timeIntervalSince1970: 1_000)
+        let recent = Date(timeIntervalSince1970: 2_000)
+        try? FileManager.default.setAttributes([.modificationDate: old], ofItemAtPath: older)
+        try? FileManager.default.setAttributes([.modificationDate: recent], ofItemAtPath: newer)
+
+        let ref = PiTranscriptReader.locate(cwd: target, root: root)
+
+        XCTAssertEqual(ref?.sessionID, "new")
+        XCTAssertEqual(ref?.path, newer)
+    }
+
+    func test_locate_nilWhenNoCwdMatch() {
+        let root = NSTemporaryDirectory() + "pi-locate-\(UUID().uuidString)"
+        _ = writeSession([header(cwd: "/Users/x/other"), assistantLine(input: 5, cacheRead: 0, cacheWrite: 0)],
+                         dirName: "--Users-x-other--", root: root)
+
+        XCTAssertNil(PiTranscriptReader.locate(cwd: "/Users/x/absent", root: root))
+    }
+
+    // Mirrors the extension's sessionIdFromFile: the uuid is everything after the
+    // first "_" in "<timestamp>_<uuid>.jsonl". The panel correlates events to
+    // sessions across these two independent derivations (extension → filename,
+    // reader → header `id`), so they must agree on a real filename.
+    private func filenameDerivedSessionID(_ name: String) -> String {
+        let stem = (name as NSString).deletingPathExtension
+        guard let underscore = stem.firstIndex(of: "_") else { return stem }
+        return String(stem[stem.index(after: underscore)...])
+    }
+
+    func test_locate_headerSessionIDMatchesFilenameDerivation() {
+        let root = NSTemporaryDirectory() + "pi-\(UUID().uuidString)"
+        let uuid = "01a06c64-752f-7944-8c47-aebcfcb1cc24"
+        let filename = "2026-09-04T12-28-38-063Z_\(uuid).jsonl"
+        _ = writeSession([header(cwd: "/Users/x/proj", id: uuid),
+                          assistantLine(input: 5, cacheRead: 0, cacheWrite: 0)],
+                         dirName: "--Users-x-proj--", name: filename, root: root)
+
+        let ref = PiTranscriptReader.locate(cwd: "/Users/x/proj", root: root)
+
+        XCTAssertEqual(ref?.sessionID, uuid)                                   // reader reads the header id
+        XCTAssertEqual(ref?.sessionID, filenameDerivedSessionID(filename))     // == extension's derivation
+    }
+
+    func test_locate_headerParsesWhenAMultibyteCharStraddles64KB() {
+        // Regression: sessionHeader used to decode the whole 64KB prefix as UTF-8,
+        // so a multi-byte char landing on byte 65536 returned nil and left the
+        // session permanently unbound — even though line 1 is intact. Place a
+        // 3-byte "€" so its first byte is the last byte of the 65536-byte read.
+        let root = NSTemporaryDirectory() + "pi-\(UUID().uuidString)"
+        let headerLine = header(cwd: "/Users/x/proj", id: "straddle") + "\n"
+        let padCount = 65535 - headerLine.utf8.count
+        let secondLine = String(repeating: "a", count: padCount) + "€ trailing content"
+        let dir = "\(root)/--Users-x-proj--"
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        try? (headerLine + secondLine + "\n")
+            .write(toFile: "\(dir)/2026-09-01T00-00-00-000Z_straddle.jsonl", atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(PiTranscriptReader.locate(cwd: "/Users/x/proj", root: root)?.sessionID, "straddle")
+    }
+
+    func test_locate_warmCachePicksUpASessionThatMovedToANewDir() {
+        // Regression for the cache: it used to pin to the matched dir and never
+        // reconsider, so a newer session for the same cwd in a NEW dir (e.g. a pi
+        // upgrade changing the folder wrap) was missed until restart. A new subdir
+        // bumps root's mtime, which must invalidate the fast path.
+        let root = NSTemporaryDirectory() + "pi-\(UUID().uuidString)"
+        let target = "/Users/x/proj"
+
+        let older = writeSession([header(cwd: target, id: "old"), assistantLine(input: 5, cacheRead: 0, cacheWrite: 0)],
+                                 dirName: "--Users-x-proj--", name: "2026-09-01T00-00-00-000Z_old.jsonl", root: root)
+        try? FileManager.default.setAttributes([.modificationDate: Date(timeIntervalSince1970: 1_000)], ofItemAtPath: older)
+        // Pin root old so creating the new subdir below is unambiguously newer.
+        try? FileManager.default.setAttributes([.modificationDate: Date(timeIntervalSince1970: 1_000)], ofItemAtPath: root)
+
+        XCTAssertEqual(PiTranscriptReader.locate(cwd: target, root: root)?.sessionID, "old")  // cold: caches dir + rootMtime
+
+        // Same cwd, a NEW dir — creating the subdir bumps root's mtime to now.
+        let newer = writeSession([header(cwd: target, id: "new"), assistantLine(input: 5, cacheRead: 0, cacheWrite: 0)],
+                                 dirName: "--Users-x-proj-v2--", name: "2026-09-02T00-00-00-000Z_new.jsonl", root: root)
+        try? FileManager.default.setAttributes([.modificationDate: Date(timeIntervalSince1970: 2_000)], ofItemAtPath: newer)
+
+        XCTAssertEqual(PiTranscriptReader.locate(cwd: target, root: root)?.sessionID, "new")  // warm: root mtime moved → rescan
+    }
+}

--- a/Tests/StackNudgePanelCoreTests/SessionStoreTests.swift
+++ b/Tests/StackNudgePanelCoreTests/SessionStoreTests.swift
@@ -73,6 +73,17 @@ final class DetectAgentTests: XCTestCase {
         XCTAssertEqual(SessionStore.detectAgent(args: "agy"), "agy")
     }
 
+    func test_detectAgent_pi() {
+        // pi ships as a node-run bundle; the package path is the signature.
+        XCTAssertEqual(
+            SessionStore.detectAgent(
+                args: "node /Users/x/.nvm/versions/node/v22.20.0/lib/node_modules/@earendil-works/pi-coding-agent/dist/bundle/cli.js"),
+            "pi")
+        // A future compiled binary invoked directly.
+        XCTAssertEqual(SessionStore.detectAgent(args: "pi"), "pi")
+        XCTAssertEqual(SessionStore.detectAgent(args: "/opt/homebrew/bin/pi --resume"), "pi")
+    }
+
     // Similarly-named neighbours that share a prefix with an agent binary.
     func test_detectAgent_nonAgentProcesses() {
         XCTAssertNil(SessionStore.detectAgent(args: "/Users/x/.local/bin/codex-code-mode-host"))

--- a/Tests/StackNudgePanelCoreTests/TmuxFocusTests.swift
+++ b/Tests/StackNudgePanelCoreTests/TmuxFocusTests.swift
@@ -58,4 +58,40 @@ final class TmuxFocusTests: XCTestCase {
         XCTAssertNil(TmuxFocus.hostBundleID(forLCTerminal: "WezTerm"))
         XCTAssertNil(TmuxFocus.hostBundleID(forLCTerminal: nil))
     }
+
+    private func writeSidecar(_ json: String, pid: Int, dir: String) {
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        try? json.write(toFile: "\(dir)/\(pid).json", atomically: true, encoding: .utf8)
+    }
+
+    func test_sidecarTarget_resolvesPaneSocketAndHost() {
+        // pi's env is unreadable via `ps`, so the in-process extension writes the
+        // pane here; the panel focuses by pid without any `ps` call.
+        let dir = NSTemporaryDirectory() + "pi-sessions-\(UUID().uuidString)"
+        writeSidecar(
+            #"{"pane":"%39","socket":"/private/tmp/tmux-502/default","lcTerminal":"iTerm2"}"#,
+            pid: 4242, dir: dir)
+
+        let actual = TmuxFocus.sidecarTarget(pid: 4242, dir: dir)
+
+        XCTAssertEqual(actual?.pane, "%39")
+        XCTAssertEqual(actual?.socket, "/private/tmp/tmux-502/default")
+        XCTAssertEqual(actual?.hostBundleID, "com.googlecode.iterm2")
+    }
+
+    func test_sidecarTarget_nilWhenMissingOrPaneless() {
+        let dir = NSTemporaryDirectory() + "pi-sessions-\(UUID().uuidString)"
+        XCTAssertNil(TmuxFocus.sidecarTarget(pid: 1, dir: dir))  // no file
+        writeSidecar(#"{"socket":"/tmp/s"}"#, pid: 7, dir: dir)  // no pane
+        XCTAssertNil(TmuxFocus.sidecarTarget(pid: 7, dir: dir))
+    }
+
+    func test_sidecarTarget_emptySocketBecomesNil() {
+        let dir = NSTemporaryDirectory() + "pi-sessions-\(UUID().uuidString)"
+        writeSidecar(#"{"pane":"%1","socket":""}"#, pid: 9, dir: dir)
+        let actual = TmuxFocus.sidecarTarget(pid: 9, dir: dir)
+        XCTAssertEqual(actual?.pane, "%1")
+        XCTAssertNil(actual?.socket)      // empty socket → default socket
+        XCTAssertNil(actual?.hostBundleID) // no lcTerminal → no host raise
+    }
 }

--- a/hooks/pi/stack-nudge.ts
+++ b/hooks/pi/stack-nudge.ts
@@ -1,0 +1,122 @@
+// stack-nudge integration for pi (@earendil-works/pi-coding-agent).
+//
+// pi has no Claude-Code-style hook system, but it does auto-load extensions
+// from ~/.pi/agent/extensions/*.ts in every session. This extension forwards
+// pi's lifecycle events to stack-nudge's installed hook entrypoint (notify.sh)
+// exactly as the Claude Code / Codex hooks do, so pi sessions get the same
+// banner, voice, attention-focus, and per-ticket handoff capture with no
+// stack-nudge-side special-casing (the panel keys everything off the `pi` agent
+// string, which flows through the same unix socket as every other agent).
+//
+// Install: copy to ~/.pi/agent/extensions/stack-nudge.ts (install.sh does this
+// automatically when ~/.pi/agent is present).
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { spawn } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+
+// stack-nudge's installed hook entrypoint — the same script Claude/Codex invoke.
+const NOTIFY = join(homedir(), ".stack-nudge", "notify.sh");
+
+// Per-pid tmux sidecar. pi renames its process title to "pi", which clobbers the
+// argv+env memory region `ps -e` reads — so the panel CANNOT read pi's env from
+// outside to resolve its tmux pane (unlike claude, whose env stays readable).
+// The extension runs inside pi, so it's the only place that can read TMUX_PANE;
+// it writes the pane here for the panel's tmux focus to consume by pid. Analogous
+// to Claude Code's ~/.claude/sessions/<pid>.json sidecar.
+const SIDECAR_DIR = join(homedir(), ".stack-nudge", "pi-sessions");
+const sidecarPath = join(SIDECAR_DIR, `${process.pid}.json`);
+
+const removeTmuxSidecar = (): void => {
+  try {
+    rmSync(sidecarPath, { force: true });
+  } catch {
+    // ignore
+  }
+};
+
+const writeTmuxSidecar = (): void => {
+  const pane = process.env.TMUX_PANE;
+  // Not inside tmux: clear any sidecar this pid may have inherited from a dead
+  // tmux-hosted pi, rather than returning early and leaving it to point a paneless
+  // session at a stale pane. Keeps the write path idempotent for the pid either way.
+  if (!pane) {
+    removeTmuxSidecar();
+    return;
+  }
+  // TMUX is "<socket>,<serverPID>,<sessionN>"; the socket is the first field.
+  const socket = process.env.TMUX?.split(",")[0];
+  try {
+    mkdirSync(SIDECAR_DIR, { recursive: true });
+    writeFileSync(sidecarPath, JSON.stringify({
+      pane,
+      socket,
+      lcTerminal: process.env.LC_TERMINAL,
+    }));
+  } catch {
+    // never surface to the session
+  }
+};
+
+// pi's session id is the uuid half of "<timestamp>_<uuid>.jsonl". Deriving it
+// from the filename avoids reading the file just to echo the header id back.
+const sessionIdFromFile = (file: string | undefined): string | undefined => {
+  if (!file) return undefined;
+  const stem = basename(file, ".jsonl");
+  const underscore = stem.indexOf("_");
+  return underscore >= 0 ? stem.slice(underscore + 1) : stem;
+};
+
+// Fire the hook without ever blocking or throwing back into pi: a missing
+// notify.sh, a permission error, or a broken pipe must stay invisible to the
+// coding session. The payload mirrors the subset of the Claude hook JSON that
+// notify.sh reads (session_id, transcript_path, cwd); NUDGE_AGENT_PID seeds the
+// agent pid that walk_session_chain can't infer for a node-hosted agent.
+const fireHook = (event: string, sessionFile: string | undefined): void => {
+  const payload = JSON.stringify({
+    hook_event_name: event,
+    session_id: sessionIdFromFile(sessionFile),
+    transcript_path: sessionFile,
+    cwd: process.cwd(),
+  });
+  try {
+    const child = spawn("/bin/bash", [NOTIFY, "pi", event], {
+      stdio: ["pipe", "ignore", "ignore"],
+      env: { ...process.env, NUDGE_AGENT_PID: String(process.pid) },
+    });
+    child.on("error", () => {});
+    child.stdin?.on("error", () => {});
+    child.stdin?.end(payload);
+    child.unref();
+  } catch {
+    // never surface to the session
+  }
+};
+
+export default function (pi: ExtensionAPI): void {
+  // Write the tmux pane sidecar up front (the session is already running when
+  // the factory loads) and again on session_start, so the panel can focus the
+  // pane by pid from the first turn. Removed on shutdown to avoid a stale entry
+  // focusing the wrong pane if the pid is later reused.
+  writeTmuxSidecar();
+  pi.on("session_start", async () => writeTmuxSidecar());
+  pi.on("session_shutdown", async () => removeTmuxSidecar());
+
+  // agent_settled is pi's "won't continue on its own" signal — the analog of
+  // Claude Code's Stop hook. That's the moment the user's attention is wanted,
+  // and the point at which the handoff/token snapshot should be captured.
+  pi.on("agent_settled", async (_event, ctx) => {
+    if (!ctx.isIdle()) return;
+    // sessionManager is absent under `pi --no-session`; guard so the handler
+    // never throws (the event still fires, just without a transcript path).
+    let sessionFile: string | undefined;
+    try {
+      sessionFile = ctx.sessionManager?.getSessionFile();
+    } catch {
+      sessionFile = undefined;
+    }
+    fireHook("stop", sessionFile);
+  });
+}

--- a/install.sh
+++ b/install.sh
@@ -479,9 +479,27 @@ PY
   installed_any=true
 fi
 
+# pi (@earendil-works/pi-coding-agent). Unlike the others, pi has no hook-config
+# JSON to splice: it auto-loads extensions from ~/.pi/agent/extensions/*.ts, so
+# we install one that forwards pi's lifecycle events to notify.sh.
+if [[ -d "$HOME/.pi/agent" ]]; then
+  echo ""
+  echo "Detected pi (~/.pi/agent)"
+  PI_EXT_SRC="$SCRIPT_DIR/hooks/pi/stack-nudge.ts"
+  PI_EXT_DIR="$HOME/.pi/agent/extensions"
+  if [[ -f "$PI_EXT_SRC" ]]; then
+    mkdir -p "$PI_EXT_DIR"
+    cp "$PI_EXT_SRC" "$PI_EXT_DIR/stack-nudge.ts"
+    echo "  Installed extension    -> $PI_EXT_DIR/stack-nudge.ts"
+    installed_any=true
+  else
+    echo "  Skipped: $PI_EXT_SRC not found"
+  fi
+fi
+
 if [[ "$installed_any" == "false" ]]; then
   echo ""
-  echo "No supported agents detected (Claude Code, Cursor, Codex, Gemini CLI, Antigravity CLI)."
+  echo "No supported agents detected (Claude Code, Cursor, Codex, Gemini CLI, Antigravity CLI, pi)."
   echo "Install one, then re-run this script."
   exit 0
 fi

--- a/notify.sh
+++ b/notify.sh
@@ -330,6 +330,7 @@ agent_label() {
     codex)               echo "Codex" ;;
     agy|antigravity|antigravity-cli)
                          echo "Antigravity" ;;
+    pi)                  echo "pi" ;;
     *)                   echo "$1" ;;
   esac
 }
@@ -445,7 +446,11 @@ APPLESCRIPT
 # binary, parent shell, and terminal/helper. Sets AGENT_PID, SHELL_PID,
 # TERMINAL_PID, TERMINAL_APP (each empty if not found).
 walk_session_chain() {
-  AGENT_PID=""; SHELL_PID=""; TERMINAL_PID=""; TERMINAL_APP=""
+  # A caller that already knows the agent PID can seed it via NUDGE_AGENT_PID —
+  # node-hosted agents (pi runs as `node .../pi-coding-agent/...`) show comm as
+  # "node", so the walk below can't recognise them by name. The shell/terminal
+  # legs are still resolved from $PPID as usual.
+  AGENT_PID="${NUDGE_AGENT_PID:-}"; SHELL_PID=""; TERMINAL_PID=""; TERMINAL_APP=""
   local pid="$PPID"
   for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
     [[ -z "$pid" || "$pid" -le 1 ]] && break

--- a/panel/Panel.swift
+++ b/panel/Panel.swift
@@ -1999,6 +1999,29 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
                 }
             }
         }
+
+        // pi: no sidecar and (until a pi extension pushes events) no hook event,
+        // but its session file is locatable on disk by cwd, so bind + read stats
+        // directly like Claude — no event required. Skipped once a hook event has
+        // seeded a transcript ref for the PID, which the loop above then owns.
+        for session in sessions.sessions
+            where session.agent == "pi"
+                && session.status == .active
+                && nav.transcriptRefByPID[session.pid] == nil
+        {
+            guard let id = session.claudeSessionID,
+                  let project = session.projectPath
+            else { continue }
+            DispatchQueue.global(qos: .utility).async { [weak self] in
+                guard let ref = PiTranscriptReader.locate(cwd: project),
+                      let stats = TranscriptReader.read(path: ref.path)
+                else { return }
+                DispatchQueue.main.async {
+                    self?.nav.claudeSessionStats[id] = stats
+                    self?.evaluateContextThreshold(sessionID: id, stats: stats)
+                }
+            }
+        }
     }
 
     // Claude Code stores transcripts at:
@@ -2430,9 +2453,7 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         // (notify.sh's default bundle for an unknown TERM_PROGRAM).
         if config.activateImmediately,
            event.termProgram == "tmux" || event.terminalApp == "tmux" {
-            if let agentPID = event.agentPID {
-                dispatchTmuxFocus(agentPID: agentPID, settle: false)
-            }
+            dispatchTmuxFocus(agentPID: event.agentPID, shellPID: event.shellPID, settle: false)
             return
         }
         if config.activateImmediately, let bundleID = event.bundleID {
@@ -3054,10 +3075,8 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         // keystroke, so `approve` doesn't apply here. Exclusive — return even if
         // the pane can't be resolved, so we never fall through and raise Terminal.app.
         if event.termProgram == "tmux" || event.terminalApp == "tmux" {
-            if let agentPID = event.agentPID {
-                NSApp.hide(nil)
-                dispatchTmuxFocus(agentPID: agentPID, settle: true)
-            }
+            NSApp.hide(nil)
+            dispatchTmuxFocus(agentPID: event.agentPID, shellPID: event.shellPID, settle: true)
             return
         }
         guard let bundleID = event.bundleID else { return }
@@ -3812,10 +3831,8 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         // resolves under tmux). Exclusive — return even if the pane can't be
         // resolved, so we never fall through and raise Terminal.app.
         if event.termProgram == "tmux" || event.terminalApp == "tmux" {
-            if let agentPID = event.agentPID {
-                hidePanel()
-                dispatchTmuxFocus(agentPID: agentPID, settle: true)
-            }
+            hidePanel()
+            dispatchTmuxFocus(agentPID: event.agentPID, shellPID: event.shellPID, settle: true)
             return
         }
         guard let bundleID = event.bundleID else { return }
@@ -3912,10 +3929,19 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
     // `ps` read in TmuxFocus.target must not run on the UI queue. `settle` waits
     // after a panel/app hide so StackNudge has resigned frontmost before the
     // pane is raised (matches the AppActivator.activate call sites).
-    private func dispatchTmuxFocus(agentPID: Int, settle: Bool) {
+    // Resolve the tmux pane from the agent process's live env, falling back to
+    // the pane's shell. The agent pid is authoritative while it's alive, but
+    // short-lived agents (pi, and anything run non-interactively) have already
+    // exited by the time the user clicks the event — leaving nothing to read.
+    // The pane's shell (SHELL_PID from walk_session_chain) outlives the agent
+    // and carries the same TMUX_PANE/TMUX/LC_TERMINAL, so it recovers the pane
+    // for a dead-agent event. nil pids are skipped; nil target is a no-op.
+    private func dispatchTmuxFocus(agentPID: Int?, shellPID: Int?, settle: Bool) {
         DispatchQueue.global(qos: .userInitiated).async {
             if settle { Thread.sleep(forTimeInterval: 0.15) }
-            guard let target = TmuxFocus.target(agentPID: agentPID) else { return }
+            let target = agentPID.flatMap { TmuxFocus.target(agentPID: $0) }
+                ?? shellPID.flatMap { TmuxFocus.target(agentPID: $0) }
+            guard let target else { return }
             AppActivator.focusTmux(pane: target.pane,
                                    socket: target.socket,
                                    hostBundleID: target.hostBundleID)
@@ -3930,7 +3956,9 @@ final class PanelController: NSObject, NSApplicationDelegate, PanelKeyDelegate,
         // in the process tree), so focus the pane via the tmux server instead.
         if session.terminalApp == "tmux" {
             hidePanel()
-            dispatchTmuxFocus(agentPID: session.pid, settle: true)
+            // A session in the list is live, so its own pid resolves the pane;
+            // no shell fallback needed (that's for dead-agent event focus).
+            dispatchTmuxFocus(agentPID: session.pid, shellPID: nil, settle: true)
             return
         }
         guard let bundleID = bundleID(for: session.terminalApp) else { return }

--- a/panel/PiTranscriptStats.swift
+++ b/panel/PiTranscriptStats.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+// A located pi session: its transcript path, session id, and last-write time.
+// pi has no per-pid sidecar (Claude) and no live-status RPC (Antigravity), but
+// it writes one JSONL per session under a per-cwd directory whose first line is
+// a `session` header carrying the id and the absolute cwd. That lets us bind a
+// running `pi` process to its transcript from disk alone — no hook event
+// required — which is what makes pi sessions show context stats the moment the
+// panel opens, the same as Claude's sidecar path.
+struct PiSessionRef: Equatable {
+    let path: String
+    let sessionID: String
+    let lastActivityAt: Date?
+}
+
+// Reads a pi (@earendil-works/pi-coding-agent) session JSONL and returns the
+// same TranscriptStats the Claude/Codex readers produce, so the Sessions and
+// Compact views render context usage identically across agents.
+//
+// pi's transcript differs from Claude Code's in the shape that matters here:
+//   • Every entry is wrapped: the assistant turn is `type == "message"` with the
+//     model turn under `.message` (role == "assistant"), not a top-level
+//     `type == "assistant"`.
+//   • Usage keys are camelCase and additive: totalTokens == input + output +
+//     cacheRead + cacheWrite + reasoning. `input` does NOT already include the
+//     cached portion (unlike Codex), so context-window occupancy is
+//     input + cacheRead + cacheWrite — output and reasoning don't persist into
+//     the next turn's prompt, mirroring the Claude reader's exclusion of output.
+enum PiTranscriptReader {
+
+    private static let sessionsRoot = "\(NSHomeDirectory())/.pi/agent/sessions"
+
+    // Read the whole file and scan newest-first (same approach and tens-of-MB
+    // caveat as the Claude reader). First assistant message with a usage block
+    // wins. Returns nil for unreadable files or transcripts with no assistant
+    // turn yet.
+    static func read(path: String) -> TranscriptStats? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path), options: .mappedIfSafe),
+              let text = String(data: data, encoding: .utf8)
+        else { return nil }
+
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: true)
+        for line in lines.reversed() {
+            guard let lineData = line.data(using: .utf8),
+                  let obj = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  (obj["type"] as? String) == "message",
+                  let message = obj["message"] as? [String: Any],
+                  (message["role"] as? String) == "assistant",
+                  let usage = message["usage"] as? [String: Any]
+            else { continue }
+            let input      = intValue(usage["input"])
+            let cacheRead  = intValue(usage["cacheRead"])
+            let cacheWrite = intValue(usage["cacheWrite"])
+            let model = message["model"] as? String
+            return TranscriptStats(tokens: input + cacheRead + cacheWrite, model: model)
+        }
+        return nil
+    }
+
+    // Locate the active session file for a working directory. pi groups sessions
+    // by cwd in a directory named `--<path-with-slashes-as-dashes>--`, but the
+    // exact wrap rule has drifted across versions, so we match on the cwd stamped
+    // inside each file's `session` header rather than reconstructing the folder
+    // name. Newest matching file (by mtime) is the one the running process is
+    // appending to. Disk I/O — call off the main thread.
+    // Remembers which per-cwd directory matched last time, tagged with the root
+    // directory's mtime. pi appends to the same transcript within a session
+    // (which does not change root's mtime), so the steady-state poll re-scans
+    // just that one directory instead of listing every session dir and reading
+    // every header. A NEW per-cwd directory — e.g. after a pi upgrade changes the
+    // folder-wrap rule for an existing project — DOES bump root's mtime, which
+    // invalidates the fast path and forces a full rescan, so a session that moves
+    // to a new directory is picked up rather than pinned to the old one. Guarded
+    // by a lock because locate() runs on background queues (enrichPi + the stat
+    // refresh).
+    private static let dirCacheLock = NSLock()
+    private static var dirCache: [String: (rootMtime: Date, dir: String)] = [:]  // "root::cwd" -> ...
+
+    static func locate(cwd: String, root: String = sessionsRoot) -> PiSessionRef? {
+        let fileManager = FileManager.default
+        let cacheKey = "\(root)::\(cwd)"
+        let rootMtime = (try? fileManager.attributesOfItem(atPath: root))?[.modificationDate] as? Date
+
+        // Fast path: only while root's mtime is unchanged (no new per-cwd dir has
+        // appeared). Re-scan the remembered dir for its newest file and re-verify
+        // the header cwd, so an in-place session rotation still can't mismatch.
+        dirCacheLock.lock()
+        let cached = dirCache[cacheKey]
+        dirCacheLock.unlock()
+        if let cached, let rootMtime, cached.rootMtime == rootMtime,
+           let newest = newestTranscript(inDir: cached.dir, fileManager: fileManager),
+           let header = sessionHeader(path: newest.path), header.cwd == cwd {
+            return PiSessionRef(path: newest.path, sessionID: header.id, lastActivityAt: newest.modified)
+        }
+
+        // Full scan: match on the cwd stamped in each dir's newest header, keep
+        // the newest match, and remember its directory (tagged with root's mtime).
+        guard let subdirs = try? fileManager.contentsOfDirectory(atPath: root) else { return nil }
+        var best: (ref: PiSessionRef, dir: String, modified: Date)?
+        for sub in subdirs {
+            let dir = "\(root)/\(sub)"
+            var isDir: ObjCBool = false
+            guard fileManager.fileExists(atPath: dir, isDirectory: &isDir), isDir.boolValue else { continue }
+            guard let newest = newestTranscript(inDir: dir, fileManager: fileManager) else { continue }
+            guard let header = sessionHeader(path: newest.path), header.cwd == cwd else { continue }
+            if best == nil || newest.modified > best!.modified {
+                best = (PiSessionRef(path: newest.path,
+                                     sessionID: header.id,
+                                     lastActivityAt: newest.modified),
+                        dir, newest.modified)
+            }
+        }
+        dirCacheLock.lock()
+        if let best, let rootMtime {
+            dirCache[cacheKey] = (rootMtime, best.dir)
+        } else {
+            dirCache[cacheKey] = nil
+        }
+        dirCacheLock.unlock()
+        return best?.ref
+    }
+
+    private static func newestTranscript(inDir dir: String,
+                                         fileManager: FileManager) -> (path: String, modified: Date)? {
+        guard let files = try? fileManager.contentsOfDirectory(atPath: dir) else { return nil }
+        var newest: (path: String, modified: Date)?
+        for file in files where file.hasSuffix(".jsonl") {
+            let path = "\(dir)/\(file)"
+            guard let modified = (try? fileManager.attributesOfItem(atPath: path))?[.modificationDate] as? Date
+            else { continue }
+            if newest == nil || modified > newest!.modified {
+                newest = (path, modified)
+            }
+        }
+        return newest
+    }
+
+    // The first line of every pi session is a `session` header:
+    // {"type":"session","version":N,"id":"<uuid>","timestamp":"...","cwd":"..."}.
+    // Read only a bounded prefix — the header is tiny and the file can be MB.
+    private static func sessionHeader(path: String) -> (id: String, cwd: String)? {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+        let prefix = handle.readData(ofLength: 65536)
+        // Parse only the first line's bytes. Decoding the whole 64 KiB prefix as
+        // UTF-8 returns nil whenever a multi-byte character straddles the cut —
+        // which would lose an intact ~110-byte header and leave the session
+        // permanently unbound. The header is a single JSONL line, so slice at
+        // the first newline and hand those bytes straight to the JSON parser.
+        guard let newline = prefix.firstIndex(of: 0x0A),
+              let obj = try? JSONSerialization.jsonObject(with: prefix[..<newline]) as? [String: Any],
+              (obj["type"] as? String) == "session",
+              let id = obj["id"] as? String,
+              let cwd = obj["cwd"] as? String
+        else { return nil }
+        return (id, cwd)
+    }
+
+    // pi serialises token counts as JSON integers, but decode defensively in
+    // case a provider or version emits them as doubles.
+    private static func intValue(_ value: Any?) -> Int {
+        if let int = value as? Int { return int }
+        if let number = value as? NSNumber { return number.intValue }
+        if let double = value as? Double { return Int(double) }
+        return 0
+    }
+}

--- a/panel/SessionStore.swift
+++ b/panel/SessionStore.swift
@@ -9,7 +9,7 @@ enum SessionStatus: Equatable {
 struct Session: Identifiable, Equatable {
     let id: Int           // pid — pids are reusable but stable for this process's lifetime
     let pid: Int
-    let agent: String     // "claude" | "gemini" | "codex" | "agy"
+    let agent: String     // "claude" | "gemini" | "codex" | "agy" | "pi"
     let projectPath: String?
     let projectName: String?
     let terminalPID: Int?
@@ -388,7 +388,26 @@ final class SessionStore: ObservableObject {
             ))
         }
         enrichAntigravity(&found)
+        enrichPi(&found)
         return found
+    }
+
+    // pi has no per-pid sidecar (Claude) and no live-status RPC (Antigravity),
+    // but its session file is locatable on disk by the cwd stamped in its header,
+    // so we bind each pi session to its transcript at discovery. That gives the
+    // session id up front (so context stats populate the moment the panel opens,
+    // like Claude's sidecar) and a last-activity time from the file's mtime for
+    // dormancy. Live busy/idle stays nil until a pi extension pushes hook events
+    // over the socket — matching how Codex behaves before its first hook fires.
+    private static func enrichPi(_ found: inout [Session]) {
+        guard found.contains(where: { $0.agent == "pi" }) else { return }
+        for index in found.indices where found[index].agent == "pi" {
+            guard let cwd = found[index].projectPath,
+                  let ref = PiTranscriptReader.locate(cwd: cwd)
+            else { continue }
+            found[index].claudeSessionID = ref.sessionID
+            found[index].lastActivityAt = ref.lastActivityAt
+        }
     }
 
     // Antigravity has no per-pid sidecar like Claude; instead the running `agy`
@@ -436,6 +455,7 @@ final class SessionStore: ObservableObject {
         if baseName == "gemini" { return "gemini" }
         if baseName == "codex"  { return "codex"  }
         if baseName == "agy"    { return "agy"    }
+        if baseName == "pi"     { return "pi"     }
 
         // Node / Deno-hosted agents: inspect later tokens for known script paths.
         if baseName == "node" || baseName == "deno" || baseName == "bun" {
@@ -447,6 +467,11 @@ final class SessionStore: ObservableObject {
             }
             if args.range(of: #"\b(agy|antigravity(-cli)?)\b"#, options: .regularExpression) != nil {
                 return "agy"
+            }
+            // pi ships as ~/.../@earendil-works/pi-coding-agent/dist/bundle/cli.js
+            // run under node; the package path is the unambiguous signature.
+            if args.contains("pi-coding-agent") {
+                return "pi"
             }
         }
         return nil

--- a/panel/TmuxFocus.swift
+++ b/panel/TmuxFocus.swift
@@ -29,14 +29,56 @@ enum TmuxFocus {
     // Runs on a background queue (callers dispatch), with a timeout so a hung
     // `ps` can't wedge the focus path.
     static func target(agentPID: Int) -> Target? {
+        // Sidecar first, but only for a live `pi` process. pi renames its process
+        // title, clobbering the argv+env region `ps` reads, so its pane can't be
+        // recovered from the env — the in-process extension writes it to a per-pid
+        // sidecar instead. Gating on a live `pi` (comm IS readable) stops a stale
+        // sidecar, left by a crash, from hijacking focus once the OS reuses that
+        // pid for another process (or another agent). claude et al. have no
+        // sidecar and fall through to the env read.
+        if isLivePi(pid: agentPID), let resolved = sidecarTarget(pid: agentPID) {
+            debug("target(pid=\(agentPID)) -> pane=\(resolved.pane) via sidecar "
+                + "socket=\(resolved.socket ?? "default") host=\(resolved.hostBundleID ?? "nil")")
+            return resolved
+        }
+
         guard let raw = ProcessOutput.read(
             "/bin/ps", ["eww", "-o", "pid=,command=", "-p", String(agentPID)],
             timeout: 3) else { return nil }
         let resolved = parse(psOutput: raw, pid: agentPID)
         debug("target(pid=\(agentPID)) -> " + (resolved.map {
             "pane=\($0.pane) socket=\($0.socket ?? "default") host=\($0.hostBundleID ?? "nil")"
-        } ?? "nil (no TMUX_PANE in that pid's env)"))
+        } ?? "nil (no sidecar, no TMUX_PANE in that pid's env)"))
         return resolved
+    }
+
+    // True when `pid` is a live process named `pi`. `ps -o comm=` is readable even
+    // though pi's environment is not, so this cheaply confirms a sidecar belongs
+    // to the pi it was written for rather than a later reuse of the same pid.
+    private static func isLivePi(pid: Int) -> Bool {
+        guard let comm = ProcessOutput.read(
+            "/bin/ps", ["-o", "comm=", "-p", String(pid)], timeout: 3)?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !comm.isEmpty
+        else { return false }
+        return (comm as NSString).lastPathComponent == "pi"
+    }
+
+    // Read a per-pid tmux sidecar (~/.stack-nudge/pi-sessions/<pid>.json), written
+    // by an in-process extension for agents whose env `ps` can't read. Shape:
+    // {"pane":"%39","socket":"/private/tmp/tmux-502/default","lcTerminal":"iTerm2"}.
+    // `dir` is injectable for tests; production uses the install location. Callers
+    // gate on isLivePi first — this does not itself validate the pid.
+    static func sidecarTarget(pid: Int,
+                              dir: String = "\(NSHomeDirectory())/.stack-nudge/pi-sessions") -> Target? {
+        let path = "\(dir)/\(pid).json"
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let pane = obj["pane"] as? String, !pane.isEmpty
+        else { return nil }
+        let socket = (obj["socket"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        return Target(pane: pane,
+                      socket: socket,
+                      hostBundleID: hostBundleID(forLCTerminal: obj["lcTerminal"] as? String))
     }
 
     // Gated on STACKNUDGE_PANEL_DEBUG (same switch AppActivator uses). Off by

--- a/panel/TranscriptStats.swift
+++ b/panel/TranscriptStats.swift
@@ -27,12 +27,17 @@ struct TranscriptRef: Equatable {
 enum TranscriptReader {
 
     // Dispatch by transcript path. Codex rollout files live under
-    // ~/.codex/sessions/.../rollout-*.jsonl and use a different JSONL schema
-    // (token_count events rather than assistant-message usage blocks), so they
-    // route to CodexTranscriptReader. Everything else is a Claude Code
-    // transcript. Both return the same TranscriptStats shape so the Sessions
-    // and Compact views render context usage identically across agents.
+    // ~/.codex/sessions/.../rollout-*.jsonl and pi sessions under
+    // ~/.pi/agent/sessions/, each using a different JSONL schema from Claude's
+    // (token_count events / camelCase-wrapped messages rather than top-level
+    // assistant-message usage blocks), so they route to their own readers.
+    // Everything else is a Claude Code transcript. All return the same
+    // TranscriptStats shape so the Sessions and Compact views render context
+    // usage identically across agents.
     static func read(path: String) -> TranscriptStats? {
+        if path.contains("/.pi/agent/sessions/") {
+            return PiTranscriptReader.read(path: path)
+        }
         if path.contains("/.codex/")
             || (path as NSString).lastPathComponent.hasPrefix("rollout-") {
             return CodexTranscriptReader.read(path: path)

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -160,6 +160,15 @@ print(f"  Cleaned {path}")
 PY
 fi
 
+# pi has no hook config to splice — it loads an extension from
+# ~/.pi/agent/extensions/. Left behind it would keep spawning a now-removed
+# notify.sh on every pi turn. (Its ~/.stack-nudge/pi-sessions/ sidecars are
+# removed with $INSTALL_DIR below.)
+if [[ -f "$HOME/.pi/agent/extensions/stack-nudge.ts" ]]; then
+  rm -f "$HOME/.pi/agent/extensions/stack-nudge.ts"
+  echo "  Removed ~/.pi/agent/extensions/stack-nudge.ts"
+fi
+
 # Stop and remove launchd agents (macOS)
 for label in com.stackonehq.stack-nudge com.stackonehq.stack-nudge-daemon com.stackonehq.stack-nudge-panel; do
   plist="$HOME/Library/LaunchAgents/${label}.plist"


### PR DESCRIPTION
Adds `pi` (`@earendil-works/pi-coding-agent`) as a first-class agent, alongside Claude Code / Codex / Gemini / Antigravity.

## Sessions
- Detect `pi` in the process scan (`SessionStore.detectAgent`), including the node-hosted `pi-coding-agent` bundle.
- New `PiTranscriptReader` parses pi's session JSONL (`~/.pi/agent/sessions/…/*.jsonl`) into the same `TranscriptStats` the Claude/Codex readers produce; `TranscriptStats.read` dispatches `/.pi/agent/sessions/` paths to it. Context occupancy = `input + cacheRead + cacheWrite`.
- `SessionStore.enrichPi` binds each pi session to its transcript from disk (matching the header `cwd`, not the folder encoding), so tokens/model show the moment the panel opens — no hook required. `Panel.refreshAllClaudeStats` keeps them live.

## Events
- pi has no Claude-style hooks, so `hooks/pi/stack-nudge.ts` is a global pi extension (auto-loaded from `~/.pi/agent/extensions/`). It forwards `agent_settled` (pi's Stop analog) to `notify.sh pi stop`, so pi gets the same banner/voice/handoff path as every other agent. `install.sh` installs it when `~/.pi/agent` is present.
- `notify.sh`: `pi` label; `walk_session_chain` seeds `AGENT_PID` from `NUDGE_AGENT_PID` (node-hosted agents show `comm=node`). pi is notification-only (no permission decisions), like Antigravity.

## tmux click-to-focus
pi renames its process title to `pi`, which clobbers the argv+env memory `ps -e` reads — so `TmuxFocus` could not read `TMUX_PANE` from pi's process to resolve its pane (it works for Claude, whose env stays readable). The extension writes a per-pid sidecar `~/.stack-nudge/pi-sessions/<pid>.json` with the pane/socket/host from inside the process, and `TmuxFocus.target` reads that first (falling back to the `ps` ancestry walk for other agents). Also adds a shell-pid fallback for events whose agent has already exited.

## Not included
- The macOS first-launch wizard (`Bootstrap.swift`) does not auto-wire pi yet — its model is JSON-hook-splicing and pi needs a file copy; `install.sh` wires it.
- No Usage-tab history/quota for pi (local models / own keys have no subscription window).

## Verification
- `swift build` green; test sources typecheck; new tests: `PiTranscriptReaderTests`, `TmuxFocusTests` sidecar coverage, a `detectAgent` case.
- Verified live on macOS: sessions show tokens/model, events fire with banner + voice, and Sessions/Events click-to-focus jumps to the tmux pane in iTerm2.
