### PR TITLE
fix(voice): recover from a wedged stackvox daemon

### DIFF
--- a/Tests/StackNudgePanelCoreTests/SpeakerRecoveryTests.swift
+++ b/Tests/StackNudgePanelCoreTests/SpeakerRecoveryTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+
+@testable import StackNudgePanelCore
+
+final class SpeakerRecoveryTests: XCTestCase {
+
+    // MARK: - sayRecovery
+
+    func test_sayRecovery_acceptsCleanExit() {
+        let actual = Speaker.sayRecovery(exitCode: 0, terminatedBySignal: false, attempt: 1)
+        XCTAssertEqual(actual, .accepted)
+    }
+
+    func test_sayRecovery_retriesOnBusyFirstAttempt() {
+        // CLI exit 2 == daemon replied "busy" (queue full / worker wedged).
+        let actual = Speaker.sayRecovery(exitCode: 2, terminatedBySignal: false, attempt: 1)
+        XCTAssertEqual(actual, .retry)
+    }
+
+    func test_sayRecovery_givesUpAfterFinalAttempt() {
+        let actual = Speaker.sayRecovery(
+            exitCode: 2, terminatedBySignal: false, attempt: Speaker.maxSayAttempts)
+        XCTAssertEqual(actual, .giveUp)
+    }
+
+    func test_sayRecovery_retriesOnAnyNonZeroExit() {
+        // A non-busy failure (e.g. transient client error) is still worth one
+        // cancel+retry — cancel is a harmless no-op when the daemon is down.
+        let actual = Speaker.sayRecovery(exitCode: 1, terminatedBySignal: false, attempt: 1)
+        XCTAssertEqual(actual, .retry)
+    }
+
+    func test_sayRecovery_givesUpWhenKilledBySignal() {
+        // Quit / stopAllAudio SIGTERMs the client — do not resurrect audio the
+        // user is silencing, even though the exit status is non-zero.
+        let actual = Speaker.sayRecovery(exitCode: 15, terminatedBySignal: true, attempt: 1)
+        XCTAssertEqual(actual, .giveUp)
+    }
+
+    func test_sayRecovery_signalKillWinsOverCleanExitCode() {
+        // Defensive: a signal-terminated process should never be read as
+        // accepted, whatever its reported exit code happens to be.
+        let actual = Speaker.sayRecovery(exitCode: 0, terminatedBySignal: true, attempt: 1)
+        XCTAssertEqual(actual, .giveUp)
+    }
+}

--- a/Tests/StackNudgePanelCoreTests/SpeakerRecoveryTests.swift
+++ b/Tests/StackNudgePanelCoreTests/SpeakerRecoveryTests.swift
@@ -23,11 +23,12 @@ final class SpeakerRecoveryTests: XCTestCase {
         XCTAssertEqual(actual, .giveUp)
     }
 
-    func test_sayRecovery_retriesOnAnyNonZeroExit() {
-        // A non-busy failure (e.g. transient client error) is still worth one
-        // cancel+retry — cancel is a harmless no-op when the daemon is down.
+    func test_sayRecovery_givesUpOnDeterministicClientError() {
+        // Exit 1 == empty text or a failed --normalize: deterministic, so a
+        // retry fails identically. Recovering would also cancel any utterance
+        // currently playing for nothing, so only exit 2 (daemon "busy") retries.
         let actual = Speaker.sayRecovery(exitCode: 1, terminatedBySignal: false, attempt: 1)
-        XCTAssertEqual(actual, .retry)
+        XCTAssertEqual(actual, .giveUp)
     }
 
     func test_sayRecovery_givesUpWhenKilledBySignal() {
@@ -42,5 +43,18 @@ final class SpeakerRecoveryTests: XCTestCase {
         // accepted, whatever its reported exit code happens to be.
         let actual = Speaker.sayRecovery(exitCode: 0, terminatedBySignal: true, attempt: 1)
         XCTAssertEqual(actual, .giveUp)
+    }
+
+    // MARK: - retryStillValid
+
+    func test_retryStillValid_trueWhenGenerationUnchanged() {
+        // No Mute/Quit happened during the retry delay — safe to speak.
+        XCTAssertTrue(Speaker.retryStillValid(scheduled: 3, current: 3))
+    }
+
+    func test_retryStillValid_falseWhenGenerationAdvanced() {
+        // stopAllAudio() bumped the generation in the gap (user muted or quit) —
+        // the scheduled retry must not spawn a fresh utterance.
+        XCTAssertFalse(Speaker.retryStillValid(scheduled: 3, current: 4))
     }
 }

--- a/panel/Speaker.swift
+++ b/panel/Speaker.swift
@@ -66,14 +66,28 @@ enum Speaker {
     }
 
     // Pure decision so the recovery policy is unit-testable without spawning a
-    // process. `terminatedBySignal` is true when we (Quit / stopAllAudio) or the
-    // user killed the `say` client — we must not resurrect audio the user is
+    // process. Only the daemon-refused code recovers: `stackvox say` exits 2
+    // when the daemon replies "busy" (queue full / worker wedged), which a
+    // cancel+retry clears. Exit 1 is a deterministic client-side failure (empty
+    // text, a failed `--normalize`) — it would fail identically on retry while
+    // needlessly cancelling whatever utterance is currently playing, so it gives
+    // up. `terminatedBySignal` is true when we (Quit / Mute via stopAllAudio) or
+    // the user killed the `say` client — we must not resurrect audio the user is
     // actively silencing, so that path always gives up regardless of exit code.
     static func sayRecovery(exitCode: Int32, terminatedBySignal: Bool, attempt: Int) -> SayOutcome {
         if terminatedBySignal { return .giveUp }
         if exitCode == 0 { return .accepted }
         if attempt >= maxSayAttempts { return .giveUp }
-        return .retry
+        return exitCode == 2 ? .retry : .giveUp
+    }
+
+    // A wedge-recovery retry is scheduled via `asyncAfter`, so it isn't in the
+    // `activeAudio` snapshot that `stopAllAudio()` terminates. It captures the
+    // audio generation when scheduled and calls this at fire time; a bumped
+    // generation means the user muted or quit in the gap, so the retry must not
+    // spawn a fresh utterance into a silence they just asked for.
+    static func retryStillValid(scheduled: Int, current: Int) -> Bool {
+        scheduled == current
     }
 
     private static func runSay(
@@ -92,6 +106,7 @@ enum Speaker {
         say.terminationHandler = { ended in
             audioLock.lock()
             activeAudio.removeAll { $0 === ended }
+            let generation = audioGeneration
             audioLock.unlock()
 
             let bySignal = ended.terminationReason == .uncaughtSignal
@@ -100,9 +115,13 @@ enum Speaker {
             case .accepted, .giveUp:
                 return
             case .retry:
-                NSLog("[stack-nudge] stackvox say refused (exit \(ended.terminationStatus)); cancelling wedged daemon and retrying")
+                NSLog("%@", "[stack-nudge] stackvox say refused (exit \(ended.terminationStatus)); cancelling wedged daemon and retrying")
                 cancel()
                 DispatchQueue.global().asyncAfter(deadline: .now() + recoveryDelaySeconds) {
+                    audioLock.lock()
+                    let current = audioGeneration
+                    audioLock.unlock()
+                    guard retryStillValid(scheduled: generation, current: current) else { return }
                     runSay(python: python, stackvox: stackvox, env: env,
                            text: text, voice: voice, speed: speed,
                            normalize: normalize, attempt: attempt + 1)
@@ -335,6 +354,10 @@ enum Speaker {
     // also silences the audio that this event chain spawned.
     static func stopAllAudio() {
         audioLock.lock()
+        // Advance the generation so any wedge-recovery retry scheduled off in a
+        // pending asyncAfter — which isn't in the snapshot below — sees it moved
+        // and bails instead of speaking after the user silenced audio.
+        audioGeneration &+= 1
         let snapshot = activeAudio
         activeAudio.removeAll()
         audioLock.unlock()
@@ -345,4 +368,6 @@ enum Speaker {
 }
 
 private var activeAudio: [Process] = []
+// Bumped by stopAllAudio() (Quit / Mute); guarded by audioLock.
+private var audioGeneration = 0
 private let audioLock = NSLock()

--- a/panel/Speaker.swift
+++ b/panel/Speaker.swift
@@ -39,9 +39,50 @@ enum Speaker {
         let config = ConfigFile.read()
         let resolvedVoice = voice ?? config["STACKNUDGE_VOICE_NAME"]  ?? "af_aoede"
         let resolvedSpeed = speed ?? config["STACKNUDGE_VOICE_SPEED"] ?? "1.1"
+        runSay(python: python, stackvox: stackvox, env: env,
+               text: text, voice: resolvedVoice, speed: resolvedSpeed,
+               normalize: normalize, attempt: 1)
+    }
+
+    // How many times a single utterance is handed to `stackvox say`. The daemon
+    // replies "busy" (CLI exit 2) when its playback queue is full, and the queue
+    // stays full forever if the worker thread is wedged inside a hung
+    // `tts.speak()` — a stale CoreAudio device (headphones yanked mid-utterance,
+    // output device swapped) is the usual cause. Left alone the app then sends
+    // every subsequent nudge into a dead daemon and the user hears nothing, with
+    // no error, until the daemon is manually cancelled or restarted. One retry —
+    // preceded by a `cancel` that aborts the stuck utterance and drains the
+    // queue — recovers that in-app without restarting the daemon.
+    static let maxSayAttempts = 2
+
+    // Beat between the recovery `cancel` and the retry `say`, so the daemon's
+    // cancel handler has unblocked its worker before the new utterance arrives.
+    private static let recoveryDelaySeconds = 0.2
+
+    enum SayOutcome: Equatable {
+        case accepted   // played (or handed off cleanly) — nothing more to do
+        case retry      // daemon refused (busy/wedged) — cancel and try once more
+        case giveUp     // killed by us, or already retried — stop
+    }
+
+    // Pure decision so the recovery policy is unit-testable without spawning a
+    // process. `terminatedBySignal` is true when we (Quit / stopAllAudio) or the
+    // user killed the `say` client — we must not resurrect audio the user is
+    // actively silencing, so that path always gives up regardless of exit code.
+    static func sayRecovery(exitCode: Int32, terminatedBySignal: Bool, attempt: Int) -> SayOutcome {
+        if terminatedBySignal { return .giveUp }
+        if exitCode == 0 { return .accepted }
+        if attempt >= maxSayAttempts { return .giveUp }
+        return .retry
+    }
+
+    private static func runSay(
+        python: String, stackvox: String, env: [String: String],
+        text: String, voice: String, speed: String, normalize: Bool, attempt: Int
+    ) {
         let say = Process()
         say.executableURL = URL(fileURLWithPath: python)
-        var sayArgs = [stackvox, "say", "--voice", resolvedVoice, "--speed", resolvedSpeed]
+        var sayArgs = [stackvox, "say", "--voice", voice, "--speed", speed]
         if normalize { sayArgs += ["--normalize", "--no-markdown"] }
         sayArgs.append(text)
         say.arguments = sayArgs
@@ -49,8 +90,24 @@ enum Speaker {
         say.standardOutput = FileHandle.nullDevice
         say.standardError = FileHandle.nullDevice
         say.terminationHandler = { ended in
-            audioLock.lock(); defer { audioLock.unlock() }
+            audioLock.lock()
             activeAudio.removeAll { $0 === ended }
+            audioLock.unlock()
+
+            let bySignal = ended.terminationReason == .uncaughtSignal
+            switch sayRecovery(exitCode: ended.terminationStatus,
+                               terminatedBySignal: bySignal, attempt: attempt) {
+            case .accepted, .giveUp:
+                return
+            case .retry:
+                NSLog("[stack-nudge] stackvox say refused (exit \(ended.terminationStatus)); cancelling wedged daemon and retrying")
+                cancel()
+                DispatchQueue.global().asyncAfter(deadline: .now() + recoveryDelaySeconds) {
+                    runSay(python: python, stackvox: stackvox, env: env,
+                           text: text, voice: voice, speed: speed,
+                           normalize: normalize, attempt: attempt + 1)
+                }
+            }
         }
         do {
             try say.run()


### PR DESCRIPTION
## Problem

Voice notifications go silent with no error once the stackvox TTS daemon wedges. The daemon's worker thread runs `tts.speak()` synchronously; if a `tts.speak()` call hangs on the audio backend (a stale CoreAudio device — headphones yanked mid-utterance, output device swapped), the worker never returns to drain its queue. The queue fills, `submit()` starts returning `busy` (CLI exit 2), and **every** subsequent `stackvox say` is rejected forever.

The app never recovered: `Speaker.speak()` only spawns a fresh `serve` when the socket file is *absent*, but a wedged daemon keeps its socket. And all `say` output was routed to `/dev/null`, so the failure was completely invisible — the fix in the field was a manual `stackvox cancel`/`stop`.

## Fix

- Split `speak()` into a resolver + a private `runSay(…, attempt:)`.
- Added a pure, unit-testable `sayRecovery(exitCode:terminatedBySignal:attempt:)` decision.
- On a clean non-zero `say` exit (busy/wedged), `runSay` sends `cancel()` — which calls `tts.stop()` and unblocks the stuck worker — waits a short beat, and retries once. A signal-terminated `say` (Quit / `stopAllAudio`) always gives up, so we never resurrect audio the user is silencing.
- Added a single `NSLog` on the recovery path so a wedge shows up in Console.app instead of being silent.

Trade-off: if the daemon is legitimately mid-utterance when a new nudge arrives, the retry cancels it to play the newer one (newest-wins) — consistent with `SpeakSelection`'s existing interrupt-on-repeat behavior, and better than dropping the new nudge.

## Testing

New `SpeakerRecoveryTests` (6 cases: clean exit, busy-retry, retry exhaustion, generic non-zero, and both signal-kill cases). Full suite: `make test-without-xcode` → 620 tests, 0 failures.